### PR TITLE
getVolume method

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -227,6 +227,13 @@ var WaveSurfer = {
     setVolume: function (newVolume) {
         this.backend.setVolume(newVolume);
     },
+    
+    /**
+     * Get the playback volume.
+     */
+    getVolume: function (newVolume) {
+        return this.backend.getVolume();
+    },
 
     /**
      * Set the playback rate.

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -231,7 +231,7 @@ var WaveSurfer = {
     /**
      * Get the playback volume.
      */
-    getVolume: function (newVolume) {
+    getVolume: function () {
         return this.backend.getVolume();
     },
 

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -227,7 +227,7 @@ var WaveSurfer = {
     setVolume: function (newVolume) {
         this.backend.setVolume(newVolume);
     },
-    
+
     /**
      * Get the playback volume.
      */


### PR DESCRIPTION
Returns the current gainNode volume.
You can now do wavesurfer.getVolume() to return the current playback volume.