### PR TITLE
Readded global audio singleton, added closeAudioContext parameter

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -14,6 +14,7 @@ var WaveSurfer = {
         audioRate     : 1,
         autoCenter    : true,
         backend       : 'WebAudio',
+        closeAudioContext: false,
         container     : null,
         cursorColor   : '#333',
         cursorWidth   : 1,

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -11,12 +11,12 @@ WaveSurfer.WebAudio = {
     },
 
     getAudioContext: function () {
-        if (!window.WaveSurfer.WebAudio.audioContext) {
-            window.WaveSurfer.WebAudio.audioContext = new (
+        if (!WaveSurfer.WebAudio.audioContext) {
+            WaveSurfer.WebAudio.audioContext = new (
                 window.AudioContext || window.webkitAudioContext
             );
         }
-        return window.WaveSurfer.WebAudio.audioContext;
+        return WaveSurfer.WebAudio.audioContext;
     },
 
     getOfflineAudioContext: function (sampleRate) {

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -11,12 +11,12 @@ WaveSurfer.WebAudio = {
     },
 
     getAudioContext: function () {
-        if (!this.ac) {
-            this.ac = new (
+        if (!window.WaveSurfer.WebAudio.audioContext) {
+            window.WaveSurfer.WebAudio.audioContext = new (
                 window.AudioContext || window.webkitAudioContext
             );
         }
-        return this.ac;
+        return window.WaveSurfer.WebAudio.audioContext;
     },
 
     getOfflineAudioContext: function (sampleRate) {
@@ -283,13 +283,14 @@ WaveSurfer.WebAudio = {
         this.gainNode.disconnect();
         this.scriptNode.disconnect();
         this.analyser.disconnect();
-        // close the audioContext if it was created by wavesurfer
-        // not passed in as a parameter
-        if (!this.params.audioContext) {
+        // close the audioContext if closeAudioContext option is set to true
+        if (this.params.closeAudioContext) {
             // check if browser supports AudioContext.close()
-            if (typeof this.ac.close === 'function') {
-                this.ac.close();
+            if (typeof WaveSurfer.WebAudio.audioContext.close === 'function') {
+                WaveSurfer.WebAudio.audioContext.close();
             }
+            WaveSurfer.WebAudio.audioContext = null;
+            WaveSurfer.WebAudio.offlineAudioContext = null;
         }
     },
 

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -286,10 +286,19 @@ WaveSurfer.WebAudio = {
         // close the audioContext if closeAudioContext option is set to true
         if (this.params.closeAudioContext) {
             // check if browser supports AudioContext.close()
-            if (typeof WaveSurfer.WebAudio.audioContext.close === 'function') {
-                WaveSurfer.WebAudio.audioContext.close();
+            if (typeof this.ac.close === 'function') {
+                this.ac.close();
             }
-            WaveSurfer.WebAudio.audioContext = null;
+            // clear the reference to the audiocontext
+            this.ac = null;
+            // clear the actual audiocontext, either passed as param or the
+            // global singleton
+            if (!this.params.audioContext) {
+                WaveSurfer.WebAudio.audioContext = null;
+            } else {
+                this.params.audioContext = null;
+            }
+            // clear the offlineAudioContext
             WaveSurfer.WebAudio.offlineAudioContext = null;
         }
     },


### PR DESCRIPTION
### Short description of changes:

* audio context is now reused and not destroyed everytime. This allows more than 6 waves to exist.
* audio context is destroyed in the `destroy` method if `params.closeAudioContext` is set to true

### Breaking in the external API:
* None, unless usage relied on the closing of the wavesurfer AudioContext, this needs to be done explicitly (see above)

### Breaking changes in the internal API:
/

### Todos/Notes:
* For v2/next I would use `window.WaveSurferAudioContext` since the library object isn't necessarily a global variable.

### Related Issues and other PRs:
* https://github.com/katspaugh/wavesurfer.js/issues/1005
* https://github.com/katspaugh/wavesurfer.js/pull/1015
* https://github.com/katspaugh/wavesurfer.js/pull/998
* https://github.com/katspaugh/wavesurfer.js/pull/962
* https://github.com/katspaugh/wavesurfer.js/issues/374