### PR TITLE
Added listener on mouseup to body for region usability improvement.

### DIFF
--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -329,12 +329,16 @@ WaveSurfer.Region = {
             };
 
             my.element.addEventListener('mousedown', onDown);
-            my.wrapper.addEventListener('mouseup', onUp);
             my.wrapper.addEventListener('mousemove', onMove);
+            document.body.addEventListener('mouseup', onUp);
 
             my.on('remove', function () {
-                my.wrapper.removeEventListener('mouseup', onUp);
+                document.body.removeEventListener('mouseup', onUp);
                 my.wrapper.removeEventListener('mousemove', onMove);
+            });
+
+            my.wavesurfer.on('destroy', function () {
+                document.body.removeEventListener('mouseup', onUp);
             });
         }());
     },


### PR DESCRIPTION
With this code i easier  to use the dragging and resizing of region because if the mouseup event happens outside the wavesurfer element this actions are stopped and you don't get stuck with it until you click again. This way is easier to adjust a region to the star or end of the wave.