### PR TITLE
Fix for #400: disconnect direct path in 'FX loop'

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -75,7 +75,10 @@ WaveSurfer.WebAudio = {
      * @param {Array} filters Packed ilters array
      */
     setFilters: function (filters) {
+        // Remove existing filters
         this.disconnectFilters();
+        // Disconnect direct path before inserting filters
+        this.analyser.disconnect();
 
         if (filters && filters.length) {
             this.filters = filters;

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -79,20 +79,21 @@ WaveSurfer.WebAudio = {
     setFilters: function (filters) {
         // Remove existing filters
         this.disconnectFilters();
-        // Disconnect direct path before inserting filters
-        this.analyser.disconnect();
 
+        // Insert filters if filter array not empty
         if (filters && filters.length) {
             this.filters = filters;
+
+            // Disconnect direct path before inserting filters
+            this.analyser.disconnect();
 
             // Connect each filter in turn
             filters.reduce(function (prev, curr) {
                 prev.connect(curr);
                 return curr;
             }, this.analyser).connect(this.gainNode);
-        } else {
-            this.analyser.connect(this.gainNode);
         }
+
     },
 
     createScriptNode: function () {

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -56,6 +56,8 @@ WaveSurfer.WebAudio = {
                 filter && filter.disconnect();
             });
             this.filters = null;
+            // Reconnect direct path
+            this.analyser.connect(this.gainNode);
         }
     },
 


### PR DESCRIPTION
This fixes the bug in #400. Direct path from analyser to gain node is
disconnected before connecting filters in turn, so that all audio goes
exclusively through the inserted filters now.