### PR TITLE
Updating README formatting and resource links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ and Canvas.
 ![Screenshot](example/screenshot.png?raw=true "Screenshot")
 
 ## Browser support
-wavesurfer.js works only in modern browsers supporting Web Audio
-(Chrome, Firefox, Safari, Opera etc).
+wavesurfer.js works only in [modern browsers supporting Web Audio](http://caniuse.com/#search=web%20audio).
 
 It will fallback to Audio Element in other browsers (without
 graphics).  You can also try
@@ -203,7 +202,7 @@ General events:
  * `remove` - Happens just before the region is removed.
  * `update` - When the region's options are updated.
 
- Mouse events:
+Mouse events:
 
  * `click` - When the mouse clicks on the region.  Callback will receive a `MouseEvent`.
  * `dblclick` - When the mouse double-clicks on the region.  Callback will receive a `MouseEvent`.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,13 @@
 # wavesurfer.js
 
-Interactive navigable audio visualization using
-[Web Audio](https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html)
-and Canvas.
+Interactive navigable audio visualization using [Web Audio](https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html) and Canvas.
 
 ![Screenshot](example/screenshot.png?raw=true "Screenshot")
 
 ## Browser support
-wavesurfer.js works only in [modern browsers supporting Web Audio](http://caniuse.com/#search=web%20audio).
+wavesurfer.js works only in [modern browsers supporting Web Audio](http://caniuse.com/audio-api).
 
-It will fallback to Audio Element in other browsers (without
-graphics).  You can also try
-[wavesurfer.swf](https://github.com/laurentvd/wavesurfer.swf) which is
-a Flash-based fallback with graphics.
+It will fallback to Audio Element in other browsers (without graphics). You can also try [wavesurfer.swf](https://github.com/laurentvd/wavesurfer.swf) which is a Flash-based fallback with graphics.
 
 ## FAQ
 ### Can the audio start playing before the waveform is drawn?


### PR DESCRIPTION
I noticed that **Mouse Events** wasn't formatted correctly under **Region Events**. I also added a link to the browser support for Web Audio to http://caniuse.com/audio-api