### PR TITLE
limit regions/callback on region update/create

### DIFF
--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -12,16 +12,29 @@ WaveSurfer.Regions = {
 
     /* Remove a region. */
     add: function (params) {
+        //Limit ranges count
         var region = Object.create(WaveSurfer.Region);
-        region.init(params, this.wavesurfer);
 
-        this.list[region.id] = region;
-
-        region.on('remove', (function () {
-            delete this.list[region.id];
-        }).bind(this));
-
-        return region;
+        if(Object(params).hasOwnProperty('count')) {
+            if( Object.keys(this.list).length < params.count){
+                region.init(params, this.wavesurfer);
+                this.list[region.id] = region;
+                region.on('remove', (function () {
+                    delete this.list[region.id];
+                }).bind(this));
+                return region;
+            } else {
+                return null;
+            }    
+        } else {
+            region.init(params, this.wavesurfer);
+            this.list[region.id] = region;
+            region.on('remove', (function () {
+                delete this.list[region.id];
+            }).bind(this));
+            return region;
+        }
+        
     },
 
     /* Remove all regions. */
@@ -55,11 +68,18 @@ WaveSurfer.Regions = {
 
             var duration = my.wavesurfer.getDuration();
             var end = my.wavesurfer.drawer.handleEvent(e);
-            region.update({
-                start: Math.min(end * duration, start * duration),
-                end: Math.max(end * duration, start * duration)
-            });
+            //Watch if returned region object exists
+            if (region !== null){
+                region.update({
+                    start: Math.min(end * duration, start * duration),
+                    end: Math.max(end * duration, start * duration)
+                });
+            }
+            if(Object(wavesurfer).hasOwnProperty('regionsCallback')){
+                wavesurfer.regionsCallback();
+            }
         });
+
     }
 };
 
@@ -347,6 +367,9 @@ WaveSurfer.Region = {
             start: this.start + delta,
             end: this.end + delta
         });
+        if(Object(wavesurfer).hasOwnProperty('regionsCallback')){
+            wavesurfer.regionsCallback();
+        }
     },
 
     onResize: function (delta, direction) {
@@ -360,6 +383,9 @@ WaveSurfer.Region = {
                 start: Math.min(this.end + delta, this.start),
                 end: Math.max(this.end + delta, this.start)
             });
+        }
+        if(Object(wavesurfer).hasOwnProperty('regionsCallback')){
+            wavesurfer.regionsCallback();
         }
     }
 };


### PR DESCRIPTION
Regions count limit patch
--------
Use option 'count: integer'

Regions callback
--------
Use option regionsCallback
Call wavesurfer.regionsCallback

Example
--------
    //Save time to input and localStorage.
    var saveRegion = function() {
        var regionHolder = document.getElementById('region-data'),
            regions = wavesurfer.regions.list,
            regionsObj = Object.keys(regions).map(function (id) {
                var region = regions[id];
                return {
                    start: region.start,
                    end: region.end
                };
            });

        for (var i = 0; i < regionsObj.length; i++) {
            var audioRegion = regionsObj[i],
                start = Math.round(audioRegion.start),
                end = Math.round(audioRegion.end);
            startInput.value = start;
            endInput.value = end;
        }

        localStorage.regions = JSON.stringify(regionsObj);
    };

    if (wavesurfer.enableDragSelection) {
        wavesurfer.enableDragSelection({
            color: 'rgba(0, 255, 0, 0.1)',
            count: 1 
        });
        wavesurfer.regionsCallback = saveRegion;
    }