### PR TITLE
814: Pre-generated waveform on MultiCanvas and zoom doesn't fill out each canvas

### DIFF
--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -240,7 +240,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
         var scale = 1;
         if (this.params.fillParent && this.width != length) {
-            scale = ctx.canvas.width / length;
+            scale = this.width / length;
         }
 
         var first = Math.round(length * entry.start),


### PR DESCRIPTION
For #814.