### PR TITLE
Only recent on zoom, removed seek

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -277,7 +277,7 @@ var WaveSurfer = {
 
         this.drawBuffer();
 
-        this.seekAndCenter(
+        this.drawer.recenter(
             this.getCurrentTime() / this.getDuration()
         );
         this.fireEvent('zoom', pxPerSec);


### PR DESCRIPTION
Zoom should not modify the play position. Removing seek greatly increases performance while zooming.