### PR TITLE
Configure autoplay for mediaelment

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -25,7 +25,7 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
 
         var media = document.createElement(this.mediaType);
         media.controls = this.params.mediaControls;
-        media.autoplay = false;
+        media.autoplay = this.params.autoplay || false;
         media.preload = 'auto';
         media.src = url;
         media.style.width = '100%';


### PR DESCRIPTION
Enable autoplay for backend "mediaelement". Background is the `canplay` event on an `<audio>` element, which is mapped to `ready` in wavesurfer is not triggered automatically on iOS. The [workaround](http://stackoverflow.com/questions/9920297/html5-audio-canplay-event-doesnt-fire-on-safari-mac-desktop) is to set `autoplay` to `true` and pause the audio as soon as the `ready` event is fired.

Note: This could provide a workaround for #429.

```javascript
wavesurfer.init({autoplay: true});
wavesurfer.on('ready', function() { wavesurfer.pause(); })
```