### PR TITLE
avoid 'for in' array enumeration

### DIFF
--- a/plugin/wavesurfer.timeline.js
+++ b/plugin/wavesurfer.timeline.js
@@ -228,19 +228,19 @@ WaveSurfer.Timeline = {
     },
 
     setFillStyles: function (fillStyle) {
-        for (var i in this.canvases) {
+        for (var i = 0; i < this.canvases.length; i++) {
             this.canvases[i].getContext('2d').fillStyle = fillStyle;
         }
     },
 
     setFonts: function (font) {
-        for (var i in this.canvases) {
+        for (var i = 0; i < this.canvases.length; i++) {
             this.canvases[i].getContext('2d').font = font;
         }
     },
 
     fillRect: function (x, y, width, height) {
-        for (var i in this.canvases) {
+        for (var i = 0; i < this.canvases.length; i++) {
             var canvas = this.canvases[i],
                 leftOffset = i * this.maxCanvasWidth;
 
@@ -265,7 +265,7 @@ WaveSurfer.Timeline = {
         var textWidth,
             xOffset = 0;
 
-        for (var i in this.canvases) {
+        for (var i = 0; i < this.canvases.length; i++) {
             var context = this.canvases[i].getContext('2d'),
                 canvasWidth = context.canvas.width;
 


### PR DESCRIPTION
I'm integrating wavesurfer.js into an Ember project and have found that in this context canvas enumeration in the timeline plugin is incorrectly iterating over array properties. 