### PR TITLE
make sure the element exists before styling it

### DIFF
--- a/plugin/wavesurfer.microphone.js
+++ b/plugin/wavesurfer.microphone.js
@@ -151,6 +151,13 @@
         },
 
         /**
+         * Destroy the microphone plugin.
+         */
+        destroy: function(event) {
+            this.stop();
+        },
+
+        /**
          * Device error callback.
          */
         deviceError: function(code) {

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -75,11 +75,13 @@ WaveSurfer.Drawer = {
     },
 
     style: function (el, styles) {
-        Object.keys(styles).forEach(function (prop) {
-            if (el && el.style[prop] != styles[prop]) {
-                el.style[prop] = styles[prop];
-            }
-        });
+        if (el) {
+            Object.keys(styles).forEach(function (prop) {
+                if (el.style[prop] != styles[prop]) {
+                    el.style[prop] = styles[prop];
+                }
+            });
+        }
         return el;
     },
 

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -76,7 +76,7 @@ WaveSurfer.Drawer = {
 
     style: function (el, styles) {
         Object.keys(styles).forEach(function (prop) {
-            if (el.style[prop] != styles[prop]) {
+            if (el && el.style[prop] != styles[prop]) {
                 el.style[prop] = styles[prop];
             }
         });


### PR DESCRIPTION
Sometimes right after destroying a wavesurfer, an additional `drawer.style` call is made somewhere but since the element does not exist, it throws an error in `drawer.js`:

```
TypeError: el is null

if (el.style[prop] != styles[prop]) {
```

This PR makes sure the element exists before styling it.