### PR TITLE
use absolute value for peaks

### DIFF
--- a/example/annotation/app.js
+++ b/example/annotation/app.js
@@ -147,7 +147,7 @@ function extractRegions(peaks, duration) {
     // Gather silence indeces
     var silences = [];
     Array.prototype.forEach.call(peaks, function (val, index) {
-        if (val < minValue) {
+        if (Math.abs(val) <= minValue) {
             silences.push(index);
         }
     });


### PR DESCRIPTION
For proper silence detection, we should actually be taking the absolute value of the peaks. `<=` allows us to use true silence (0.0) as our detection threshold. Also, it would be better to measure RMS instead of peak values. I may add a getRMS function later.

Thanks!