### PR TITLE
Region now won't oversize the wave element

### DIFF
--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -195,14 +195,14 @@ WaveSurfer.Region = {
         var dur = this.wavesurfer.getDuration();
         var fillParentNoScroll = (!this.wavesurfer.params.scrollParent && this.wavesurfer.params.fillParent);
         var width = fillParentNoScroll ? this.wavesurfer.drawer.getWidth() : this.wrapper.scrollWidth;
-        var seconds = this.end - this.start;
+
         if (this.start < 0) {
           this.start = 0;
-          this.end = seconds;
+          this.end = this.end - this.start;
         }
         if (this.end > dur) {
           this.end = dur;
-          this.start = dur - seconds;
+          this.start = dur - (this.end - this.start);
         }
         this.style(this.element, {
             left: ~~(this.start / dur * width) + 'px',


### PR DESCRIPTION
With this changes now the start and end of the region won't oversize the wave element in any case. 