### PR TITLE
Next: Fixes a few minor bugs and adds responsive option

### DIFF
--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -261,7 +261,7 @@ export default util.extend({}, drawer, {
         for (j = canvasEnd - 1; j >= canvasStart; j--) {
             const peak = peaks[2 * j + 1] || 0;
             const h = Math.round(peak / absmax * halfH);
-            ctx.lineTo((i - first) * scale + this.halfPixel, halfH - h + offsetY);
+            ctx.lineTo((j - first) * scale + this.halfPixel, halfH - h + offsetY);
         }
 
         ctx.closePath();

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -133,7 +133,7 @@ export default util.extend({}, drawer, {
             const channels = peaks;
             if (this.params.splitChannels) {
                 this.setHeight(channels.length * this.params.height * this.params.pixelRatio);
-                channels.forEach(this.drawBars, this);
+                channels.forEach((channelPeaks, i) => this.drawBars(channelPeaks, i, start, end));
                 return;
             }
             peaks = channels[0];
@@ -176,7 +176,7 @@ export default util.extend({}, drawer, {
             const channels = peaks;
             if (this.params.splitChannels) {
                 this.setHeight(channels.length * this.params.height * this.params.pixelRatio);
-                channels.forEach(this.drawWave, this);
+                channels.forEach((channelPeaks, i) => this.drawWave(channelPeaks, i, start, end));
                 return;
             }
             peaks = channels[0];

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -35,7 +35,6 @@ export default util.extend({}, drawer, {
     updateSize() {
         const totalWidth = Math.round(this.width / this.params.pixelRatio);
         const requiredCanvases = Math.ceil(totalWidth / this.maxCanvasElementWidth);
-        let i;
 
         while (this.canvases.length < requiredCanvases) {
             this.addCanvas();
@@ -45,7 +44,7 @@ export default util.extend({}, drawer, {
             this.removeCanvas();
         }
 
-        for (i in this.canvases) {
+        this.canvases.forEach((entry, i) => {
             // Add some overlap to prevent vertical white stripes, keep the width even for simplicity.
             let canvasWidth = this.maxCanvasWidth + 2 * Math.ceil(this.params.pixelRatio / 2);
 
@@ -53,9 +52,9 @@ export default util.extend({}, drawer, {
                 canvasWidth = this.width - (this.maxCanvasWidth * (this.canvases.length - 1));
             }
 
-            this.updateDimensions(this.canvases[i], canvasWidth, this.height);
-            this.clearWaveForEntry(this.canvases[i]);
-        }
+            this.updateDimensions(entry, canvasWidth, this.height);
+            this.clearWaveForEntry(entry);
+        });
     },
 
     addCanvas() {
@@ -118,10 +117,7 @@ export default util.extend({}, drawer, {
     },
 
     clearWave() {
-        let i;
-        for (i in this.canvases) {
-            this.clearWaveForEntry(this.canvases[i]);
-        }
+        this.canvases.forEach(entry => this.clearWaveForEntry(entry));
     },
 
     clearWaveForEntry(entry) {
@@ -218,15 +214,11 @@ export default util.extend({}, drawer, {
     },
 
     drawLine(peaks, absmax, halfH, offsetY, start, end) {
-        let i;
-        for (i in this.canvases) {
-            const entry = this.canvases[i];
-
+        this.canvases.forEach(entry => {
             this.setFillStyles(entry);
-
             this.drawLineToContext(entry, entry.waveCtx, peaks, absmax, halfH, offsetY, start, end);
             this.drawLineToContext(entry, entry.progressCtx, peaks, absmax, halfH, offsetY, start, end);
-        }
+        });
     },
 
     drawLineToContext(entry, ctx, peaks, absmax, halfH, offsetY, start, end) {

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -186,9 +186,9 @@ export default util.extend({}, drawer, {
         const hasMinValues = [].some.call(peaks, val => val < 0);
         if (!hasMinValues) {
             const reflectedPeaks = [];
+            const len = peaks.length;
             let i;
-            let len;
-            for (i = 0, len = peaks.length; i < len; i++) {
+            for (i = 0; i < len; i++) {
                 reflectedPeaks[2 * i] = peaks[i];
                 reflectedPeaks[2 * i + 1] = -peaks[i];
             }

--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -217,8 +217,8 @@ export default function(params = {}) {
 
             render() {
                 const len = this.getWidth();
-                const peaks = this.wavesurfer.backend.getPeaks(len);
-                this.drawPeaks(peaks, len);
+                const peaks = this.wavesurfer.backend.getPeaks(len, 0, len);
+                this.drawPeaks(peaks, len, 0, len);
 
                 if (this.params.showOverview) {
                     //get proportional width of overview region considering the respective

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -248,23 +248,19 @@ export default function(params = {}) {
             },
 
             setFillStyles(fillStyle) {
-                let i;
-                for (i in this.canvases) {
-                    this.canvases[i].getContext('2d').fillStyle = fillStyle;
-                }
+                this.canvases.forEach(canvas => {
+                    canvas.getContext('2d').fillStyle = fillStyle;
+                });
             },
 
             setFonts(font) {
-                let i;
-                for (i in this.canvases) {
-                    this.canvases[i].getContext('2d').font = font;
-                }
+                this.canvases.forEach(canvas => {
+                    canvas.getContext('2d').font = font;
+                });
             },
 
             fillRect(x, y, width, height) {
-                let i;
-                for (i in this.canvases) {
-                    const canvas = this.canvases[i];
+                this.canvases.forEach((canvas, i) => {
                     const leftOffset = i * this.maxCanvasWidth;
 
                     const intersection = {
@@ -282,7 +278,7 @@ export default function(params = {}) {
                             intersection.y2 - intersection.y1
                         );
                     }
-                }
+                });
             },
 
             fillText(text, x, y) {

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -33,6 +33,7 @@ const WaveSurfer = util.extend({}, util.observer, { util }, {
         mediaType     : 'audio',
         autoCenter    : true,
         partialRender : false,
+        responsive    : false,
         plugins       : []
     },
 
@@ -232,6 +233,18 @@ const WaveSurfer = util.extend({}, util.observer, { util }, {
         this.drawer = Object.create(this.Drawer);
         this.drawer.init(this.container, this.params);
         this.fireEvent('drawer-created', this.drawer);
+        let prevWidth = 0;
+        this._onResize = () => {
+            if (prevWidth != this.drawer.wrapper.clientWidth) {
+                prevWidth = this.drawer.wrapper.clientWidth;
+                this.empty();
+                this.drawBuffer();
+            }
+        };
+
+        if (this.params.responsive) {
+            window.addEventListener('resize', this._onResize, true);
+        }
 
         this.drawer.on('redraw', () => {
             this.drawBuffer();
@@ -699,6 +712,7 @@ const WaveSurfer = util.extend({}, util.observer, { util }, {
         this.cancelAjax();
         this.clearTmpEvents();
         this.unAll();
+        window.removeEventListener('resize', this._onResize, true);
         this.backend.destroy();
         this.drawer.destroy();
         this.isDestroyed = true;


### PR DESCRIPTION
### Description

* Fixes the bugs that came up because of out-of-date calls to `getPeaks` and `drawPeaks` (minimap plugin and when rendering split channels) (on master https://github.com/katspaugh/wavesurfer.js/pull/945 and https://github.com/katspaugh/wavesurfer.js/pull/959)
* Fixes the incorrect `for ... in this.canvases` loops in timeline plugin and multicanvas renderer, refactored to use `forEach` where possible (on master https://github.com/katspaugh/wavesurfer.js/pull/961)
* Turn unnecessary `let` into `const`
* Fixes "only half the waveform is being drawn" bug
* Added `responsive` option (set to `true` to enable automatic rescaling when the window resizes)

### Motivation
* I created on PR for all these small changes because I was lazy, hope that's ok.
* Fix bugs …
* Responsive option was added because I think it's a very common request and the pattern used seems to appear quite often. (It is also being used in the minimap plugin)

### Breaking changes in the public facing API
/

### Breaking changes in the internal API
/

### Todos/Notes
/