### PR TITLE
Next: Merge from master: Improve rendering performance when pxPerSec is high (#909)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - "4.2"
+  - "4"
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-install: npm install
+install:
+  - npm prune
+  - npm install
+  - npm update
 script:
   - npm run test
   - npm run build

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,7 +6,7 @@ module.exports = function (config) {
             'jasmine-matchers'
         ],
         hostname: 'localhost',
-        post: 9876,
+        port: 9876,
         singleRun: true,
         autoWatch: false,
         files: [
@@ -20,12 +20,14 @@ module.exports = function (config) {
             // specs
             'spec/plugin-api.spec.js',
             'spec/util.spec.js',
-            'spec/wavesurfer.spec.js'
+            'spec/wavesurfer.spec.js',
+            'spec/peakcache.spec.js'
         ],
         preprocessors: {
             'spec/plugin-api.spec.js': ['webpack'],
             'spec/util.spec.js': ['webpack'],
-            'spec/wavesurfer.spec.js': ['webpack']
+            'spec/wavesurfer.spec.js': ['webpack'],
+            'spec/peakcache.spec.js': ['webpack']
         },
         webpackMiddleware: {
             stats: 'errors-only'

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "1.0.2",
     "karma-jasmine-matchers": "3.0.1",
-    "karma-webpack": "^1.8.0",
-    "webpack": "^2.1.0-beta.25",
-    "webpack-dev-server": "^2.1.0-beta.9"
+    "karma-webpack": "^2.0.2",
+    "webpack": "2",
+    "webpack-dev-server": "2"
   },
   "homepage": "https://github.com/katspaugh/wavesurfer.js"
 }

--- a/spec/peakcache.spec.js
+++ b/spec/peakcache.spec.js
@@ -1,0 +1,99 @@
+import PeakCache from '../src/peakcache';
+
+describe('peakcache', function() {
+    var peakcache;
+    var test_length = 200;
+    var test_length2 = 300;
+    var test_start = 50;
+    var test_end = 100;
+    var test_start2 = 100;
+    var test_end2 = 120;
+    var test_start3 = 120;
+    var test_end3 = 150;
+
+    var window_size = 20;
+
+    function __createPeakCache() {
+        peakcache = Object.create(PeakCache);
+        peakcache.init();
+    }
+
+    beforeEach(function (done) {
+        __createPeakCache();
+        done();
+    });
+
+    it('empty cache returns full range', function() {
+        var newranges = peakcache.addRangeToPeakCache(test_length, test_start, test_end);
+        expect(newranges.length).toEqual(1);
+        expect(newranges[0][0]).toEqual(test_start);
+        expect(newranges[0][1]).toEqual(test_end);
+    });
+
+    it('different length clears cache', function() {
+        peakcache.addRangeToPeakCache(test_length, test_start, test_end);
+        var newranges = peakcache.addRangeToPeakCache(test_length2, test_start, test_end);
+        expect(newranges.length).toEqual(1);
+        expect(newranges[0][0]).toEqual(test_start);
+        expect(newranges[0][1]).toEqual(test_end);
+    });
+
+    it('consecutive calls return no ranges', function() {
+        peakcache.addRangeToPeakCache(test_length, test_start, test_end);
+        var newranges = peakcache.addRangeToPeakCache(test_length, test_start, test_end);
+        expect(newranges.length).toEqual(0);
+    });
+
+    it('sliding window returns window sized range', function() {
+        var newranges = peakcache.addRangeToPeakCache(test_length, test_start, test_end);
+        expect(newranges.length).toEqual(1);
+        expect(newranges[0][0]).toEqual(test_start);
+        expect(newranges[0][1]).toEqual(test_end);
+        var newranges = peakcache.addRangeToPeakCache(test_length, test_start + window_size, test_end + window_size);
+        expect(newranges.length).toEqual(1);
+        expect(newranges[0][0]).toEqual(test_end);
+        expect(newranges[0][1]).toEqual(test_end + window_size);
+        var newranges = peakcache.addRangeToPeakCache(test_length, test_start + window_size * 2, test_end + window_size * 2);
+        expect(newranges.length).toEqual(1);
+        expect(newranges[0][0]).toEqual(test_end + window_size);
+        expect(newranges[0][1]).toEqual(test_end + window_size * 2);
+    });
+
+    it('disjoint set creates two ranges', function() {
+        peakcache.addRangeToPeakCache(test_length, test_start, test_end);
+        peakcache.addRangeToPeakCache(test_length, test_start3, test_end3);
+        var ranges = peakcache.getCacheRanges();
+        expect(ranges.length).toEqual(2);
+        expect(ranges[0][0]).toEqual(test_start);
+        expect(ranges[0][1]).toEqual(test_end);
+        expect(ranges[1][0]).toEqual(test_start3);
+        expect(ranges[1][1]).toEqual(test_end3);
+    });
+
+    it('filling in disjoint sets coalesces', function() {
+        peakcache.addRangeToPeakCache(test_length, test_start, test_end);
+        peakcache.addRangeToPeakCache(test_length, test_start3, test_end3);
+        var newranges = peakcache.addRangeToPeakCache(test_length, test_start, test_end3);
+        expect(newranges.length).toEqual(1);
+        expect(newranges[0][0]).toEqual(test_end);
+        expect(newranges[0][1]).toEqual(test_start3);
+        var ranges = peakcache.getCacheRanges();
+        expect(ranges.length).toEqual(1);
+        expect(ranges[0][0]).toEqual(test_start);
+        expect(ranges[0][1]).toEqual(test_end3);
+    });
+
+    it('filling in disjoint sets coalesces / edge cases', function() {
+        peakcache.addRangeToPeakCache(test_length, test_start, test_end);
+        peakcache.addRangeToPeakCache(test_length, test_start3, test_end3);
+        var newranges = peakcache.addRangeToPeakCache(test_length, test_start2, test_end2);
+        expect(newranges.length).toEqual(1);
+        expect(newranges[0][0]).toEqual(test_end);
+        expect(newranges[0][1]).toEqual(test_start3);
+        var ranges = peakcache.getCacheRanges();
+        expect(ranges.length).toEqual(1);
+        expect(ranges[0][0]).toEqual(test_start);
+        expect(ranges[0][1]).toEqual(test_end3);
+    });
+
+});

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -83,13 +83,12 @@ export default util.extend({}, util.observer, {
         this.wrapper.addEventListener('scroll', e => this.fireEvent('scroll', e));
     },
 
-    drawPeaks(peaks, length) {
-        this.resetScroll();
+    drawPeaks(peaks, length, start, end) {
         this.setWidth(length);
 
         this.params.barWidth ?
-            this.drawBars(peaks) :
-            this.drawWave(peaks);
+            this.drawBars(peaks, 0, start, end) :
+            this.drawWave(peaks, 0, start, end);
     },
 
     // Backward compatibility
@@ -135,11 +134,19 @@ export default util.extend({}, util.observer, {
 
     },
 
+    getScrollX() {
+        return Math.round(this.wrapper.scrollLeft * this.params.pixelRatio);
+    },
+
     getWidth() {
         return Math.round(this.container.clientWidth * this.params.pixelRatio);
     },
 
     setWidth(width) {
+        if (this.width == width) {
+            return;
+        }
+
         this.width = width;
 
         if (this.params.fillParent || this.params.scrollParent) {

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -137,7 +137,7 @@ export default util.extend({}, drawer, {
         }
     },
 
-    drawBars(peaks, channelIndex) {
+    drawBars(peaks, channelIndex, start, end) {
         // Split channels
         if (peaks[0] instanceof Array) {
             const channels = peaks;
@@ -152,16 +152,15 @@ export default util.extend({}, drawer, {
         // Bar wave draws the bottom only as a reflection of the top,
         // so we don't need negative values
         const hasMinVals = [].some.call(peaks, val => val < 0);
-        if (hasMinVals) {
-            peaks = [].filter.call(peaks, (_, index) => index % 2 == 0);
-        }
+        // Skip every other value if there are negatives.
+        const peakIndexScale = hasMinVals ? 2 : 1;
 
         // A half-pixel offset makes lines crisp
         const width = this.width;
         const height = this.params.height * this.params.pixelRatio;
         const offsetY = height * channelIndex || 0;
         const halfH = height / 2;
-        const length = peaks.length;
+        const length = peaks.length / peakIndexScale;
         const bar = this.params.barWidth * this.params.pixelRatio;
         const gap = Math.max(this.params.pixelRatio, ~~(bar / 2));
         const step = bar + gap;
@@ -174,13 +173,14 @@ export default util.extend({}, drawer, {
         const scale = length / width;
         let i;
 
-        for (i = 0; i < width; i += step) {
-            const h = Math.round(peaks[Math.floor(i * scale)] / absmax * halfH);
+        for (i = (start / scale); i < (end / scale); i += step) {
+            const peak = peaks[Math.floor(i * scale * peakIndexScale)] || 0;
+            const h = Math.round(peak / absmax * halfH);
             this.fillRect(i + this.halfPixel, halfH - h + offsetY, bar + this.halfPixel, h * 2);
         }
     },
 
-    drawWave(peaks, channelIndex) {
+    drawWave(peaks, channelIndex, start, end) {
         // Split channels
         if (peaks[0] instanceof Array) {
             const channels = peaks;
@@ -217,25 +217,25 @@ export default util.extend({}, drawer, {
             absmax = -min > max ? -min : max;
         }
 
-        this.drawLine(peaks, absmax, halfH, offsetY);
+        this.drawLine(peaks, absmax, halfH, offsetY, start, end);
 
         // Always draw a median line
         this.fillRect(0, halfH + offsetY - this.halfPixel, this.width, this.halfPixel);
     },
 
-    drawLine(peaks, absmax, halfH, offsetY) {
+    drawLine(peaks, absmax, halfH, offsetY, start, end) {
         let i;
         for (i in this.canvases) {
             const entry = this.canvases[i];
 
             this.setFillStyles(entry);
 
-            this.drawLineToContext(entry, entry.waveCtx, peaks, absmax, halfH, offsetY);
-            this.drawLineToContext(entry, entry.progressCtx, peaks, absmax, halfH, offsetY);
+            this.drawLineToContext(entry, entry.waveCtx, peaks, absmax, halfH, offsetY, start, end);
+            this.drawLineToContext(entry, entry.progressCtx, peaks, absmax, halfH, offsetY, start, end);
         }
     },
 
-    drawLineToContext(entry, ctx, peaks, absmax, halfH, offsetY) {
+    drawLineToContext(entry, ctx, peaks, absmax, halfH, offsetY, start, end) {
         if (!ctx) { return; }
 
         const length = peaks.length / 2;
@@ -247,22 +247,27 @@ export default util.extend({}, drawer, {
 
         const first = Math.round(length * entry.start);
         const last = Math.round(length * entry.end);
+        if (first > end || last < start) { return; }
+        const canvasStart = Math.max(first, start);
+        const canvasEnd = Math.min(last, end);
         let i;
         let j;
 
         ctx.beginPath();
-        ctx.moveTo(this.halfPixel, halfH + offsetY);
+        ctx.moveTo((canvasStart - first) * scale + this.halfPixel, halfH + offsetY);
 
-        for (i = first; i < last; i++) {
-            const h = Math.round(peaks[2 * i] / absmax * halfH);
+        for (i = canvasStart; i < canvasEnd; i++) {
+            const peak = peaks[2 * i] || 0;
+            const h = Math.round(peak / absmax * halfH);
             ctx.lineTo((i - first) * scale + this.halfPixel, halfH - h + offsetY);
         }
 
         // Draw the bottom edge going backwards, to make a single
         // closed hull to fill.
-        for (j = last - 1; j >= first; j--) {
-            const k = Math.round(peaks[2 * j + 1] / absmax * halfH);
-            ctx.lineTo((j - first) * scale + this.halfPixel, halfH - k + offsetY);
+        for (j = canvasEnd - 1; j >= canvasStart; j--) {
+            const peak = peaks[2 * j + 1] || 0;
+            const h = Math.round(peak / absmax * halfH);
+            ctx.lineTo((i - first) * scale + this.halfPixel, halfH - h + offsetY);
         }
 
         ctx.closePath();
@@ -270,8 +275,13 @@ export default util.extend({}, drawer, {
     },
 
     fillRect(x, y, width, height) {
+        const startCanvas = Math.floor(x / this.maxCanvasWidth);
+        const endCanvas = Math.min(
+          Math.ceil((x + width) / this.maxCanvasWidth) + 1,
+          this.canvases.length
+        );
         let i;
-        for (i in this.canvases) {
+        for (i = startCanvas; i < endCanvas; i++) {
             const entry = this.canvases[i];
             const leftOffset = i * this.maxCanvasWidth;
 

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -182,9 +182,9 @@ export default util.extend({}, webaudio, {
         }
     },
 
-    getPeaks(length) {
+    getPeaks(length, start, end) {
         if (this.buffer) {
-            return webaudio.getPeaks.call(this, length);
+            return webaudio.getPeaks.call(this, length, start, end);
         }
         return this.peaks || [];
     },

--- a/src/peakcache.js
+++ b/src/peakcache.js
@@ -1,0 +1,87 @@
+export default {
+    init() {
+        this.clearPeakCache();
+    },
+
+    clearPeakCache() {
+        // Flat array with entries that are always in pairs to mark the
+        // beginning and end of each subrange.  This is a convenience so we can
+        // iterate over the pairs for easy set difference operations.
+        this.peakCacheRanges = [];
+        // Length of the entire cachable region, used for resetting the cache
+        // when this changes (zoom events, for instance).
+        this.peakCacheLength = -1;
+    },
+
+    addRangeToPeakCache(length, start, end) {
+        if (length != this.peakCacheLength) {
+            this.clearPeakCache();
+            this.peakCacheLength = length;
+        }
+
+        // Return ranges that weren't in the cache before the call.
+        let uncachedRanges = [];
+        let i = 0;
+        // Skip ranges before the current start.
+        while (i < this.peakCacheRanges.length && this.peakCacheRanges[i] < start) {
+            i++;
+        }
+        // If |i| is even, |start| falls after an existing range.  Otherwise,
+        // |start| falls between an existing range, and the uncached region
+        // starts when we encounter the next node in |peakCacheRanges| or
+        // |end|, whichever comes first.
+        if (i % 2 == 0) {
+            uncachedRanges.push(start);
+        }
+        while (i < this.peakCacheRanges.length && this.peakCacheRanges[i] <= end) {
+            uncachedRanges.push(this.peakCacheRanges[i]);
+            i++;
+        }
+        // If |i| is even, |end| is after all existing ranges.
+        if (i % 2 == 0) {
+            uncachedRanges.push(end);
+        }
+
+        // Filter out the 0-length ranges.
+        uncachedRanges = uncachedRanges.filter((item, pos, arr) => {
+            if (pos == 0) {
+                return item != arr[pos + 1];
+            } else if (pos == arr.length - 1) {
+                return item != arr[pos - 1];
+            }
+            return item != arr[pos - 1] && item != arr[pos + 1];
+        });
+
+        // Merge the two ranges together, uncachedRanges will either contain
+        // wholly new points, or duplicates of points in peakCacheRanges.  If
+        // duplicates are detected, remove both and extend the range.
+        this.peakCacheRanges = this.peakCacheRanges.concat(uncachedRanges);
+        this.peakCacheRanges = this.peakCacheRanges.sort((a, b) => a - b).filter((item, pos, arr) => {
+            if (pos == 0) {
+                return item != arr[pos + 1];
+            } else if (pos == arr.length - 1) {
+                return item != arr[pos - 1];
+            }
+            return item != arr[pos - 1] && item != arr[pos + 1];
+        });
+
+        // Push the uncached ranges into an array of arrays for ease of
+        // iteration in the functions that call this.
+        const uncachedRangePairs = [];
+        for (i = 0; i < uncachedRanges.length; i += 2) {
+            uncachedRangePairs.push([uncachedRanges[i], uncachedRanges[i+1]]);
+        }
+
+        return uncachedRangePairs;
+    },
+
+    // For testing
+    getCacheRanges() {
+        const peakCacheRangePairs = [];
+        let i;
+        for (i = 0; i < this.peakCacheRanges.length; i += 2) {
+            peakCacheRangePairs.push([this.peakCacheRanges[i], this.peakCacheRanges[i+1]]);
+        }
+        return peakCacheRangePairs;
+    }
+};

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -48,6 +48,7 @@ const WebAudio = util.extend({}, util.observer, {
 
         this.setState(this.PAUSED_STATE);
         this.setPlaybackRate(this.params.audioRate);
+        this.setLength(0);
     },
 
     disconnectFilters() {
@@ -179,28 +180,54 @@ const WebAudio = util.extend({}, util.observer, {
     },
 
     /**
+     * Set the rendered length (different from the length of the audio).
+     */
+    setLength(length) {
+        // No resize, we can preserve the cached peaks.
+        if (this.mergedPeaks && length == ((2 * this.mergedPeaks.length - 1) + 2)) {
+            return;
+        }
+
+        this.splitPeaks = [];
+        this.mergedPeaks = [];
+        // Set the last element of the sparse array so the peak arrays are
+        // appropriately sized for other calculations.
+        const channels = this.buffer ? this.buffer.numberOfChannels : 1;
+        let c;
+        for (c = 0; c < channels; c++) {
+            this.splitPeaks[c] = [];
+            this.splitPeaks[c][2 * (length - 1)] = 0;
+            this.splitPeaks[c][2 * (length - 1) + 1] = 0;
+        }
+        this.mergedPeaks[2 * (length - 1)] = 0;
+        this.mergedPeaks[2 * (length - 1) + 1] = 0;
+    },
+
+    /**
      * Compute the max and min value of the waveform when broken into
      * <length> subranges.
-     * @param {Number} How many subranges to break the waveform into.
+     * @param {Number} length How many subranges to break the waveform into.
+     * @param {Number} first First sample in the required range.
+     * @param {Number} last Last sample in the required range.
      * @returns {Array} Array of 2*<length> peaks or array of arrays
      * of peaks consisting of (max, min) values for each subrange.
      */
-    getPeaks(length) {
+    getPeaks(length, first, last) {
         if (this.peaks) { return this.peaks; }
+
+        this.setLength(length);
 
         const sampleSize = this.buffer.length / length;
         const sampleStep = ~~(sampleSize / 10) || 1;
         const channels = this.buffer.numberOfChannels;
-        const splitPeaks = [];
-        const mergedPeaks = [];
         let c;
 
         for (c = 0; c < channels; c++) {
-            const peaks = splitPeaks[c] = [];
+            const peaks = this.splitPeaks[c];
             const chan = this.buffer.getChannelData(c);
             let i;
 
-            for (i = 0; i < length; i++) {
+            for (i = first; i <= last; i++) {
                 const start = ~~(i * sampleSize);
                 const end = ~~(start + sampleSize);
                 let min = 0;
@@ -222,17 +249,17 @@ const WebAudio = util.extend({}, util.observer, {
                 peaks[2 * i] = max;
                 peaks[2 * i + 1] = min;
 
-                if (c == 0 || max > mergedPeaks[2 * i]) {
-                    mergedPeaks[2 * i] = max;
+                if (c == 0 || max > this.mergedPeaks[2 * i]) {
+                    this.mergedPeaks[2 * i] = max;
                 }
 
-                if (c == 0 || min < mergedPeaks[2 * i + 1]) {
-                    mergedPeaks[2 * i + 1] = min;
+                if (c == 0 || min < this.mergedPeaks[2 * i + 1]) {
+                    this.mergedPeaks[2 * i + 1] = min;
                 }
             }
         }
 
-        return this.params.splitChannels ? splitPeaks : mergedPeaks;
+        return this.params.splitChannels ? this.splitPeaks : this.mergedPeaks;
     },
 
     getPlayedPercents() {
@@ -345,7 +372,7 @@ const WebAudio = util.extend({}, util.observer, {
         this.source.start(0, start, end - start);
 
         if (this.ac.state == 'suspended') {
-          this.ac.resume && this.ac.resume();
+            this.ac.resume && this.ac.resume();
         }
 
         this.setState(this.PLAYING_STATE);


### PR DESCRIPTION
* Adds an optional 'partialRender' parameter to enable
* Calculates and renders peaks only for current visible waveform
* Keeps track of currently calculated/rendered peaks to avoid
  duplicate calculation and only incremental scroll changes are rendered

Tested all combinations of Canvas/MultiCanvas and Wave/Bars rendering
at various zoom levels.