### PR TITLE
Call pause() when scheduled pause time is reached

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -116,8 +116,7 @@ WaveSurfer.WebAudio = {
                 my.setState(my.FINISHED_STATE);
                 my.fireEvent('pause');
             } else if (time >= my.scheduledPause) {
-                my.setState(my.PAUSED_STATE);
-                my.fireEvent('pause');
+                my.pause();
             } else if (my.state === my.states[my.PLAYING_STATE]) {
                 my.fireEvent('audioprocess', time);
             }


### PR DESCRIPTION
When the scheduled pause time is reached (because only a range of the sound is playing), call `pause()` instead of setting the state and firing the pause event. This ensures that `startPosition` will be recalculated to the time of the pause event.

Addresses issue #741.