### PR TITLE
add getPlaybackRate method for mediaelement.js

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -140,6 +140,10 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
         return (this.getCurrentTime() / this.getDuration()) || 0;
     },
 
+    getPlaybackRate: function () {
+        return this.playbackRate || this.media.playbackRate;
+    },
+
     /**
      * Set the audio source playback rate.
      */


### PR DESCRIPTION
Add getPlaybackRate method when using mediaelement backend.
