### PR TITLE
Fix events being fired multiple times

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -155,33 +155,33 @@ var WaveSurfer = {
             my.dragging = false;
         });
 
-		// Mouse events for Regions
-		this.drawer.on('region-over', function (region, e) {
-			region.fireEvent('over', e);
-			my.fireEvent('region-over', region, e);
-		});
-		this.drawer.on('region-leave', function (region, e) {
-			region.fireEvent('leave', e);
-			my.fireEvent('region-leave', region, e);
-		});
-		this.drawer.on('region-click', function (region, e) {
-			region.fireEvent('click', e);
-			my.fireEvent('region-click', region, e);
-		});
+	// Mouse events for Regions
+	this.drawer.on('region-over', function (region, e) {
+		region.fireEvent('over', e);
+		my.fireEvent('region-over', region, e);
+	});
+	this.drawer.on('region-leave', function (region, e) {
+		region.fireEvent('leave', e);
+		my.fireEvent('region-leave', region, e);
+	});
+	this.drawer.on('region-click', function (region, e) {
+		region.fireEvent('click', e);
+		my.fireEvent('region-click', region, e);
+	});
 
-		// Mouse events for Marks
-		this.drawer.on('mark-over', function (mark, e) {
-			mark.fireEvent('over', e);
-			my.fireEvent('mark-over', mark, e);
-		});
-		this.drawer.on('mark-leave', function (mark, e) {
-			mark.fireEvent('leave', e);
-			my.fireEvent('mark-leave', mark, e);
-		});
-		this.drawer.on('mark-click', function (mark, e) {
-			mark.fireEvent('click', e);
-			my.fireEvent('mark-click', mark, e);
-		});
+	// Mouse events for Marks
+	this.drawer.on('mark-over', function (mark, e) {
+		mark.fireEvent('over', e);
+		my.fireEvent('mark-over', mark, e);
+	});
+	this.drawer.on('mark-leave', function (mark, e) {
+		mark.fireEvent('leave', e);
+		my.fireEvent('mark-leave', mark, e);
+	});
+	this.drawer.on('mark-click', function (mark, e) {
+		mark.fireEvent('click', e);
+		my.fireEvent('mark-click', mark, e);
+	});
     },
 
     createBackend: function () {


### PR DESCRIPTION
Resolves issue #214 

region-over, region-leave, region-click, mark-over, mark-leave, and mark-click previously would fire once for each mark or region created, instead of just once for the particular mark or region that was related to the event.

The cause was the "on event" being defined within the Mark or Region, thus creating an entry into the "handlers" array for that event each time a new Mark or Region was created.  Moving the "on event" capture into createDrawer() ensures the event handler is created only once.
