### PR TITLE
Add autoCenter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ where you can also add your own project.
 | `scrollParent` | boolean | `false` | Whether to scroll the container with a lengthy waveform. Otherwise the waveform is shrunk to the container width (see `fillParent`). |
 | `skipLength` | float | `2` | Number of seconds to skip with the `skipForward()` and `skipBackward()` methods. |
 | `waveColor` | string | `#999` | The fill color of the waveform after the cursor. |
-
+| `autoCenter` | boolean | true | If a scrollbar is present, center the waveform around the progress |
 ## WaveSurfer Methods
 
 All methods are intentionally public, but the most readily available are the following:

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -164,7 +164,7 @@ WaveSurfer.Drawer = {
         if (pos < this.lastPos || pos - this.lastPos >= minPxDelta) {
             this.lastPos = pos;
 
-            if (this.params.scrollParent) {
+            if (this.params.scrollParent && this.params.autoCenter) {
                 var newPos = ~~(this.wrapper.scrollWidth * progress);
                 this.recenterOnPosition(newPos);
             }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -33,7 +33,8 @@ var WaveSurfer = {
         mediaControls : false,
         renderer      : 'Canvas',
         backend       : 'WebAudio',
-        mediaType     : 'audio'
+        mediaType     : 'audio',
+        autoCenter    : true
     },
 
     init: function (params) {


### PR DESCRIPTION
This seems like a common use case. At least for the thing I'm building, it's pretty distracting to have the waveform move while playing, as I'm often zoomed in really far, so it would be nice to disable it.

The default behavior is the same as the old behavior. 

Thanks for the great library btw