### PR TITLE
Update wavesurfer.minimap.js

### DIFF
--- a/plugin/wavesurfer.minimap.js
+++ b/plugin/wavesurfer.minimap.js
@@ -94,17 +94,8 @@ WaveSurfer.Minimap = WaveSurfer.util.extend({}, WaveSurfer.Drawer, WaveSurfer.Dr
 
     bindWaveSurferEvents: function () {
         var my = this;
-        // check if parameter renderOnLoad is definied and set to true to render minimap on load
-        var miniRenderOnLoad = (this.params.miniRenderOnLoad||false);
-        if (typeof this.params.miniRenderOnLoad !== 'undefined') {
-            if (miniRenderOnLoad) {
-                this.render();
-            } else {
-                this.wavesurfer.on('ready', this.render.bind(this));
-            }
-        } else {
-            this.wavesurfer.on('ready', this.render.bind(this));
-        }
+        // render on load
+        this.render();
         this.wavesurfer.on('audioprocess', function (currentTime) {
             my.progress(my.wavesurfer.backend.getPlayedPercents());
         });

--- a/plugin/wavesurfer.minimap.js
+++ b/plugin/wavesurfer.minimap.js
@@ -99,10 +99,10 @@ WaveSurfer.Minimap = WaveSurfer.util.extend({}, WaveSurfer.Drawer, WaveSurfer.Dr
         if (typeof this.params.miniRenderOnLoad !== 'undefined') {
             if (miniRenderOnLoad) {
                 this.render();
-            } else{
+            } else {
                 this.wavesurfer.on('ready', this.render.bind(this));
             }
-        } else{
+        } else {
             this.wavesurfer.on('ready', this.render.bind(this));
         }
         this.wavesurfer.on('audioprocess', function (currentTime) {

--- a/plugin/wavesurfer.minimap.js
+++ b/plugin/wavesurfer.minimap.js
@@ -94,7 +94,7 @@ WaveSurfer.Minimap = WaveSurfer.util.extend({}, WaveSurfer.Drawer, WaveSurfer.Dr
 
     bindWaveSurferEvents: function () {
         var my = this;
-        this.wavesurfer.on('ready', my.render());
+        this.wavesurfer.on('ready', this.render());
         this.wavesurfer.on('audioprocess', function (currentTime) {
             my.progress(my.wavesurfer.backend.getPlayedPercents());
         });

--- a/plugin/wavesurfer.minimap.js
+++ b/plugin/wavesurfer.minimap.js
@@ -94,7 +94,7 @@ WaveSurfer.Minimap = WaveSurfer.util.extend({}, WaveSurfer.Drawer, WaveSurfer.Dr
 
     bindWaveSurferEvents: function () {
         var my = this;
-        this.wavesurfer.on('ready', my.render.bind(this));
+        this.wavesurfer.on('ready', my.render());
         this.wavesurfer.on('audioprocess', function (currentTime) {
             my.progress(my.wavesurfer.backend.getPlayedPercents());
         });
@@ -178,8 +178,8 @@ WaveSurfer.Minimap = WaveSurfer.util.extend({}, WaveSurfer.Drawer, WaveSurfer.Dr
 
     render: function () {
         var len = this.getWidth();
-        var peaks = this.wavesurfer.backend.getPeaks(len);
-        this.drawPeaks(peaks, len);
+        var peaks = this.wavesurfer.backend.getPeaks(len, 0, len);
+        this.drawPeaks(peaks, len, 0, len);
 
         if (this.params.showOverview) {
             //get proportional width of overview region considering the respective

--- a/plugin/wavesurfer.minimap.js
+++ b/plugin/wavesurfer.minimap.js
@@ -94,7 +94,7 @@ WaveSurfer.Minimap = WaveSurfer.util.extend({}, WaveSurfer.Drawer, WaveSurfer.Dr
 
     bindWaveSurferEvents: function () {
         var my = this;
-        this.wavesurfer.on('ready', this.render.bind(this));
+        this.wavesurfer.on('ready', my.render.bind(this));
         this.wavesurfer.on('audioprocess', function (currentTime) {
             my.progress(my.wavesurfer.backend.getPlayedPercents());
         });

--- a/plugin/wavesurfer.minimap.js
+++ b/plugin/wavesurfer.minimap.js
@@ -96,14 +96,14 @@ WaveSurfer.Minimap = WaveSurfer.util.extend({}, WaveSurfer.Drawer, WaveSurfer.Dr
         var my = this;
         // check if parameter renderOnLoad is definied and set to true to render minimap on load
         var miniRenderOnLoad = (this.params.miniRenderOnLoad||false);
-        if (typeof this.params.miniRenderOnLoad !== "undefined") {
+        if (typeof this.params.miniRenderOnLoad !== 'undefined') {
             if (miniRenderOnLoad) {
                 this.render();
             } else{
-                this.wavesurfer.on('ready', this.render.bind(this))):
+                this.wavesurfer.on('ready', this.render.bind(this));
             }
         } else{
-            this.wavesurfer.on('ready', this.render.bind(this))):
+            this.wavesurfer.on('ready', this.render.bind(this));
         }
         this.wavesurfer.on('audioprocess', function (currentTime) {
             my.progress(my.wavesurfer.backend.getPlayedPercents());

--- a/plugin/wavesurfer.minimap.js
+++ b/plugin/wavesurfer.minimap.js
@@ -94,7 +94,17 @@ WaveSurfer.Minimap = WaveSurfer.util.extend({}, WaveSurfer.Drawer, WaveSurfer.Dr
 
     bindWaveSurferEvents: function () {
         var my = this;
-        this.wavesurfer.on('ready', this.render());
+        // check if parameter renderOnLoad is definied and set to true to render minimap on load
+        var miniRenderOnLoad = (this.params.miniRenderOnLoad||false);
+        if (typeof this.params.miniRenderOnLoad !== "undefined") {
+            if (miniRenderOnLoad) {
+                this.render();
+            } else{
+                this.wavesurfer.on('ready', this.render.bind(this))):
+            }
+        } else{
+            this.wavesurfer.on('ready', this.render.bind(this))):
+        }
         this.wavesurfer.on('audioprocess', function (currentTime) {
             my.progress(my.wavesurfer.backend.getPlayedPercents());
         });


### PR DESCRIPTION
renders the minimap without the need to resize the window. #954 #942 #951 

Preview:
http://codepen.io/entonbiba/pen/ggeGyG

Changed 

        this.wavesurfer.on('ready', this.render.bind(this));

to 

        this.wavesurfer.on('ready', my.render.bind(this));