### PR TITLE
Fix click-to-seek for audios which are not spanning the entire canvas

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -41,8 +41,25 @@ WaveSurfer.Drawer = {
 
     handleEvent: function (e) {
         e.preventDefault();
+
         var bbox = this.wrapper.getBoundingClientRect();
-        return ((e.clientX - bbox.left + this.wrapper.scrollLeft) / this.wrapper.scrollWidth) || 0;
+
+        var nominalWidth = this.width;
+        var parentWidth = this.getWidth();
+
+        var progress;
+
+        if (!this.params.fillParent && nominalWidth < parentWidth) {
+            progress = ((e.clientX - bbox.left) * this.params.pixelRatio / nominalWidth) || 0;
+
+            if (progress > 1) {
+                progress = 1;
+            }
+        } else {
+            progress = ((e.clientX - bbox.left + this.wrapper.scrollLeft) / this.wrapper.scrollWidth) || 0;
+        }
+
+        return progress;
     },
 
     setupWrapperEvents: function () {


### PR DESCRIPTION
Solves #686 