### PR TITLE
Add clean to build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,9 @@ module.exports = function(grunt) {
       '<%= pkg.homepage ? "* " + pkg.homepage + "\\n" : "" %>' +
       '* @license <%= pkg.license %> */',
     // Task configuration.
+    clean : {
+      build: ['dist']
+    },
     concat: {
       options: {
         stripBanners: true
@@ -189,10 +192,11 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-coveralls');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-umd');
-  grunt.loadNpmTasks("grunt-jscs");
+  grunt.loadNpmTasks('grunt-jscs');
+  grunt.loadNpmTasks('grunt-contrib-clean');
 
   // Default task.
-  grunt.registerTask('default', ['jshint', 'jscs', 'test', 'coverage', 'concat',
+  grunt.registerTask('default', ['clean', 'jshint', 'jscs', 'test', 'coverage', 'concat',
     'umd', 'uglify']);
 
   // Dev

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": ">=0.4.0",
     "grunt-contrib-connect": "^0.11.2",
     "grunt-contrib-jasmine": ">=0.8.2",


### PR DESCRIPTION
We're having trouble with the build creating extra files when there are already files in `dist`, so here's a `clean` task for deleting `dist` before each build to keep that from happening. #608 