### PR TITLE
Added HTML Variable Preload Attribute

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -50,13 +50,17 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
      *  @param  {HTMLElement}   container   HTML element
      *  @param  {Array}         peaks       array of peak data
      */
-    load: function (url, container, peaks) {
+    load: function (url, container, peaks, preload) {
         var my = this;
 
         var media = document.createElement(this.mediaType);
         media.controls = this.params.mediaControls;
         media.autoplay = this.params.autoplay || false;
-        media.preload = 'auto';
+        if (preload) {
+            media.preload = preload;
+        } else {
+            media.preload = 'auto';
+        }
         media.src = url;
         media.style.width = '100%';
 

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -49,6 +49,7 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
      *  @param  {String}        url         path to media file
      *  @param  {HTMLElement}   container   HTML element
      *  @param  {Array}         peaks       array of peak data
+     *  @param  {String}        preload     HTML 5 preload attribute value
      */
     load: function (url, container, peaks, preload) {
         var my = this;

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -56,11 +56,7 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
         var media = document.createElement(this.mediaType);
         media.controls = this.params.mediaControls;
         media.autoplay = this.params.autoplay || false;
-        if (preload) {
-            media.preload = preload;
-        } else {
-            media.preload = 'auto';
-        }
+        media.preload = preload == null ? 'auto' : preload;
         media.src = url;
         media.style.width = '100%';
 


### PR DESCRIPTION
Added a way to define the the preload attribute of the HTML5 audio markup.
'Metadata' and 'None' saves bandwidth, especially if there is multiple players on the page.
'Metadata' allows to have track length.
Default is left to 'auto' to avoid unexpected change for wavesurfer users.
Note that this attribute interpretation may be different on different browsers.