### PR TITLE
check if hardware context limit reached

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -14,7 +14,12 @@ WaveSurfer.WebAudio = {
         if (!this.ac) {
             // check if audiocontext limit has been reached
             if(this.ac.length >= 6){
-                console.log('This browser supports up to 6 hardware contexts');
+                var hwcText = 'This browser supports up to 6 hardware contexts';
+                if (typeof console != "undefined") {
+                    console.log(hwcText);
+                } else{
+                    window.alert(hwcText);
+                }
                 return false;
             } else{
                 this.ac = new (

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -13,9 +13,8 @@ WaveSurfer.WebAudio = {
     getAudioContext: function () {
         if (!this.ac) {
             // check if audiocontext limit has been reached
-            if(this.ac.length >= 5){
-                var contextlimitText = 'This browser supports up to 6 hardware contexts';
-                throw new Error(contextlimitText);
+            if (this.ac.length >= 5) {
+                throw new Error('This browser supports up to 6 hardware contexts at a time');
             } else {
                 this.ac = new (
                     window.AudioContext || window.webkitAudioContext

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -13,7 +13,7 @@ WaveSurfer.WebAudio = {
     getAudioContext: function () {
         if (!this.ac) {
             // check if audiocontext limit has been reached
-            if(this.ac.length >= 6){
+            if(this.ac.length >= 5){
                 var contextlimitText = 'This browser supports up to 6 hardware contexts';
                 throw new Error(contextlimitText);
             } else {

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -16,7 +16,6 @@ WaveSurfer.WebAudio = {
             if(this.ac.length >= 6){
                 var contextlimitText = 'This browser supports up to 6 hardware contexts';
                 throw new Error(contextlimitText);
-                return false;
             } else {
                 this.ac = new (
                     window.AudioContext || window.webkitAudioContext

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -15,11 +15,7 @@ WaveSurfer.WebAudio = {
             // check if audiocontext limit has been reached
             if(this.ac.length >= 6){
                 var contextlimitText = 'This browser supports up to 6 hardware contexts';
-                if (typeof console != 'undefined') {
-                    console.log(contextlimitText);
-                } else {
-                    window.alert(contextlimitText);
-                }
+                throw new Error(contextlimitText);
                 return false;
             } else {
                 this.ac = new (

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -12,9 +12,15 @@ WaveSurfer.WebAudio = {
 
     getAudioContext: function () {
         if (!this.ac) {
-            this.ac = new (
-                window.AudioContext || window.webkitAudioContext
-            );
+            // check if audiocontext limit has been reached
+            if(this.ac.length >= 6){
+                console.log('This browser supports up to 6 hardware contexts');
+                return false;
+            } else{
+                this.ac = new (
+                    window.AudioContext || window.webkitAudioContext
+                );
+            }
         }
         return this.ac;
     },

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -14,14 +14,14 @@ WaveSurfer.WebAudio = {
         if (!this.ac) {
             // check if audiocontext limit has been reached
             if(this.ac.length >= 6){
-                var hwcText = 'This browser supports up to 6 hardware contexts';
-                if (typeof console != "undefined") {
-                    console.log(hwcText);
-                } else{
-                    window.alert(hwcText);
+                var contextlimitText = 'This browser supports up to 6 hardware contexts';
+                if (typeof console != 'undefined') {
+                    console.log(contextlimitText);
+                } else {
+                    window.alert(contextlimitText);
                 }
                 return false;
-            } else{
+            } else {
                 this.ac = new (
                     window.AudioContext || window.webkitAudioContext
                 );


### PR DESCRIPTION
return false if audiocontext limit has been reached and console outputs the following message "This browser supports up to 6 hardware contexts".

Might need to add check for `console.log` or default to window.alert to return the message.

#1005

here is the chrome test check,
https://chromium.googlesource.com/experimental/chromium/blink/+/master/LayoutTests/webaudio/audiocontext-max-contexts-expected.txt 