### PR TITLE
Next: Refactor timeline plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,7 +114,12 @@ module.exports = {
         "no-bitwise": "off",
         "no-caller": "error",
         "no-catch-shadow": "error",
-        "no-confusing-arrow": "error",
+        "no-confusing-arrow": [
+            "error",
+            {
+                "allowParens": true
+            }
+        ],
         "no-continue": "error",
         "no-div-regex": "error",
         "no-duplicate-imports": "error",

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - "4.2"
+  - "4"
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-install: npm install
+install:
+  - npm prune
+  - npm install
+  - npm update
 script:
   - npm run test
   - npm run build

--- a/example/timeline/index.html
+++ b/example/timeline/index.html
@@ -98,10 +98,10 @@ wavesurfer.load('example/media/demo.mp3');</code></pre>
                       <li><code>secondaryColor</code> - the color of the non-modulo-ten notch lines. The default is '#c0c0c0'.</li>
                       <li><code>primaryFontColor</code> - the color of the non-modulo-ten time labels (e.g. 10sec, 20sec). The default is '#000'.</li>
                       <li><code>primaryFontColor</code> - the color of the non-modulo-ten time labels (e.g. 5sec, 15sec). The default is '#c0c0c0'.</li>
-                      <li><code>timeInterval</code> - number of intervals that records consists of. Usually it is equal to the duration in minutes.</li>
-                      <li><code>primaryLabelInterval</code> - number of primary time labels.</li>
-                      <li><code>secondaryLabelInterval</code> - number of secondary time labels (Time labels between primary labels).</li>
-                      <li><code>formatTimeCallback</code> - custom time format callback.</li>
+                      <li><code>timeInterval</code> - number of intervals that records consists of. Usually it is equal to the duration in minutes. (Integer or function which receives pxPerSec value and reurns value)</li>
+                      <li><code>primaryLabelInterval</code> - number of primary time labels. (Integer or function which receives pxPerSec value and reurns value)</li>
+                      <li><code>secondaryLabelInterval</code> - number of secondary time labels (Time labels between primary labels, integer or function which receives pxPerSec value and reurns value).</li>
+                      <li><code>formatTimeCallback</code> - custom time format callback. (Function which receives number of seconds and returns formatted string)</li>
                     </ul>
                 </div>
             </div>

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "1.0.2",
     "karma-jasmine-matchers": "3.0.1",
-    "karma-webpack": "^1.8.0",
-    "webpack": "^2.1.0-beta.25",
-    "webpack-dev-server": "^2.1.0-beta.9"
+    "karma-webpack": "^2.0.2",
+    "webpack": "2",
+    "webpack-dev-server": "2"
   },
   "homepage": "https://github.com/katspaugh/wavesurfer.js"
 }

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -73,6 +73,7 @@ export default function(params = {}) {
                         return 2;
                     }
                 }, params);
+
                 this.canvases = [];
 
                 this._onScroll = () => {
@@ -115,7 +116,6 @@ export default function(params = {}) {
             },
 
             createWrapper: function () {
-
                 const wsParams = this.wavesurfer.params;
                 this.wrapper = this.container.appendChild(
                     document.createElement('timeline')
@@ -225,7 +225,7 @@ export default function(params = {}) {
                 const fontSize = this.opts.fontSize * wsParams.pixelRatio;
                 let i;
 
-                for (i = 0; i < totalSeconds/timeInterval; i++) {
+                for (i = 0; i < totalSeconds / timeInterval; i++) {
                     if (i % primaryLabelInterval == 0) {
                         this.setFillStyles(this.opts.primaryColor);
                         this.fillRect(curPixel, 0, 1, height1);

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -12,6 +12,7 @@ export default function(params = {}) {
         instance: {
             init: function (wavesurfer) {
                 this.wavesurfer = wavesurfer;
+                this.style = wavesurfer.util.style;
 
                 this.container = 'string' == typeof params.container
                     ? document.querySelector(params.container)
@@ -113,7 +114,7 @@ export default function(params = {}) {
                 this.wrapper = this.container.appendChild(
                     document.createElement('timeline')
                 );
-                this.drawer.style(this.wrapper, {
+                this.style(this.wrapper, {
                     display: 'block',
                     position: 'relative',
                     userSelect: 'none',
@@ -122,7 +123,7 @@ export default function(params = {}) {
                 });
 
                 if (wsParams.fillParent || wsParams.scrollParent) {
-                    this.drawer.style(this.wrapper, {
+                    this.style(this.wrapper, {
                         width: '100%',
                         overflowX: 'hidden',
                         overflowY: 'hidden'
@@ -154,7 +155,7 @@ export default function(params = {}) {
                 for (i = 0; i < requiredCanvases; i++) {
                     canvas = this.wrapper.appendChild(document.createElement('canvas'));
                     this.canvases.push(canvas);
-                    this.drawer.style(canvas, {
+                    this.style(canvas, {
                         position: 'absolute',
                         zIndex: 4
                     });
@@ -180,9 +181,11 @@ export default function(params = {}) {
 
                     canvas.width = canvasWidth * this.pixelRatio;
                     canvas.height = this.opts.height * this.pixelRatio;
-                    canvas.style.width = canvasWidth + 'px';
-                    canvas.style.left = i * this.maxCanvasElementWidth + 'px';
-                    canvas.style.height = `${this.opts.height}px`;
+                    this.style(canvas, {
+                        width: `${canvasWidth}px`,
+                        height: `${this.opts.height}px`,
+                        left: `${i * this.maxCanvasElementWidth}px`
+                    });
                 }
             },
 

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -75,10 +75,10 @@ export default function(params = {}) {
                 }, params);
                 this.canvases = [];
 
-                this._onRedraw = () => {
-                    this.render();
+                this._onScroll = () => {
+                    this.wrapper.scrollLeft = this.drawer.wrapper.scrollLeft;
                 };
-
+                this._onRedraw = () => this.render();
                 this._onReady = () => {
                     this.drawer = this.wavesurfer.drawer;
                     this.width = this.wavesurfer.drawer.width;
@@ -88,7 +88,7 @@ export default function(params = {}) {
 
                     this.createWrapper();
                     this.render();
-                    this.wavesurfer.drawer.wrapper.addEventListener('scroll', e => this.updateScroll(e));
+                    wavesurfer.drawer.wrapper.addEventListener('scroll', this._onScroll);
                     this.wavesurfer.on('redraw', this._onRedraw);
                 };
                 this.wavesurfer.on('ready', this._onReady);
@@ -102,6 +102,8 @@ export default function(params = {}) {
                 this.unAll();
                 this.wavesurfer.un('redraw', this._onRedraw);
                 this.wavesurfer.un('ready', this._onReady);
+                this.wavesurfer.drawer.wrapper.removeEventListener('scroll', this._onScroll);
+                    this.wrapper.removeEventListener('click', this._onClick);
                 if (this.wrapper && this.wrapper.parentNode) {
                     this.wrapper.parentNode.removeChild(this.wrapper);
                     this.wrapper = null;
@@ -130,11 +132,13 @@ export default function(params = {}) {
                     });
                 }
 
-                this.wrapper.addEventListener('click', e => {
+                this._onClick = e => {
                     e.preventDefault();
                     const relX = 'offsetX' in e ? e.offsetX : e.layerX;
                     this.fireEvent('click', (relX / this.wrapper.scrollWidth) || 0);
-                });
+                };
+
+                this.wrapper.addEventListener('click', this._onClick);
             },
 
             removeOldCanvases: function () {
@@ -302,10 +306,6 @@ export default function(params = {}) {
 
                     xOffset += canvasWidth;
                 }
-            },
-
-            updateScroll: function () {
-                this.wrapper.scrollLeft = this.drawer.wrapper.scrollLeft;
             }
         }
     };

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -14,8 +14,9 @@ export default function(params = {}) {
                 this.params = params;
                 this.wavesurfer = wavesurfer;
 
-                this.container = 'string' == typeof params.container ?
-                document.querySelector(params.container) : params.container;
+                this.container = 'string' == typeof params.container
+                    ? document.querySelector(params.container)
+                    : params.container;
 
                 if (!this.container) {
                     throw new Error('No container for WaveSurfer timeline');

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -22,7 +22,7 @@ export default function(params = {}) {
                     throw new Error('No container for WaveSurfer timeline');
                 }
 
-                this.opts = wavesurfer.util.extend({}, {
+                this.params = wavesurfer.util.extend({}, {
                     height: 20,
                     notchPercentHeight: 90,
                     primaryColor: '#000',
@@ -122,7 +122,7 @@ export default function(params = {}) {
                     position: 'relative',
                     userSelect: 'none',
                     webkitUserSelect: 'none',
-                    height: `${this.opts.height}px`
+                    height: `${this.params.height}px`
                 });
 
                 if (wsParams.fillParent || wsParams.scrollParent) {
@@ -184,10 +184,10 @@ export default function(params = {}) {
                     }
 
                     canvas.width = canvasWidth * this.pixelRatio;
-                    canvas.height = this.opts.height * this.pixelRatio;
+                    canvas.height = this.params.height * this.pixelRatio;
                     this.style(canvas, {
                         width: `${canvasWidth}px`,
-                        height: `${this.opts.height}px`,
+                        height: `${this.params.height}px`,
                         left: `${i * this.maxCanvasElementWidth}px`
                     });
                 }
@@ -202,13 +202,13 @@ export default function(params = {}) {
                     : this.drawer.wrapper.scrollWidth * wsParams.pixelRatio;
                 const pixelsPerSecond = width / duration;
 
-                const formatTime = this.opts.formatTimeCallback;
+                const formatTime = this.params.formatTimeCallback;
                 // if parameter is function, call the function with
                 // pixelsPerSecond, otherwise simply take the value as-is
                 const intervalFnOrVal = option => (typeof option === 'function' ? option(pixelsPerSecond) : option);
-                const timeInterval = intervalFnOrVal(this.opts.timeInterval);
-                const primaryLabelInterval = intervalFnOrVal(this.opts.primaryLabelInterval);
-                const secondaryLabelInterval = intervalFnOrVal(this.opts.secondaryLabelInterval);
+                const timeInterval = intervalFnOrVal(this.params.timeInterval);
+                const primaryLabelInterval = intervalFnOrVal(this.params.primaryLabelInterval);
+                const secondaryLabelInterval = intervalFnOrVal(this.params.secondaryLabelInterval);
 
                 let curPixel = 0;
                 let curSeconds = 0;
@@ -217,26 +217,26 @@ export default function(params = {}) {
                     return;
                 }
 
-                const height1 = this.opts.height - 4;
-                const height2 = (this.opts.height * (this.opts.notchPercentHeight / 100)) - 4;
-                const fontSize = this.opts.fontSize * wsParams.pixelRatio;
+                const height1 = this.params.height - 4;
+                const height2 = (this.params.height * (this.params.notchPercentHeight / 100)) - 4;
+                const fontSize = this.params.fontSize * wsParams.pixelRatio;
                 let i;
 
                 for (i = 0; i < totalSeconds / timeInterval; i++) {
                     if (i % primaryLabelInterval == 0) {
-                        this.setFillStyles(this.opts.primaryColor);
+                        this.setFillStyles(this.params.primaryColor);
                         this.fillRect(curPixel, 0, 1, height1);
-                        this.setFonts(`${fontSize}px ${this.opts.fontFamily}`);
-                        this.setFillStyles(this.opts.primaryFontColor);
+                        this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
+                        this.setFillStyles(this.params.primaryFontColor);
                         this.fillText(formatTime(curSeconds), curPixel + 5, height1);
                     } else if (i % secondaryLabelInterval == 0) {
-                        this.setFillStyles(this.opts.secondaryColor);
+                        this.setFillStyles(this.params.secondaryColor);
                         this.fillRect(curPixel, 0, 1, height1);
-                        this.setFonts(`${fontSize}px ${this.opts.fontFamily}`);
-                        this.setFillStyles(this.opts.secondaryFontColor);
+                        this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
+                        this.setFillStyles(this.params.secondaryFontColor);
                         this.fillText(formatTime(curSeconds), curPixel + 5, height1);
                     } else {
-                        this.setFillStyles(this.opts.secondaryColor);
+                        this.setFillStyles(this.params.secondaryColor);
                         this.fillRect(curPixel, 0, 1, height2);
                     }
 

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -80,22 +80,24 @@ export default function(params = {}) {
                 };
                 this._onRedraw = () => this.render();
                 this._onReady = () => {
-                    this.drawer = this.wavesurfer.drawer;
-                    this.width = this.wavesurfer.drawer.width;
-                    this.pixelRatio = this.wavesurfer.drawer.params.pixelRatio;
-                    this.maxCanvasWidth = this.wavesurfer.drawer.maxCanvasWidth || this.width;
-                    this.maxCanvasElementWidth = this.wavesurfer.drawer.maxCanvasElementWidth || Math.round(this.maxCanvasWidth / this.pixelRatio);
+                    this.drawer = wavesurfer.drawer;
+                    this.pixelRatio = wavesurfer.drawer.params.pixelRatio;
+                    this.maxCanvasWidth = wavesurfer.drawer.maxCanvasWidth || wavesurfer.drawer.width;
+                    this.maxCanvasElementWidth = wavesurfer.drawer.maxCanvasElementWidth || Math.round(this.maxCanvasWidth / this.pixelRatio);
 
                     this.createWrapper();
                     this.render();
                     wavesurfer.drawer.wrapper.addEventListener('scroll', this._onScroll);
-                    this.wavesurfer.on('redraw', this._onRedraw);
+                    wavesurfer.on('redraw', this._onRedraw);
                 };
-                this.wavesurfer.on('ready', this._onReady);
-                // Check if ws is ready
-                if (this.wavesurfer.backend) {
+
+                // backend (and drawer) already existed, just call
+                // initialisation code
+                if (wavesurfer.backend) {
                     this._onReady();
                 }
+                // ws is ready, call the initialisation code
+                wavesurfer.on('ready', this._onReady);
             },
 
             destroy: function () {

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -14,11 +14,6 @@ export default function(params = {}) {
                 this.params = params;
                 this.wavesurfer = wavesurfer;
 
-                if (!this.wavesurfer) {
-                    throw Error('No WaveSurfer intance provided');
-                }
-
-
                 this.container = 'string' == typeof params.container ?
                 document.querySelector(params.container) : params.container;
 

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -106,12 +106,9 @@ export default function(params = {}) {
                 this.wavesurfer.un('redraw', this._onRedraw);
                 this.wavesurfer.un('ready', this._onReady);
                 this.wavesurfer.drawer.wrapper.removeEventListener('scroll', this._onScroll);
-                if (this.wrapper) {
-                    this.wrapper.removeEventListener('click', this._onClick);
-                    if (this.wrapper.parentNode) {
-                        this.wrapper.parentNode.removeChild(this.wrapper);
-                        this.wrapper = null;
-                    }
+                if (this.wrapper && this.wrapper.parentNode) {
+                    this.wrapper.parentNode.removeChild(this.wrapper);
+                    this.wrapper = null;
                 }
             },
 

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -105,10 +105,12 @@ export default function(params = {}) {
                 this.wavesurfer.un('redraw', this._onRedraw);
                 this.wavesurfer.un('ready', this._onReady);
                 this.wavesurfer.drawer.wrapper.removeEventListener('scroll', this._onScroll);
+                if (this.wrapper) {
                     this.wrapper.removeEventListener('click', this._onClick);
-                if (this.wrapper && this.wrapper.parentNode) {
-                    this.wrapper.parentNode.removeChild(this.wrapper);
-                    this.wrapper = null;
+                    if (this.wrapper.parentNode) {
+                        this.wrapper.parentNode.removeChild(this.wrapper);
+                        this.wrapper = null;
+                    }
                 }
             },
 

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -23,7 +23,7 @@ export default function(params = {}) {
                 document.querySelector(params.container) : params.container;
 
                 if (!this.container) {
-                    throw Error('No container for WaveSurfer timeline');
+                    throw new Error('No container for WaveSurfer timeline');
                 }
 
                 this.height = this.params.height || 20;

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -157,11 +157,10 @@ export default function(params = {}) {
 
                 const totalWidth = Math.round(this.drawer.wrapper.scrollWidth);
                 const requiredCanvases = Math.ceil(totalWidth / this.maxCanvasElementWidth);
-                let canvas;
                 let i;
 
                 for (i = 0; i < requiredCanvases; i++) {
-                    canvas = this.wrapper.appendChild(document.createElement('canvas'));
+                    const canvas = this.wrapper.appendChild(document.createElement('canvas'));
                     this.canvases.push(canvas);
                     this.style(canvas, {
                         position: 'absolute',

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -197,11 +197,14 @@ export default function(params = {}) {
             },
 
             drawTimeCanvases: function() {
-                const backend = this.wavesurfer.backend;
                 const wsParams = this.wavesurfer.params;
-                const duration = backend.getDuration();
+                const duration = this.wavesurfer.backend.getDuration();
                 const totalSeconds = parseInt(duration, 10) + 1;
-                let width;
+                const width = wsParams.fillParent && !wsParams.scrollParent
+                    ? this.drawer.getWidth()
+                    : this.drawer.wrapper.scrollWidth * wsParams.pixelRatio;
+                const pixelsPerSecond = width / duration;
+
                 const formatTime = this.opts.formatTimeCallback;
                 // if parameter is function, call the function with
                 // pixelsPerSecond, otherwise simply take the value as-is
@@ -213,14 +216,8 @@ export default function(params = {}) {
                 let curPixel = 0;
                 let curSeconds = 0;
 
-                if (wsParams.fillParent && !wsParams.scrollParent) {
-                    width = this.drawer.getWidth();
-                } else {
-                    width = this.drawer.wrapper.scrollWidth * wsParams.pixelRatio;
-                }
-                const pixelsPerSecond = width/duration;
-
-                if (duration <= 0) { return; }
+                if (duration <= 0) {
+                    return;
                 }
 
                 const height1 = this.opts.height - 4;

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -345,7 +345,7 @@ const WebAudio = util.extend({}, util.observer, {
         this.source.start(0, start, end - start);
 
         if (this.ac.state == 'suspended') {
-          this.ac.resume && this.ac.resume();
+            this.ac.resume && this.ac.resume();
         }
 
         this.setState(this.PLAYING_STATE);


### PR DESCRIPTION
### Description
* Timeline parameters are constructed in an object literal
* variables are locally scoped where possible to reduce build size when minifying
* plugin options now extend defaults in an object literal and are cached in `this.params`.
* Intervals for the timeline labels (`timeInterval`, `primaryLabelInterval`, `secondaryLabelInterval`) can now be defined as raw values (as before) – or as a callback which receive `pxPerSec` as parameter and return the interval. – The calculated defaults are the same as before.
* Improved plugin life cycle management, things get destroyed, unhooked etc.

### Motivation
* Smaller minified builds
* Make plugin work better with the (dynamic) plugin API
* Make code more readable

### Breaking changes in the public facing API
/

### Breaking changes in the internal API
/

### Todos/Notes
https://github.com/katspaugh/wavesurfer.js/pull/893/commits/db392aa847f9f5b80f0e098180f0b8c71641e87c https://github.com/katspaugh/wavesurfer.js/pull/893/commits/b4f8020d7f99088e98ad36f17627fd94cce71c19 and https://github.com/katspaugh/wavesurfer.js/pull/893/commits/b5ac66c2f51f40f6b43b4b85e72e586a7f9f50a1 were added to fix broken build.
