### PR TITLE
Use Float32Array#subarray instead of Array.slice

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -38,15 +38,19 @@ WaveSurfer.Drawer = {
 
         // Frames per pixel
         var k = buffer.getChannelData(0).length / this.width;
-        var slice = Array.prototype.slice;
         var sums = [];
 
         for (var i = 0; i < this.width; i++) {
             var sum = 0;
             for (var c = 0; c < buffer.numberOfChannels; c++) {
                 var chan = buffer.getChannelData(c);
-                var vals = slice.call(chan, i * k, (i + 1) * k);
-                var peak = Math.max.apply(Math, vals.map(Math.abs));
+                var vals = chan.subarray(i * k, (i + 1) * k);
+                var peak = -Infinity;
+                for (var p = 0, l = vals.length; p < l; p++){
+                    if (vals[p] > peak){
+                        peak = vals[p];
+                    }
+                }
                 sum += peak;
             }
             sums[i] = sum;


### PR DESCRIPTION
...Also use a loop instead of Math.max

slice vs subarray: http://jsperf.com/float32array-array-slice-call-vs-subarray
for loop vs Math.max: http://jsperf.com/find-max-in-float32array
getPeaks (new vs old): http://jsperf.com/wavesurfer-getpeaks

This guy was running something like 450ms on a 3:30 audio file for me, so I wanted to see if I could get that down a bit. Same file with the new function runs in about 40ms now.

Awesome work on this library. Huge fan.
