### PR TITLE
Region container width depends on the behavior chose in the params of wa...

### DIFF
--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -194,6 +194,9 @@ WaveSurfer.Region = {
     /* Update element's position, width, color. */
     updateRender: function () {
         var dur = this.wavesurfer.getDuration();
+        var fillParentNoScroll = (!this.wavesurfer.params.scrollParent && this.wavesurfer.params.fillParent);
+        var width = fillParentNoScroll ? this.wavesurfer.drawer.getWidth() : this.wrapper.scrollWidth;
+
         var width = this.wrapper.scrollWidth;
         var seconds = this.end - this.start;
         if (this.start < 0) {


### PR DESCRIPTION
With this change, regions will resize correctly when using something like:
```javascript
window.removeEventListener("resize", _.debounce(function() {
  wavesurfer.empty();
  wavesurfer.drawBuffer();
  region.updateRender();
}, 500);
```