### PR TITLE
Fill parent even when the sounds are short

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -237,11 +237,16 @@ var WaveSurfer = {
     },
 
     drawBuffer: function () {
+        var width = this.draw,
+            length;
+
         if (this.params.fillParent && !this.params.scrollParent) {
-            var length = this.drawer.getWidth();
+            length = width;
         } else {
-            length = Math.round(this.getDuration() * this.params.minPxPerSec * this.params.pixelRatio);
+            var newLength = Math.round(this.getDuration() * this.params.minPxPerSec * this.params.pixelRatio);
+            length = (this.params.fillParent && newLength < width) ? width : newLength;
         }
+
         var peaks = this.backend.getPeaks(length);
         this.drawer.drawPeaks(peaks, length);
         this.fireEvent('redraw', peaks, length);


### PR DESCRIPTION
Hello,

Short sounds not fill parent even the param fillParent is true.
Now before set new length, is checked if it not less than the parent width.

In these images we can see what happened prior to this fix when a region is created in short songs, and fillParent and scrollParent are true.

![before](https://cloud.githubusercontent.com/assets/583094/5306904/73422fe2-7bef-11e4-903a-1a090839f506.jpg)

![after](https://cloud.githubusercontent.com/assets/583094/5306905/76bae3d0-7bef-11e4-91d7-9327abe02230.jpg)

Thanks
