### PR TITLE
close the audiocontext in the destroy method of the webaudio backend

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -10,6 +10,15 @@ WaveSurfer.WebAudio = {
         return !!(window.AudioContext || window.webkitAudioContext);
     },
 
+    getAudioContext: function () {
+        if (!this.ac) {
+            this.ac = new (
+                window.AudioContext || window.webkitAudioContext
+            );
+        }
+        return this.ac;
+    },
+
     getOfflineAudioContext: function (sampleRate) {
         if (!WaveSurfer.WebAudio.offlineAudioContext) {
             WaveSurfer.WebAudio.offlineAudioContext = new (
@@ -21,9 +30,7 @@ WaveSurfer.WebAudio = {
 
     init: function (params) {
         this.params = params;
-        this.ac = params.audioContext || new (
-            window.AudioContext || window.webkitAudioContext
-        );
+        this.ac = params.audioContext || this.getAudioContext();
 
         this.lastPlay = this.ac.currentTime;
         this.startPosition = 0;

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -257,7 +257,11 @@ WaveSurfer.WebAudio = {
         this.gainNode.disconnect();
         this.scriptNode.disconnect();
         this.analyser.disconnect();
-        this.ac.close();
+        // close the audioContext if it was created by wavesurfer
+        // not passed in as a parameter
+        if (!this.params.audioContext) {
+            this.ac.close();
+        }
     },
 
     load: function (buffer) {

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -10,15 +10,6 @@ WaveSurfer.WebAudio = {
         return !!(window.AudioContext || window.webkitAudioContext);
     },
 
-    getAudioContext: function () {
-        if (!WaveSurfer.WebAudio.audioContext) {
-            WaveSurfer.WebAudio.audioContext = new (
-                window.AudioContext || window.webkitAudioContext
-            );
-        }
-        return WaveSurfer.WebAudio.audioContext;
-    },
-
     getOfflineAudioContext: function (sampleRate) {
         if (!WaveSurfer.WebAudio.offlineAudioContext) {
             WaveSurfer.WebAudio.offlineAudioContext = new (
@@ -30,7 +21,9 @@ WaveSurfer.WebAudio = {
 
     init: function (params) {
         this.params = params;
-        this.ac = params.audioContext || this.getAudioContext();
+        this.ac = params.audioContext || new (
+            window.AudioContext || window.webkitAudioContext
+        );
 
         this.lastPlay = this.ac.currentTime;
         this.startPosition = 0;

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -257,6 +257,7 @@ WaveSurfer.WebAudio = {
         this.gainNode.disconnect();
         this.scriptNode.disconnect();
         this.analyser.disconnect();
+        this.ac.close();
     },
 
     load: function (buffer) {


### PR DESCRIPTION
There is a maximum amount (6) for active audioContexts, so this allows on the fly enabling/disabling without reaching that limit (if the number of currently active acs is always below 6)

https://developer.mozilla.org/en/docs/Web/API/AudioContext/close