### PR TITLE
Fixed AudioContext.close()

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -287,7 +287,7 @@ WaveSurfer.WebAudio = {
         // not passed in as a parameter
         if (!this.params.audioContext) {
             // check if browser supports AudioContext.close()
-            if (typeof this.ac.close() !== 'undefined') {
+            if (typeof this.ac.close === 'function') {
                 this.ac.close();
             }
         }


### PR DESCRIPTION
Fixed wrong check close function in AudioContext instance.