### PR TITLE
Fixed a bug in Firefox and scrollbar usage

### DIFF
--- a/plugin/wavesurfer.regions.js
+++ b/plugin/wavesurfer.regions.js
@@ -42,6 +42,12 @@ WaveSurfer.Regions = {
 
         var eventDown = function (e) {
             if (e.touches && e.touches.length > 1) { return; }
+
+            // Check whether the click/tap is on the bottom-most DOM element
+            // Effectively prevent clicks on the scrollbar from registering as
+            // region creation.
+            if (e.target.childElementCount > 0) { return; }
+
             touchId = e.targetTouches ? e.targetTouches[0].identifier : null;
 
             drag = true;


### PR DESCRIPTION
In Firefox, using the scrollbars (with the mouse pointer) would trigger a region selection. The fix for this might be a bit hacky, but it works.

Tested in Mac Chrome, Firefox, Safari, and Windows Chrome, Firefox.

Fixes #830, fixes #748, fixes #843 
