### PR TITLE
Timeline pixel ratio fix

### DIFF
--- a/plugin/wavesurfer.timeline.js
+++ b/plugin/wavesurfer.timeline.js
@@ -105,6 +105,8 @@
                 var pixelsPerSecond = wsParams.minPxPerSec;
             }
 
+            pixelsPerSecond = pixelsPerSecond / this.wavesurfer.drawer.pixelRatio;
+
             if (duration > 0) {
                 var curPixel = 0,
                     curSeconds = 0,


### PR DESCRIPTION
This is a simple PR that fixes an issue with the timeline rendering on retina displays. It looks up the pixelRatio directly on the drawer instance, which I figured was ok because it's guaranteed to be set.
