### PR TITLE
Fix MultiCanvas bar drawing exception

### DIFF
--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -174,11 +174,6 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
         var scale = length / width;
 
-        this.canvases[0].waveCtx.fillStyle = this.params.waveColor;
-        if (this.canvases[0].progressCtx) {
-            this.canvases[0].progressCtx.fillStyle = this.params.progressColor;
-        }
-
         for (var i = 0; i < width; i += step) {
             var h = Math.round(peaks[Math.floor(i * scale)] / absmax * halfH);
             this.fillRect(i + this.halfPixel, halfH - h + offsetY, bar + this.halfPixel, h * 2);


### PR DESCRIPTION
My fix for #790 means that we get an extra redraw upon initial load. This is fine, but it woke up a sleeping bug. The initial redraw throws the following exception in Chrome:
```Uncaught TypeError: Cannot read property 'waveCtx' of undefined```

I forgot to delete a bit of code from my initial implementation of MultiCanvas. It was naively setting the fill styles of the first canvas element in the array, even if the array is empty.

I already have the proper code in place for this (`fillRect()` calls `setFillStyle()`), so the fix is to simply delete the bit of old code.