### PR TITLE
Added option for slop protection

### DIFF
--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -36,6 +36,8 @@ WaveSurfer.Regions = {
         var drag;
         var start;
         var region;
+        var slop = params.slop || 2;
+        var pxMove = 0;
 
         function eventDown(e) {
             drag = true;
@@ -53,6 +55,7 @@ WaveSurfer.Regions = {
         });
         function eventUp(e) {
             drag = false;
+            pxMove = 0;
 
             if (region) {
                 region.fireEvent('update-end', e);
@@ -69,6 +72,7 @@ WaveSurfer.Regions = {
         });
         function eventMove(e) {
             if (!drag) { return; }
+            if (++pxMove <= slop) { return; }
 
             if (!region) {
                 region = my.add(params || {});


### PR DESCRIPTION
I noticed when clicking around to move the cursor, it was too easy to accidentally create a region. This addresses that issue. Default value is 2 pixels, and it can be overridden as well:

```javascript
    wavesurfer.enableDragSelection({ slop: 0 });
```
