### PR TITLE
package.json js location causing bower/wiredep issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wavesurfer.js",
   "version": "1.0.28",
   "description": "Interactive navigable audio visualization using Web Audio and Canvas",
-  "main": "dist/wavesurfer.js",
+  "main": "dist/wavesurfer.min.js",
   "directories": {
     "example": "example"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wavesurfer.js",
   "version": "1.0.28",
   "description": "Interactive navigable audio visualization using Web Audio and Canvas",
-  "main": "dist/wavesurfer.cjs.js",
+  "main": "dist/wavesurfer.js",
   "directories": {
     "example": "example"
   },


### PR DESCRIPTION
…n js file

I'm not sure of the backstory here, but it looks like there has been some conversation around bower in the past. 

I'm noticing that when trying to use wiredep in grunt to automatically pull in bower_components, it fails for wavesurfer.js because main is not correctly set in package.json . 

Can we change main to what's proposed in the PR? Or if not, create a bower.json file that defines main as the .js in the dist folder? 

Currently have to use this workaround in our bower.json file for wiredep to work:

```
"overrides": {
    "wavesurfer.js": {
      "main": "dist/wavesurfer.min.js"
    }
```