### PR TITLE
Enhance timeline plugin to support multi-canvas rendering

### DIFF
--- a/plugin/wavesurfer.timeline.js
+++ b/plugin/wavesurfer.timeline.js
@@ -19,6 +19,9 @@ WaveSurfer.Timeline = {
         }
 
         this.width = drawer.width;
+        this.pixelRatio = this.drawer.params.pixelRatio;
+        this.maxCanvasWidth = drawer.maxCanvasWidth || this.width;
+        this.maxCanvasElementWidth = drawer.maxCanvasElementWidth || Math.round(this.maxCanvasWidth / this.pixelRatio);
         this.height = this.params.height || 20;
         this.notchPercentHeight = this.params.notchPercentHeight || 90;
         this.primaryColor = this.params.primaryColor || '#000';
@@ -31,9 +34,10 @@ WaveSurfer.Timeline = {
         this.primaryLabelInterval = this.params.primaryLabelInterval;
         this.secondaryLabelInterval = this.params.secondaryLabelInterval;
         this.formatTimeCallback = this.params.formatTimeCallback;
+        this.canvases = [];
 
         this.createWrapper();
-        this.createCanvas();
+        this.createCanvases();
         this.render();
 
         wavesurfer.drawer.wrapper.onscroll = this.updateScroll.bind(this);
@@ -83,33 +87,45 @@ WaveSurfer.Timeline = {
         });
     },
 
-    createCanvas: function () {
-        var canvas = this.canvas = this.wrapper.appendChild(
-            document.createElement('canvas')
-        );
+    createCanvases: function () {
+        var totalWidth = Math.round(this.drawer.wrapper.scrollWidth),
+            requiredCanvases = Math.ceil(totalWidth / this.maxCanvasElementWidth),
+            canvas;
 
-        this.timeCc = canvas.getContext('2d');
-
-        this.wavesurfer.drawer.style(canvas, {
-            position: 'absolute',
-            zIndex: 4
-        });
+        for (var i = 0; i < requiredCanvases; i++) {
+            canvas = this.wrapper.appendChild(document.createElement('canvas'));
+            this.canvases.push(canvas);
+            this.drawer.style(canvas, {
+                position: 'absolute',
+                zIndex: 4
+            });
+        }
     },
 
     render: function () {
         this.updateCanvasStyle();
-        this.drawTimeCanvas();
+        this.drawTimeCanvases();
     },
 
     updateCanvasStyle: function () {
-        var width = this.drawer.wrapper.scrollWidth;
-        this.canvas.width = width * this.wavesurfer.params.pixelRatio;
-        this.canvas.height = this.height * this.wavesurfer.params.pixelRatio;
-        this.canvas.style.width = width + 'px';
-        this.canvas.style.height = this.height + 'px';
+        var requiredCanvases = this.canvases.length;
+        for (var i = 0; i < requiredCanvases; i++) {
+            var canvas = this.canvases[i],
+                canvasWidth = this.maxCanvasElementWidth;
+
+            if (i === requiredCanvases - 1) {
+                canvasWidth = this.width / this.pixelRatio - (this.maxCanvasElementWidth * (requiredCanvases - 1));
+            }
+
+            canvas.width = canvasWidth * this.pixelRatio;
+            canvas.height = this.height * this.pixelRatio;
+            canvas.style.width = canvasWidth + 'px';
+            canvas.style.height = this.height + 'px';
+            canvas.style.left = i * canvasWidth + 'px';
+        }
     },
 
-    drawTimeCanvas: function() {
+    drawTimeCanvases: function() {
         var backend = this.wavesurfer.backend,
         wsParams = this.wavesurfer.params,
         duration = backend.getDuration(),
@@ -170,24 +186,79 @@ WaveSurfer.Timeline = {
 
         for (var i = 0; i < totalSeconds/timeInterval; i++) {
             if (i % primaryLabelInterval == 0) {
-                this.timeCc.fillStyle = this.primaryColor;
-                this.timeCc.fillRect(curPixel, 0, 1, height1);
-                this.timeCc.font = fontSize + 'px ' + this.fontFamily;
-                this.timeCc.fillStyle = this.primaryFontColor;
-                this.timeCc.fillText(formatTime(curSeconds), curPixel + 5, height1);
+                this.setFillStyles(this.primaryColor);
+                this.fillRect(curPixel, 0, 1, height1);
+                this.setFonts(fontSize + 'px ' + this.fontFamily);
+                this.setFillStyles(this.primaryFontColor);
+                this.fillText(formatTime(curSeconds), curPixel + 5, height1);
             } else if (i % secondaryLabelInterval == 0) {
-                this.timeCc.fillStyle = this.secondaryColor;
-                this.timeCc.fillRect(curPixel, 0, 1, height1);
-                this.timeCc.font = fontSize + 'px ' + this.fontFamily;
-                this.timeCc.fillStyle = this.secondaryFontColor;
-                this.timeCc.fillText(formatTime(curSeconds), curPixel + 5, height1);
+                this.setFillStyles(this.secondaryColor);
+                this.fillRect(curPixel, 0, 1, height1);
+                this.setFonts(fontSize + 'px ' + this.fontFamily);
+                this.setFillStyles(this.secondaryFontColor);
+                this.fillText(formatTime(curSeconds), curPixel + 5, height1);
             } else {
-                this.timeCc.fillStyle = this.secondaryColor;
-                this.timeCc.fillRect(curPixel, 0, 1, height2);
+                this.setFillStyles(this.secondaryColor);
+                this.fillRect(curPixel, 0, 1, height2);
             }
 
             curSeconds += timeInterval;
             curPixel += pixelsPerSecond * timeInterval;
+        }
+    },
+
+    setFillStyles: function (fillStyle) {
+        for (var i in this.canvases) {
+            this.canvases[i].getContext('2d').fillStyle = fillStyle;
+        }
+    },
+
+    setFonts: function (font) {
+        for (var i in this.canvases) {
+            this.canvases[i].getContext('2d').font = font;
+        }
+    },
+
+    fillRect: function (x, y, width, height) {
+        for (var i in this.canvases) {
+            var canvas = this.canvases[i],
+                leftOffset = i * this.maxCanvasWidth;
+
+            var intersection = {
+                x1: Math.max(x, i * this.maxCanvasWidth),
+                y1: y,
+                x2: Math.min(x + width, i * this.maxCanvasWidth + canvas.width),
+                y2: y + height
+            };
+
+            if (intersection.x1 < intersection.x2) {
+                canvas.getContext('2d').fillRect(
+                    intersection.x1 - leftOffset,
+                    intersection.y1,
+                    intersection.x2 - intersection.x1,
+                    intersection.y2 - intersection.y1);
+            }
+        }
+    },
+
+    fillText: function (text, x, y) {
+        var textWidth,
+            xOffset = 0;
+
+        for (var i in this.canvases) {
+            var context = this.canvases[i].getContext('2d'),
+                canvasWidth = context.canvas.width;
+
+            if (xOffset > x + textWidth) {
+                break;
+            }
+
+            if (xOffset + canvasWidth > x) {
+                textWidth = context.measureText(text).width; 
+                context.fillText(text, x - xOffset, y);
+            }
+
+            xOffset += canvasWidth;
         }
     },
 


### PR DESCRIPTION
A merge request to cover #696. I have endeavoured to maintain backwards compatibility with the `Canvas` renderer. I have attached a [multicanvas-timeline-tests.zip](https://github.com/katspaugh/wavesurfer.js/files/349198/multicanvas-timeline-tests.zip) file containing my changes, along with a test html and js file in the `src` directory that can be run to visually observe the results.

I don't personally use the timeline plugin, so there may be some edge cases that I'm not aware of. I've changed some function names, e.g. `drawTimeCanvas` -> `drawTimeCanvases`, so that's a potential breaking change.

@chinshr and @jeremylach, it would be great if you could download the attached zip file and see if the changes meet your needs before the changes are merged (assuming they are ☺).
