### PR TITLE
Updated render function for drawPeaks/getPeaks

### DIFF
--- a/plugin/wavesurfer.minimap.js
+++ b/plugin/wavesurfer.minimap.js
@@ -178,8 +178,8 @@ WaveSurfer.Minimap = WaveSurfer.util.extend({}, WaveSurfer.Drawer, WaveSurfer.Dr
 
     render: function () {
         var len = this.getWidth();
-        var peaks = this.wavesurfer.backend.getPeaks(len);
-        this.drawPeaks(peaks, len);
+        var peaks = this.wavesurfer.backend.getPeaks(len, 0, len);
+        this.drawPeaks(peaks, len, 0, len);
 
         if (this.params.showOverview) {
             //get proportional width of overview region considering the respective


### PR DESCRIPTION
Updated the render function to call the new version of the getPeaks and drawPeaks calls which now require start and end parameters.  Fixes flat waveform drawing in minimap plugin.