### PR TITLE
Fix Play Percentage on Zoom when audio paused.

### DIFF
--- a/dist/wavesurfer.js
+++ b/dist/wavesurfer.js
@@ -284,6 +284,7 @@ var WaveSurfer = {
         this.params.scrollParent = true;
 
         this.drawBuffer();
+        this.drawer.progress(this.backend.getPlayedPercents());
 
         this.seekAndCenter(
             this.getCurrentTime() / this.getDuration()


### PR DESCRIPTION
Bug possibly caused by: https://github.com/katspaugh/wavesurfer.js/pull/803

By not seeking, the play percentage is not updated. Instead, we call it directly to avoid seekTo overhead.