### PR TITLE
Fix ScriptProcessor's buffer size

### DIFF
--- a/plugin/wavesurfer.spectrogram.js
+++ b/plugin/wavesurfer.spectrogram.js
@@ -135,12 +135,19 @@ WaveSurfer.Spectrogram = {
             this.fireEvent('error', 'Web Audio buffer is not available');
             return;
         }
+
+        var samplesPerPx = buffer.length / this.canvas.width;
+        
+        //Find the nearest power of two:
+        var idealBufferSize = Math.pow(2, Math.round( Math.log(samplesPerPx) / Math.log(2)));
+        //Buffer size must be within [256, 16834]
+        var bufferSize = Math.min(16384, Math.max(256,idealBufferSize));
         
         var frequencies = [];
         var context = new (window.OfflineAudioContext || window.webkitOfflineAudioContext)(1, buffer.length, buffer.sampleRate);
         var source = context.createBufferSource();
         var processor = context.createScriptProcessor ?
-            context.createScriptProcessor(0, 1, 1) : context.createJavaScriptNode(0, 1, 1);
+            context.createScriptProcessor(bufferSize, 1, 1) : context.createJavaScriptNode(bufferSize, 1, 1);
 
         var analyser = context.createAnalyser();
         analyser.fftSize = fftSamples;


### PR DESCRIPTION
ScriptProcessor is created with parameter 'bufferSize' set to 0, it'll select a default value (4096) which is too big for short audio recording. Hence the spectrogram is rendered with very wide pixel blocks. This commit will determine the best buffer size depending on the length of the recording and the width of the canvas.

![Before](https://cloud.githubusercontent.com/assets/3929490/13134473/9a7ad910-d66b-11e5-832f-f569a0055e51.png)

After the fix:
![After](https://cloud.githubusercontent.com/assets/3929490/13134518/050761ae-d66c-11e5-8be8-f13f0a3a27d7.png)
