### PR TITLE
Fixing equalizer example

### DIFF
--- a/example/equalizer/main.js
+++ b/example/equalizer/main.js
@@ -20,41 +20,41 @@ document.addEventListener('DOMContentLoaded', function () {
         var EQ = [
             {
                 f: 32,
-                type: 'LOWSHELF'
+                type: 'lowshelf'
             }, {
                 f: 64,
-                type: 'PEAKING'
+                type: 'peaking'
             }, {
                 f: 125,
-                type: 'PEAKING'
+                type: 'peaking'
             }, {
                 f: 250,
-                type: 'PEAKING'
+                type: 'peaking'
             }, {
                 f: 500,
-                type: 'PEAKING'
+                type: 'peaking'
             }, {
                 f: 1000,
-                type: 'PEAKING'
+                type: 'peaking'
             }, {
                 f: 2000,
-                type: 'PEAKING'
+                type: 'peaking'
             }, {
                 f: 4000,
-                type: 'PEAKING'
+                type: 'peaking'
             }, {
                 f: 8000,
-                type: 'PEAKING'
+                type: 'peaking'
             }, {
                 f: 16000,
-                type: 'HIGHSHELF'
+                type: 'highshelf'
             }
         ];
 
         // Create filters
         var filters = EQ.map(function (band) {
             var filter = wavesurfer.backend.ac.createBiquadFilter();
-            filter.type = filter[band.type];
+            filter.type = band.type;
             filter.gain.value = 0;
             filter.Q.value = 1;
             filter.frequency.value = band.f;


### PR DESCRIPTION
Fix for #395. After submitting the issue, realised what the problem was. Filter type was not being mapped and set correctly from the EQ array, so was just defaulting to 'lowpass'.

I'll be honest - I'm not sure why the capitalisation of the filter type stopped it working, but it did. If you're any wiser than me on that, I'd love to find out!

Tested on Chrome 40.0.2214 and Firefox Developer Edition 38.0a2