### PR TITLE
Next: Esdoc build script

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -1,0 +1,9 @@
+{
+  "source": "./src",
+  "destination": "./doc",
+  "experimentalProposal": {
+    "classProperties": true,
+    "objectRestSpread": true,
+    "exportExtensions": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - "4"
+  - "6.9.4"
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ install:
 script:
   - npm run test
   - npm run build
+  - npm run doc

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Running tests only:
 npm run test
 ```
 
+Build documentation with esdoc (generated files are placed in the `doc` directory.)
+```
+npm run doc
+```
+
 ## Editing documentation
 The homepage and the documentation are in the [`gh-pages` branch](https://github.com/katspaugh/wavesurfer.js/tree/gh-pages). Contributions to the documentation are especially welcome.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "npm run build:normal & npm run build:minified",
     "build:normal": "webpack & webpack --env.plugins & webpack --env.htmlinit",
     "build:minified": "webpack --env.minify & webpack --env.plugins --env.minify & webpack --env.htmlinit --env.minify",
+    "doc": "esdoc",
     "test": "BABEL_ENV=test karma start karma.conf.js"
   },
   "repository": {
@@ -35,6 +36,7 @@
     "babel-preset-es2015-native-modules": "^6.9.4",
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.18.0",
+    "esdoc": "^0.5.2",
     "eslint": "^3.9.1",
     "eslint-loader": "^1.6.1",
     "jasmine-core": "^2.5.2",

--- a/src/util/style.js
+++ b/src/util/style.js
@@ -2,7 +2,7 @@
  * Apply a map of styles to an element
  *
  * @param {HTMLElement} el The element that the styles will be applied to
- * @param {Object} styes The map of propName: attribute, both are used as-is
+ * @param {Object} styles The map of propName: attribute, both are used as-is
  *
  * @returns {HTMLElement} el
  */

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -547,13 +547,13 @@ export default class WaveSurfer extends util.Observer {
     }
 
     /**
-     *  Either create a media element, or load
-     *  an existing media element.
-     *  @param  {String|HTMLElement} urlOrElt Either a path to a media file,
-     *                                          or an existing HTML5 Audio/Video
-     *                                          Element
-     *  @param  {Array}            [peaks]     Array of peaks. Required to bypass
-     *                                          web audio dependency
+     * Either create a media element, or load an existing media element.
+     * @param {String|HTMLElement} urlOrElt Either a path to a media file, or an
+     * existing HTML5 Audio/Video Element
+     * @param {Number[]} peaks Array of peaks. Required to bypass web audio
+     * dependency
+     * @param {Boolean} preload Set to true if the preload attribute of the audio
+     * element should be enabled
      */
     loadMediaElement(urlOrElt, peaks, preload) {
         let url = urlOrElt;


### PR DESCRIPTION
### Description

* Adds [esdoc](https://esdoc.org/) – It compiles and analyses all the jsdoc comments and builds a HTML representation into a `doc` directory. (`npm run doc`)
* Other minor changes
  * Added doc generation to `.travis.yml`
  * updated some jsdoc comments that produced errors

### Motivation
* documentation :birthday: 

### Breaking changes in the public facing API
/

### Breaking changes in the internal API
/
### Todos/Notes
* documentation coverage is currently at 24.06% …