### PR TITLE
Remove argument from MultiCanvas clearWave() method

### DIFF
--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -61,7 +61,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
             }
 
             this.updateDimensions(this.canvases[i], canvasWidth, this.height);
-            this.clearWave(this.canvases[i]);
+            this.clearWaveForEntry(this.canvases[i]);
         }
     },
 
@@ -119,7 +119,13 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
         }
     },
 
-    clearWave: function (entry) {
+    clearWave: function () {
+        for (var i in this.canvases) {
+            this.clearWaveForEntry(this.canvases[i]);
+        }
+    },
+
+    clearWaveForEntry: function (entry) {
         entry.waveCtx.clearRect(0, 0, entry.waveCtx.canvas.width, entry.waveCtx.canvas.height);
         if (this.hasProgressCanvas) {
             entry.progressCtx.clearRect(0, 0, entry.progressCtx.canvas.width, entry.progressCtx.canvas.height);


### PR DESCRIPTION
Renamed `clearWave()` to `clearWaveForEntry()`. Added `clearWave()` method that calls `clearWaveForEntry()` on all canvases.

Question: The only thing calling `clearWave()` is the `setChannel()` method in `wavesurfer.js`. This method isn't in the API documentation as far as I can tell. Is it still used?