### PR TITLE
Change getPeaks baseline to zero

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -197,8 +197,8 @@ WaveSurfer.WebAudio = {
             for (var i = 0; i < length; i++) {
                 var start = ~~(i * sampleSize);
                 var end = ~~(start + sampleSize);
-                var min = chan[0];
-                var max = chan[0];
+                var min = 0;
+                var max = 0;
 
                 for (var j = start; j < end; j += sampleStep) {
                     var value = chan[j];


### PR DESCRIPTION
The getPeaks function was using the first sample in each channel to initialize the min and max values, causing files that start above or below zero to be drawn with persistent offsets. Initializing the min and max to 0 fixes this.