### PR TITLE
Revert "Allow to play/draw one channel specified by parameter"

### DIFF
--- a/src/drawer.canvas.js
+++ b/src/drawer.canvas.js
@@ -73,11 +73,6 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.Canvas, {
                 this.setHeight(channels.length * this.params.height * this.params.pixelRatio);
                 channels.forEach(this.drawBars, this);
                 return;
-            } else if (this.params.channel > -1) { // Channel specified
-                if (this.params.channel >= channels.length) {
-                    throw new Error('Channel doesn\'t exist');
-                }
-                peaks = channels[this.params.channel];
             } else {
                 peaks = channels[0];
             }
@@ -131,11 +126,6 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.Canvas, {
                 this.setHeight(channels.length * this.params.height * this.params.pixelRatio);
                 channels.forEach(this.drawWave, this);
                 return;
-            } else if (this.params.channel > -1) { // Channel specified
-                if (this.params.channel >= channels.length) {
-                    throw new Error('Channel doesn\'t exist');
-                }
-                peaks = channels[this.params.channel];
             } else {
                 peaks = channels[0];
             }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -29,7 +29,6 @@ var WaveSurfer = {
         audioRate     : 1,
         interact      : true,
         splitChannels : false,
-        channel       : -1,
         mediaContainer: null,
         mediaControls : false,
         renderer      : 'Canvas',
@@ -279,13 +278,6 @@ var WaveSurfer = {
             this.getCurrentTime() / this.getDuration()
         );
         this.fireEvent('zoom', pxPerSec);
-    },
-
-    setChannel: function (channel) {
-        this.params.channel = channel;
-        this.drawer.clearWave();
-        this.drawBuffer();
-        this.backend.setChannel(channel);
     },
 
     /**

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -57,7 +57,7 @@ WaveSurfer.WebAudio = {
             });
             this.filters = null;
             // Reconnect direct path
-            this.analyser.connect(this.splitter);
+            this.analyser.connect(this.gainNode);
         }
     },
 
@@ -91,7 +91,7 @@ WaveSurfer.WebAudio = {
             filters.reduce(function (prev, curr) {
                 prev.connect(curr);
                 return curr;
-            }, this.analyser).connect(this.splitter);
+            }, this.analyser).connect(this.gainNode);
         }
 
     },
@@ -126,30 +126,6 @@ WaveSurfer.WebAudio = {
 
     removeOnAudioProcess: function () {
         this.scriptNode.onaudioprocess = null;
-    },
-
-    createChannelNodes: function () {
-        var channels = this.buffer.numberOfChannels;
-
-        this.splitter = this.ac.createChannelSplitter(channels);
-        this.merger = this.ac.createChannelMerger(channels);
-
-        this.setChannel(this.params.channel);
-
-        this.analyser.disconnect();
-        this.analyser.connect(this.splitter);
-
-        this.merger.connect(this.gainNode);
-    },
-
-    setChannel: function (channel) {
-        var channels = this.buffer.numberOfChannels;
-
-        this.splitter.disconnect();
-
-        for (var c = 0; c < channels; c++) {
-            this.splitter.connect(this.merger, channel === -1 ? c : channel, c);
-        }
     },
 
     createAnalyserNode: function () {
@@ -249,7 +225,7 @@ WaveSurfer.WebAudio = {
             }
         }
 
-        return (this.params.splitChannels || this.params.channel > -1) ? splitPeaks : mergedPeaks;
+        return this.params.splitChannels ? splitPeaks : mergedPeaks;
     },
 
     getPlayedPercents: function () {
@@ -272,8 +248,6 @@ WaveSurfer.WebAudio = {
         this.disconnectSource();
         this.gainNode.disconnect();
         this.scriptNode.disconnect();
-        this.merger.disconnect();
-        this.splitter.disconnect();
         this.analyser.disconnect();
     },
 
@@ -282,7 +256,6 @@ WaveSurfer.WebAudio = {
         this.lastPlay = this.ac.currentTime;
         this.buffer = buffer;
         this.createSource();
-        this.createChannelNodes();
     },
 
     createSource: function () {


### PR DESCRIPTION
Temporarily revert #689 due to a regression described in #724.

@whenov we'll restore this feature after we come up with a solution to transparently insert new nodes into the Web Audio graph keeping the graph further extensible.