### PR TITLE
small refactor, removed unnecessary re-calculation

### DIFF
--- a/src/drawer.canvas.js
+++ b/src/drawer.canvas.js
@@ -192,10 +192,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.Canvas, {
         }, this);
     },
 
-    updateProgress: function (progress) {
-        var pos = Math.round(
-            this.width * progress
-        ) / this.params.pixelRatio;
+    updateProgress: function (pos) {
         this.style(this.progressWave, { width: pos + 'px' });
     },
 

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -186,7 +186,7 @@ WaveSurfer.Drawer = {
                 this.recenterOnPosition(newPos);
             }
 
-            this.updateProgress(progress);
+            this.updateProgress(pos);
         }
     },
 

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -307,10 +307,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
         }
     },
 
-    updateProgress: function (progress) {
-        var pos = Math.round(
-            this.width * progress
-        ) / this.params.pixelRatio;
+    updateProgress: function (pos) {
         this.style(this.progressWave, { width: pos + 'px' });
     }
 });


### PR DESCRIPTION
I noticed the calculation from progress to pos in updateProgress was already done in drawer's progress function, which I believe is the only place where updateProgress is called. 