### PR TITLE
Canvas waveforms show true min and max peaks

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -175,7 +175,11 @@ WaveSurfer.WebAudio = {
     },
 
     /**
-     * @returns {Array} Array of peaks or array of arrays of peaks.
+     * Compute the max and min value of the waveform when broken into
+     * <length> subranges.
+     * @param {Number} How many subranges to break the waveform into.
+     * @returns {Array} Array of 2*<length> peaks or array of arrays
+     * of peaks consisting of (max, min) values for each subrange.
      */
     getPeaks: function (length) {
         var sampleSize = this.buffer.length / length;
@@ -191,20 +195,24 @@ WaveSurfer.WebAudio = {
             for (var i = 0; i < length; i++) {
                 var start = ~~(i * sampleSize);
                 var end = ~~(start + sampleSize);
-                var max = 0;
+                var min = 0, max = 0;
                 for (var j = start; j < end; j += sampleStep) {
                     var value = chan[j];
-                    if (value > max) {
+                    if (j == start || value > max) {
                         max = value;
-                    // faster than Math.abs
-                    } else if (-value > max) {
-                        max = -value;
+                    }
+                    if (j == start || value < min) {
+                        min = value;
                     }
                 }
-                peaks[i] = max;
+                peaks[2*i] = max;
+                peaks[2*i + 1] = min;
 
-                if (c == 0 || max > mergedPeaks[i]) {
-                    mergedPeaks[i] = max;
+                if (c == 0 || max > mergedPeaks[2*i]) {
+                    mergedPeaks[2*i] = max;
+                }
+                if (c == 0 || min < mergedPeaks[2*i + 1]) {
+                    mergedPeaks[2*i + 1] = min;
                 }
             }
         }


### PR DESCRIPTION
This allows waveforms to be asymmetric around zero, and to see the actual wave shape when you are zoomed in far enough (or if the wave shape has low enough frequency). 

See the comparison screenshot of a zoomed-in rumble.  Top is current code, bottom is with this patch.  

This resolves https://github.com/katspaugh/wavesurfer.js/issues/449 .

<img width="1237" alt="waveform_comparison" src="https://cloud.githubusercontent.com/assets/552145/8589419/e00640b6-25ca-11e5-80f5-a14159fc7b90.png">
