### PR TITLE
create debounce method in util.js

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -9,6 +9,29 @@ WaveSurfer.util = {
         });
         return dest;
     },
+    
+    debounce: function (func, wait, immediate) {
+        var args, context, timeout;
+        var later = function() {
+            timeout = null;
+            if (!immediate) {
+                func.apply(context, args);   
+            }
+        };
+        return function() {
+            context = this;
+            args = arguments;
+            var callNow = immediate && !timeout;
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+            if(!timeout){
+                timout = setTimeout(later, wait);   
+            }
+            if (callNow) {
+                func.apply(context, args);   
+            }
+        }
+    },
 
     min: function(values) {
         var min = +Infinity;

--- a/src/util.js
+++ b/src/util.js
@@ -30,7 +30,7 @@ WaveSurfer.util = {
             if (callNow) {
                 func.apply(context, args);   
             }
-        }
+        };
     },
 
     min: function (values) {

--- a/src/util.js
+++ b/src/util.js
@@ -9,13 +9,13 @@ WaveSurfer.util = {
         });
         return dest;
     },
-    
+
     debounce: function (func, wait, immediate) {
         var args, context, timeout;
         var later = function() {
             timeout = null;
             if (!immediate) {
-                func.apply(context, args);   
+                func.apply(context, args);
             }
         };
         return function() {
@@ -25,10 +25,10 @@ WaveSurfer.util = {
             clearTimeout(timeout);
             timeout = setTimeout(later, wait);
             if (!timeout) {
-                timout = setTimeout(later, wait);   
+                timeout = setTimeout(later, wait);
             }
             if (callNow) {
-                func.apply(context, args);   
+                func.apply(context, args);
             }
         };
     },

--- a/src/util.js
+++ b/src/util.js
@@ -24,7 +24,7 @@ WaveSurfer.util = {
             var callNow = immediate && !timeout;
             clearTimeout(timeout);
             timeout = setTimeout(later, wait);
-            if(!timeout){
+            if (!timeout) {
                 timout = setTimeout(later, wait);   
             }
             if (callNow) {
@@ -33,7 +33,7 @@ WaveSurfer.util = {
         }
     },
 
-    min: function(values) {
+    min: function (values) {
         var min = +Infinity;
         for (var i in values) {
             if (values[i] < min) {
@@ -44,7 +44,7 @@ WaveSurfer.util = {
         return min;
     },
 
-    max: function(values) {
+    max: function (values) {
         var max = -Infinity;
         for (var i in values) {
             if (values[i] > max) {


### PR DESCRIPTION
Can be used with a resize event to prevent drawBuffer() from running concurrently when resizing the browser window. @mspae @thijstriemstra #963 

**preview:**
http://codepen.io/entonbiba/pen/jyKrEz

var responsiveWave = WaveSurfer.util.debounce(function() {
  wavesurfer.empty();
  wavesurfer.drawBuffer();
}, 150);

window.addEventListener(‘resize’, responsiveWave);

