### PR TITLE
Add support for forceDecode

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -464,7 +464,7 @@ var WaveSurfer = {
         // If no pre-decoded peaks provided or pre-decoded peaks are
         // provided with forceDecode flag, attempt to download the
         // audio file and decode it with Web Audio.
-        if (peaks) this.backend.setPeaks(peaks);
+        if (peaks) { this.backend.setPeaks(peaks); }
 
         if ((!peaks || this.params.forceDecode) && this.backend.supportsWebAudio()) {
             this.getArrayBuffer(url, (function (arraybuffer) {

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -10,32 +10,33 @@
 
 var WaveSurfer = {
     defaultParams: {
-        height        : 128,
-        waveColor     : '#999',
-        progressColor : '#555',
+        audioContext  : null,
+        audioRate     : 1,
+        autoCenter    : true,
+        backend       : 'WebAudio',
+        container     : null,
         cursorColor   : '#333',
         cursorWidth   : 1,
-        skipLength    : 2,
-        minPxPerSec   : 20,
-        pixelRatio    : window.devicePixelRatio || screen.deviceXDPI / screen.logicalXDPI,
-        fillParent    : true,
-        scrollParent  : false,
-        hideScrollbar : false,
-        normalize     : false,
-        audioContext  : null,
-        container     : null,
         dragSelection : true,
-        loopSelection : true,
-        audioRate     : 1,
+        fillParent    : true,
+        forceDecode   : false,
+        height        : 128,
+        hideScrollbar : false,
         interact      : true,
-        splitChannels : false,
+        loopSelection : true,
         mediaContainer: null,
         mediaControls : false,
-        renderer      : 'MultiCanvas',
-        backend       : 'WebAudio',
         mediaType     : 'audio',
-        autoCenter    : true,
-        partialRender : false
+        minPxPerSec   : 20,
+        partialRender : false,
+        pixelRatio    : window.devicePixelRatio || screen.deviceXDPI / screen.logicalXDPI,
+        progressColor : '#555',
+        normalize     : false,
+        renderer      : 'MultiCanvas',
+        scrollParent  : false,
+        skipLength    : 2,
+        splitChannels : false,
+        waveColor     : '#999',
     },
 
     init: function (params) {
@@ -460,14 +461,16 @@ var WaveSurfer = {
             }).bind(this))
         );
 
-        // If no pre-decoded peaks provided, attempt to download the
+        // If no pre-decoded peaks provided or pre-decoded peaks are
+        // provided with forceDecode flag, attempt to download the
         // audio file and decode it with Web Audio.
-        if (peaks) {
-            this.backend.setPeaks(peaks);
-        } else if (this.backend.supportsWebAudio()) {
+        if (peaks) this.backend.setPeaks(peaks);
+
+        if ((!peaks || this.params.forceDecode) && this.backend.supportsWebAudio()) {
             this.getArrayBuffer(url, (function (arraybuffer) {
                 this.decodeArrayBuffer(arraybuffer, (function (buffer) {
                     this.backend.buffer = buffer;
+                    this.backend.setPeaks(null);
                     this.drawBuffer();
                     this.fireEvent('waveform-ready');
                 }).bind(this));


### PR DESCRIPTION
### Short description of changes:
Adds the `forceDecode` option to force client side decoding of the audio after download regardless if pre-decoded peaks are passed to the `.load/2` method.

This is primarily for use with `.zoom/1` to enable high fidelity rendering on zoom of instant loading pre-decoded waveforms on the UI. Without local decoding, the zoom on pre-decoded peaks is very low fidelity.

Included in this PR is alpha sorting of the `defaultParams` to make for easier reference. *I couldn't resist...*

### Breaking in the external API:
n/a

### Breaking changes in the internal API:
n/a

### Todos/Notes:
n/a

### Related Issues and other PRs:
https://github.com/katspaugh/wavesurfer.js/issues/999