### PR TITLE
Do not attempt to add an offset to the position timing if the offset is NaN

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -171,7 +171,7 @@ var WaveSurfer = {
     timings: function (offset) {
         var position = this.backend.getCurrentTime() || 0;
         var duration = this.backend.getDuration() || 1;
-        position = Math.max(0, Math.min(duration, position + (isNaN(offset)? 0.0 : offset)));
+        position = Math.max(0, Math.min(duration, position + (offset || 0)));
         return [ position, duration ];
     },
 


### PR DESCRIPTION
Just found this project this afternoon - perfect, just what I was looking for. :D  There was just this one small thing that was stopping me from having a (time:elapsed / total:time) style counter alongside my waveform player, and that was that if you don't pass an offset to the timings function then it's NaN and the Math.min() function will also return NaN as that is smaller than duration.

Thanks for making this!
