### PR TITLE
add link to minimap plugin into navigation sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,8 @@ navigation:
         url: /plugins/timeline.html
       - title: Microphone
         url: /plugins/microphone.html
+      - title: Minimap
+        url: /plugins/minimap.html
   - title: Projects
     url: /projects/
   - title: Blog


### PR DESCRIPTION
I noticed the "Minimap" Plugin is present on the "Plugins" page but not in the Menu on the sidebar, so I added it.