### PR TITLE
adding controls to ensure region size does not change and sliding stops when the sides are reached

### DIFF
--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -425,16 +425,14 @@ WaveSurfer.Region = {
 
     onDrag: function (delta) {
         var maxEnd = this.wavesurfer.getDuration();
-        
         if ((this.end + delta) > maxEnd || (this.start + delta) < 0) {
             delta = 0;
         }        
-
+        
         this.update({
             start: this.start + delta,
             end: this.end + delta
         });
-
     },
 
     onResize: function (delta, direction) {

--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -424,10 +424,17 @@ WaveSurfer.Region = {
     },
 
     onDrag: function (delta) {
+        var maxEnd = this.wavesurfer.getDuration();
+        
+        if ((this.end + delta) > maxEnd || (this.start + delta) < 0) {
+            delta = 0;
+        }        
+
         this.update({
             start: this.start + delta,
             end: this.end + delta
         });
+
     },
 
     onResize: function (delta, direction) {

--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -427,8 +427,8 @@ WaveSurfer.Region = {
         var maxEnd = this.wavesurfer.getDuration();
         if ((this.end + delta) > maxEnd || (this.start + delta) < 0) {
             delta = 0;
-        }        
-        
+        }
+
         this.update({
             start: this.start + delta,
             end: this.end + delta

--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -426,7 +426,7 @@ WaveSurfer.Region = {
     onDrag: function (delta) {
         var maxEnd = this.wavesurfer.getDuration();
         if ((this.end + delta) > maxEnd || (this.start + delta) < 0) {
-            delta = 0;
+            return;
         }
 
         this.update({


### PR DESCRIPTION
With regards to issue #717 I was looking into it as it was something I wanted to change too so I just went ahead with it. Hopefully that's alright.

Overall, I feel it's much more intuitive now as regions don't magically resize. This is especially true when you set resizing to false but end up dragging the region to the side as well.