### PR TITLE
Replace depreciated AudioElement with MediaElement in examples

### DIFF
--- a/example/annotation/app.js
+++ b/example/annotation/app.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', function () {
         scrollParent: true,
         normalize: true,
         minimap: true,
-        backend: 'AudioElement'
+        backend: 'MediaElement'
     });
 
     wavesurfer.util.ajax({

--- a/example/audio-element/main.js
+++ b/example/audio-element/main.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function () {
         container: document.querySelector('#waveform'),
         waveColor: '#A8DBA8',
         progressColor: '#3B8686',
-        backend: 'AudioElement'
+        backend: 'MediaElement'
     });
 
     // Load audio from URL

--- a/example/zoom/main.js
+++ b/example/zoom/main.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function () {
         container: document.querySelector('#waveform'),
         waveColor: '#A8DBA8',
         progressColor: '#3B8686',
-        backend: 'AudioElement'
+        backend: 'MediaElement'
     });
 
 


### PR DESCRIPTION
There were a few cases where AudioElement was still being used in the example code.