### PR TITLE
AudioTag backend.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ CJS=build/wavesurfer.cjs.js
 SOURCE_MAP=build/wavesurfer-js-map.json
 SOURCE_MAP_ROOT=/
 SOURCES=src/wavesurfer.js\
+	src/audiotag.js\
+	src/audiotag.media.js\
         src/webaudio.js\
         src/webaudio.*.js\
         src/drawer.js\

--- a/src/audiotag.js
+++ b/src/audiotag.js
@@ -1,0 +1,100 @@
+'use strict';
+
+WaveSurfer.AudioTag = {
+
+    init: function (params) {
+        this.params = params;
+        this.loop = false;
+        this.loopStart = false;
+        this.loopEnd = false;
+        this.prevTime = 0;
+    },
+
+    loadMedia: function (media) {
+        var my = this;
+        var ready = false;
+        media.addEventListener("canplaythrough", function () {
+            // canplaythrough event gets sent twice in chrome
+            if (!my.ready) {
+                my.fireEvent('ready');
+                my.ready = true;
+            }
+        });
+
+        media.addEventListener("timeupdate", function () {
+            my.onTimeUpdate();
+        });
+        media.load();
+        this.media = media;
+        WaveSurfer.util.extend(WaveSurfer.AudioTag, WaveSurfer.AudioTag.Media);
+    },
+
+    onTimeUpdate: function () {
+        if (this.loop) {
+            if (
+                this.prevTime > this.loopStart &&
+                this.prevTime <= this.loopEnd &&
+                this.media.currentTime > this.loopEnd) {
+                this.play(this.loopStart);
+            }
+        }
+        this.prevTime = this.media.currentTime;
+    },
+
+    getPlayedPercents: function () {
+        var duration = this.getDuration();
+        return (this.getCurrentTime() / duration) || 0;
+    },
+
+    updateSelection: function (startPercent, endPercent) {
+        var duration = this.getDuration();
+        this.loop = true;
+        this.loopStart = duration * startPercent;
+        this.loopEnd = duration * endPercent;
+    },
+
+    clearSelection: function () {
+        this.loop = false;
+        this.loopStart = 0;
+        this.loopEnd = 0;
+    },
+
+
+    /* Dummy methods */
+
+    /**
+     * @returns {Boolean}
+     */
+    isPaused: function () {
+        return true;
+    },
+
+    /**
+     * Get duration in seconds.
+     */
+    getDuration: function () {
+        return 0;
+    },
+
+    /**
+     * Plays the loaded audio region.
+     *
+     * @param {Number} start Start offset in seconds,
+     * relative to the beginning of a clip.
+     * @param {Number} end When to stop
+     * relative to the beginning of a clip.
+     */
+    play: function (start, end) {},
+
+    /**
+     * Pauses the loaded audio.
+     */
+    pause: function () {},
+
+    getPeaks: function (length) {
+        throw new Error("The audio tag module cannot compute the peaks, please"
+                        + " use WaveSurfer.loadStream");
+    }
+};
+
+WaveSurfer.util.extend(WaveSurfer.AudioTag, WaveSurfer.Observer);

--- a/src/audiotag.media.js
+++ b/src/audiotag.media.js
@@ -1,0 +1,65 @@
+'use strict';
+
+WaveSurfer.AudioTag.Media = {
+
+    setVolume: function (volume) {
+        this.media.volume = volume;
+    },
+
+    getVolume: function () {
+        return this.media.volume;
+    },
+
+    getCurrentTime: function () {
+        return this.media.currentTime;
+    },
+
+    getDuration: function () {
+        return this.media.duration;
+    },
+
+    /**
+     * Plays the loaded audio region.
+     *
+     * @param {Number} start Start offset in seconds,
+     * relative to the beginning of a clip.
+     * @param {Number} end When to stop
+     * relative to the beginning of a clip.
+     */
+    play: function (start, end) {
+        if (start != null) {
+            this.media.currentTime = start;
+        }
+        if (end == null) {
+            this.scheduledPause = null;
+        } else {
+            this.scheduledPause = end;
+        }
+        this.media.play();
+        this.fireEvent('play');
+    },
+
+    isPaused: function () {
+        if (typeof this.media === "undefined") {
+            return true;
+        }
+        return this.media.paused;
+    },
+
+    /**
+     * Set the audio source playback rate.
+     */
+    setPlaybackRate: function (value) {
+        this.playbackRate = value || 1;
+        this.media.playbackRate = this.playbackRate;
+    },
+
+    /**
+     * Pauses the loaded audio.
+     */
+    pause: function () {
+        this.scheduledPause = null;
+        this.media.pause();
+        this.fireEvent('pause');
+    }
+};

--- a/src/webaudio.media.js
+++ b/src/webaudio.media.js
@@ -11,6 +11,7 @@ WaveSurfer.WebAudio.Media = {
             play: function () {},
             pause: function () {}
         };
+        WaveSurfer.util.extend(this, WaveSurfer.AudioTag.Media);
     },
 
     load: function (media) {
@@ -19,55 +20,5 @@ WaveSurfer.WebAudio.Media = {
         this.source = this.ac.createMediaElementSource(this.media);
         this.media.playbackRate = this.playbackRate;
         this.source.connect(this.analyser);
-    },
-
-    isPaused: function () {
-        return this.media.paused;
-    },
-
-    getDuration: function () {
-        return this.media.duration;
-    },
-
-    getCurrentTime: function () {
-        return this.media.currentTime;
-    },
-
-    /**
-     * Set the audio source playback rate.
-     */
-    setPlaybackRate: function (value) {
-        this.playbackRate = value || 1;
-        this.media.playbackRate = this.playbackRate;
-    },
-
-    /**
-     * Plays the loaded audio region.
-     *
-     * @param {Number} start Start offset in seconds,
-     * relative to the beginning of a clip.
-     * @param {Number} end When to stop
-     * relative to the beginning of a clip.
-     */
-    play: function (start, end) {
-        if (start != null) {
-            this.media.currentTime = start;
-        }
-        if (end == null) {
-            this.scheduledPause = null;
-        } else {
-            this.scheduledPause = end;
-        }
-        this.media.play();
-        this.fireEvent('play');
-    },
-
-    /**
-     * Pauses the loaded audio.
-     */
-    pause: function () {
-        this.scheduledPause = null;
-        this.media.pause();
-        this.fireEvent('pause');
     }
 };


### PR DESCRIPTION
Hi,

First, thanks for your project! It works really well and the code is clear and easy to modify.

So I've been tinkering with it in order to be able to load large audio files (>1 hour), which didn't work for me. I'm aware of the streaming mode, but I want the wave to be drawn straight away. The only solution I've found is to get my server to compute them and send them to wavesurfer.

So I did two things:
1. add a new parameter 'getPeaks', which is a function that gets called instead of backend.getPeaks if provided
2. add a new backend which does not make use of the webaudio api. It just adds an audio tag, just like loadStream does. This allows me to make the waveform compatible with browsers which don't support the web api.

This is a work in progress and not very well tested. I wanted to let you know about it in case you think this might interest other people.

A couple of comments:

At some point I started moving the downloadArrayBuffer and loadArrayBuffer into the WebAudio backend. My goal was to be able to do something like:

```
var params = {
            backend: "AudioTag",
            getPeaks: getPeaks
};

wave.load(url);  // don't download the file via ajax and don't decode it

var params = {
           backend: "WebAudio"
};

wave.load(url);  // use the WebAudio backend just like now
```

but then I realized I'd broken the loadBlob function. I could have fixed it but I prefered dropping you a word in order to know what your take is on this. Right now my feeling is that websurfer.js is too aware of the stream handling and that this could be delegated to the backend (or something else).

I also don't like passing in a function in the parameters, but this was the easiest way of getting it to work for me.

So there you go, sorry for the long comment :-)
