### PR TITLE
Adding missing parameters to .load()

### DIFF
--- a/docs/methods.html
+++ b/docs/methods.html
@@ -13,7 +13,7 @@ layout: default
     <li><code>getDuration()</code> – Returns the duration of an audio clip in seconds.</li>
     <li><code>getPlaybackRate()</code> – Returns the playback speed of an audio clip.</li>
     <li><code>isPlaying()</code> – Returns true if currently playing, false otherwise.</li>
-    <li><code>load(url)</code> – Loads audio from URL via XHR. Returns XHR object.</li>
+    <li><code>load(url, peaks, preload)</code> – Loads audio from <code>URL</code> via XHR. Optional array of <code>peaks<code>. Optional <code>preload</code> parameter <code>[none|metadata|auto]</code>, parsed to the <a href="https://developer.mozilla.org/en/docs/Web/HTML/Element/audio">Audio element</a> if using backend MediaElement.</li> 
     <li><code>loadBlob(url)</code> – Loads audio from a <code>Blob</code> or <code>File</code> object.</li>
     <li><code>on(eventName, callback)</code> – Subscribes to an event.  See <a href="/docs/events.html">WaveSurfer Events</a> for the list of all events.</li>
     <li><code>un(eventName, callback)</code> – Unsubscribes from an event.</li>


### PR DESCRIPTION
There were 2 missing parameters for .load() in the documentation: peaks and preload.

I also removed the line "Returns XHR object" as this is not the case.

This is potentially blocked by #973

