### PR TITLE
MediaElement#getDuration throwing TypeError fixed

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -67,7 +67,7 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
     getDuration: function () {
         var duration = this.media.duration;
         if (duration >= Infinity) { // streaming audio
-            duration = this.media.seekable.end();
+            duration = this.media.seekable.end(0);
         }
         return duration;
     },


### PR DESCRIPTION
WaveSurfer.MediaElement#getDuration throwed `TypeError: Not enough
arguments` in Safari 9.1. It also violated contract specified in [HTML Time ranges](https://developers.whatwg.org/the-video-element.html#dom-timeranges-end).

This should fix #719.