### PR TITLE
Polyfill for IE 9/10 for window.devicePixelRatio

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -17,7 +17,7 @@ var WaveSurfer = {
         cursorWidth   : 1,
         skipLength    : 2,
         minPxPerSec   : 20,
-        pixelRatio    : window.devicePixelRatio,
+        pixelRatio    : window.devicePixelRatio || screen.deviceXDPI / screen.logicalXDPI,
         fillParent    : true,
         scrollParent  : false,
         hideScrollbar : false,


### PR DESCRIPTION
IE 9/10 does not support window.devicePixelRatio.  Wavesurfer.js doesn't seem to officially support IE 9/10, but a number of members of the community are interested in supporting IE 9/10.  Our project is using wavesurfer and is supporting IE 9/10 by generating PCM on server side, and using MediaElement fallback.