### PR TITLE
check if browser supports AudioContext.close in webaudio.js

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -287,7 +287,7 @@ WaveSurfer.WebAudio = {
         // not passed in as a parameter
         if (!this.params.audioContext) {
             // check if browser supports AudioContext.close()
-            if (typeof this.ac.close() !== 'undefined'){
+            if (typeof this.ac.close() !== 'undefined') {
                 this.ac.close();
             }
         }

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -286,7 +286,10 @@ WaveSurfer.WebAudio = {
         // close the audioContext if it was created by wavesurfer
         // not passed in as a parameter
         if (!this.params.audioContext) {
-            this.ac.close();
+            // check if browser supports AudioContext.close()
+            if(typeof this.ac.close() !== 'undefined'){
+                this.ac.close();
+            }
         }
     },
 

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -287,7 +287,7 @@ WaveSurfer.WebAudio = {
         // not passed in as a parameter
         if (!this.params.audioContext) {
             // check if browser supports AudioContext.close()
-            if(typeof this.ac.close() !== 'undefined'){
+            if (typeof this.ac.close() !== 'undefined'){
                 this.ac.close();
             }
         }


### PR DESCRIPTION
add check for browser support of AudioContext.close(). This is only supported by Chrome 43+ and FireFox 40+ for now. Edge and other non supported browsers will give an undefined error. #949 

https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/close

// check if browser supports AudioContext.close()
            if(typeof this.ac.close() !== 'undefined'){
                this.ac.close();
            }