### PR TITLE
avoid error when calling pause before play

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -160,7 +160,7 @@ var WaveSurfer = {
     },
 
     pause: function () {
-        this.backend.pause();
+        this.backend.isPaused() || this.backend.pause();
     },
 
     playPause: function () {


### PR DESCRIPTION
This prevents a `Failed to execute 'stop' on 'AudioBufferSourceNode'` when stop() is called before play().