### PR TITLE
Only call media.load() if it exists

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -97,7 +97,9 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
 
         // load must be called manually on iOS, otherwise peaks won't draw
         // until a user interaction triggers load --> 'ready' event
-        media.load();
+        if (typeof media.load == 'function') {
+            media.load();
+        }
 
         media.addEventListener('error', function () {
             my.fireEvent('error', 'Error loading media element');


### PR DESCRIPTION
When running code that uses Wavesurfer under PhantomJS (even if not explicitly testing the Wavesurfer code), the JS interpreter crashes because PhantomJS DOM `<audio>` elements don't have a `load()` method. This change skips that one line if the method doesn't exist.