### PR TITLE
change electro link to our new project site

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -57,7 +57,7 @@ layout: default
         <td>A music jamming application. Users can plug-in their guitar and/or MIDI key controller. Wavesurfer.js is being used to render backing track audio files and recorded audio.</td>
       </tr>
       <tr>
-        <td><a href="https://github.com/jspear29/electro">Electro</a></td>
+        <td><a href="https://jspear29.github.io/electro">Electro</a></td>
         <td>Allows music to be mixed live from the internet</td>
       </tr>
       <tr>


### PR DESCRIPTION
Hey I finally setup a git hub project site for our project...  It would be great if you could link to that in you projects using.

I've used jekyll like once before and I think it's cool to edit those files directly?  