### PR TITLE
fix getDuration() return value when using MediaElement

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -125,7 +125,7 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
     },
 
     getDuration: function () {
-        var duration = this.buffer.duration;
+        var duration = (this.buffer || this.media).duration;
         if (duration >= Infinity) { // streaming audio
             duration = this.media.seekable.end(0);
         }

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -125,7 +125,7 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
     },
 
     getDuration: function () {
-        var duration = this.media.duration;
+        var duration = this.buffer.duration;
         if (duration >= Infinity) { // streaming audio
             duration = this.media.seekable.end(0);
         }


### PR DESCRIPTION
Change getDuration function in mediaelement.js to return the correct duration length same as WebAudio.

from
        var duration = this.media.duration; // incorrect duration value returned
        console.log preview:
![image](https://cloud.githubusercontent.com/assets/5193884/22399212/0f94f5f0-e566-11e6-8a05-ca8efd8d027b.png)

to
        var duration = this.buffer.duration; // correct duration value returned same as WebAudio
        console.log preview:
![image](https://cloud.githubusercontent.com/assets/5193884/22399215/1b4cc314-e566-11e6-8724-393f0cf44916.png)
