### PR TITLE
MediaStream stop() has been removed from the spec.

### DIFF
--- a/plugin/wavesurfer.microphone.js
+++ b/plugin/wavesurfer.microphone.js
@@ -130,7 +130,9 @@
 
             // stop stream from device
             if (this.stream) {
-                this.stream.stop();
+                this.stream.getTracks().forEach(function(track) {
+                    track.stop();
+                });
             }
         },
 


### PR DESCRIPTION
https://codereview.chromium.org/1194763002/
Looks like .stop() was deprecated in Chrome M45 and then released in M47 based
on the spec:

http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-MediaStream

This pull request provides a fix for stop.