### PR TITLE
Update Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
                 dest: 'dist',
                 deps: {
                     'default': [ 'WaveSurfer' ],
-                    amd: [ 'wavesurfer' ],
+                    amd: [ './../wavesurfer' ],
       	            cjs: [ 'wavesurfer.js' ],
                     global: [ 'WaveSurfer' ]
                 }


### PR DESCRIPTION
WaveSurfer plugins currently can not be required by a tool like webpack because their dependence on wavesurfer module uses an absolute id instead of an id on the "plugin" directory