### PR TITLE
Add grunt serve task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,11 @@ module.exports = function(grunt) {
         dest: 'dist/wavesurfer.min.js'
       }
     },
+    serve: {
+      options: {
+        port: 9000
+      }
+    },
     connect: {
         options: {
 	        base: '.',
@@ -183,6 +188,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jasmine');
   grunt.loadNpmTasks('grunt-coveralls');
   grunt.loadNpmTasks('grunt-contrib-connect');
+  grunt.loadNpmTasks('grunt-serve');
 
   // Default task.
   grunt.registerTask('default', ['jshint', 'test', 'coverage', 'concat', 'commonjs',

--- a/README.md
+++ b/README.md
@@ -247,6 +247,14 @@ grunt coverage
 
 The HTML report can be found in `coverage/html/index.html`.
 
+Start local Web server with:
+
+```
+grunt serve
+```
+
+Navigate to `http://localhost:9000/index.html` to access examples locally.
+
 ## Credits
 
 Initial idea by [Alex Khokhulin](https://github.com/xoxulin). Many

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-contrib-jshint": ">=0.10.0",
     "grunt-contrib-uglify": ">=0.5.0",
     "grunt-coveralls": ">=1.0.0",
+    "grunt-serve": "^0.1.6",
     "grunt-template-jasmine-istanbul": ">=0.3.3",
     "jasmine-expect": ">=1.22.3"
   },


### PR DESCRIPTION
Add `grunt serve` task to start local Web server for running examples.