### PR TITLE
Next: Updated plugin definition format and class exports

### DIFF
--- a/example/annotation/app.js
+++ b/example/annotation/app.js
@@ -17,14 +17,14 @@ document.addEventListener('DOMContentLoaded', function () {
         minimap: true,
         backend: 'MediaElement',
         plugins: [
-            window.WaveSurfer.regions(),
-            window.WaveSurfer.minimap({
+            window.WaveSurfer.regions.default(),
+            window.WaveSurfer.minimap.default({
                 height: 30,
                 waveColor: '#ddd',
                 progressColor: '#999',
                 cursorColor: '#999'
             }),
-            window.WaveSurfer.timeline({
+            window.WaveSurfer.timeline.default({
                 container: "#wave-timeline"
             })
         ]

--- a/example/cursor/main.js
+++ b/example/cursor/main.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', function () {
     wavesurfer = window.WaveSurfer.create({
         container: document.querySelector('#waveform'),
         plugins: [
-            window.WaveSurfer.cursor()
+            window.WaveSurfer.cursor.default()
         ]
     });
 

--- a/example/elan/app.js
+++ b/example/elan/app.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', function () {
         selectionColor: '#d0e9c6',
         loopSelection : false,
         plugins: [
-            window.WaveSurfer.elan({
+            window.WaveSurfer.elan.default({
                 url: 'transcripts/001z.xml',
                 container: '#annotations',
                 tiers: {
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     Comments: true
                 }
             }),
-            window.WaveSurfer.regions()
+            window.WaveSurfer.regions.default()
         ]
     };
 

--- a/example/microphone/app.js
+++ b/example/microphone/app.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', function () {
         interact      : false,
         cursorWidth   : 0,
         plugins: [
-            window.WaveSurfer.microphone()
+            window.WaveSurfer.microphone.default()
         ]
     });
 

--- a/example/plugin-system/app.js
+++ b/example/plugin-system/app.js
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function () {
         loaderColor   : 'purple',
         cursorColor   : 'navy',
         plugins: [
-            window.WaveSurfer.minimap(pluginOptions.minimap)
+            window.WaveSurfer.minimap.default(pluginOptions.minimap)
         ]
     };
 
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', function () {
             var pluginName = e.currentTarget.dataset.activatePlugin;
             var activate = e.target.checked;
             var options = pluginOptions[pluginName] || {};
-            var plugin = window.WaveSurfer[pluginName](options);
+            var plugin = window.WaveSurfer[pluginName].default(options);
 
             if (activate) {
                 wavesurfer.addPlugin(plugin).initPlugin(pluginName);

--- a/example/regions/app.js
+++ b/example/regions/app.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', function () {
         progressColor: '#3B8686',
         backend: 'MediaElement',
         plugins: [
-            window.WaveSurfer.regions({
+            window.WaveSurfer.regions.default({
                 regions: [
                     {
                         start: 1,

--- a/example/spectrogram/app.js
+++ b/example/spectrogram/app.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', function () {
         loaderColor   : 'purple',
         cursorColor   : 'navy',
         plugins: [
-            window.WaveSurfer.spectrogram({
+            window.WaveSurfer.spectrogram.default({
                 container: '#wave-spectrogram'
             })
         ]

--- a/example/timeline/app.js
+++ b/example/timeline/app.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', function () {
         loaderColor   : 'purple',
         cursorColor   : 'navy',
         plugins: [
-            window.WaveSurfer.timeline({
+            window.WaveSurfer.timeline.default({
                 container: '#wave-timeline'
             })
         ]

--- a/src/html-init.js
+++ b/src/html-init.js
@@ -180,7 +180,7 @@ class Init {
                     options[unprefixedOptionName] = prop;
                 }
             }
-            return this.pluginCache[plugin](options);
+            return this.pluginCache[plugin].default(options);
         });
         // build parameter object for this container
         const params = this.WaveSurfer.util.extend(

--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -1,4 +1,93 @@
 /**
+ * Cursor plugin class
+ *
+ * @implements {PluginClass}
+ * @extends {Observer}
+ */
+export class CursorPlugin {
+    constructor(params, ws) {
+        this.wavesurfer = ws;
+        this.style = ws.util.style;
+        this._onDrawerCreated = () => {
+            this.drawer = this.wavesurfer.drawer;
+            this.wrapper = this.wavesurfer.drawer.wrapper;
+
+            this._onMousemove = e => this.updateCursorPosition(this.drawer.handleEvent(e));
+            this.wrapper.addEventListener('mousemove', this._onMousemove);
+
+            this._onMouseenter = () => this.showCursor();
+            this.wrapper.addEventListener('mouseenter', this._onMouseenter);
+
+            this._onMouseleave = () => this.hideCursor();
+            this.wrapper.addEventListener('mouseleave', this._onMouseleave);
+
+            this.cursor = this.wrapper.appendChild(
+                this.style(document.createElement('wave'), {
+                    position: 'absolute',
+                    zIndex: 3,
+                    left: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: '0',
+                    display: 'block',
+                    borderRightStyle: 'solid',
+                    borderRightWidth: 1 + 'px',
+                    borderRightColor: 'black',
+                    opacity: '.25',
+                    pointerEvents: 'none'
+                })
+            );
+        };
+    }
+
+    init() {
+        // drawer already existed, just call initialisation code
+        if (this.wavesurfer.drawer) {
+            this._onDrawerCreated();
+        }
+
+        // the drawer was initialised, call the initialisation code
+        this.wavesurfer.on('drawer-created', this._onDrawerCreated);
+    }
+
+    destroy() {
+        this.wavesurfer.un('drawer-created', this._onDrawerCreated);
+
+        // if cursor was appended, remove it
+        if (this.cursor) {
+            this.cursor.parentNode.removeChild(this.cursor);
+        }
+
+        // if the drawer existed (the cached version referenced in the init code),
+        // remove the event listeners attached to it
+        if (this.drawer) {
+            this.wrapper.removeEventListener('mousemove', this._onMousemove);
+            this.wrapper.removeEventListener('mouseenter', this._onMouseenter);
+            this.wrapper.removeEventListener('mouseleave', this._onMouseleave);
+        }
+    }
+
+    updateCursorPosition(progress) {
+        const pos = Math.round(this.drawer.width * progress) / this.drawer.params.pixelRatio - 1;
+        this.style(this.cursor, {
+            left: `${pos}px`
+        });
+    }
+
+    showCursor() {
+        this.style(this.cursor, {
+            display: 'block'
+        });
+    }
+
+    hideCursor() {
+        this.style(this.cursor, {
+            display: 'none'
+        });
+    }
+}
+
+/**
  * @typedef {Object} CursorPluginParams
  * @property {?boolean} deferInit Set to true to stop auto init in `addPlugin()`
  */
@@ -9,99 +98,17 @@
  * @param  {CursorPluginParams} params parameters use to initialise the plugin
  * @return {PluginDefinition} an object representing the plugin
  */
-export default function(params) {
+export default function createCursor(params) {
     return {
         name: 'cursor',
         deferInit: params && params.deferInit ? params.deferInit : false,
-        static: {
+        params: params,
+        staticProps: {
             enableCursor() {
-                console.warn('Deprecated enableCursor! Use wavesurfer.initPlugins("cursor") instead!');
+                console.warn('Deprecated enableCursor! Use ws.initPlugins("cursor") instead!');
                 this.initPlugins('cursor');
             }
         },
-        extends: 'observer',
-        instance: Observer => class CursorPlugin extends Observer {
-            constructor(wavesurfer) {
-                super();
-                this.wavesurfer = wavesurfer;
-                this.style = wavesurfer.util.style;
-                this._onDrawerCreated = () => {
-                    this.drawer = wavesurfer.drawer;
-                    this.wrapper = wavesurfer.drawer.wrapper;
-
-                    this._onMousemove = e => this.updateCursorPosition(this.drawer.handleEvent(e));
-                    this.wrapper.addEventListener('mousemove', this._onMousemove);
-
-                    this._onMouseenter = () => this.showCursor();
-                    this.wrapper.addEventListener('mouseenter', this._onMouseenter);
-
-                    this._onMouseleave = () => this.hideCursor();
-                    this.wrapper.addEventListener('mouseleave', this._onMouseleave);
-
-                    this.cursor = this.wrapper.appendChild(
-                        this.style(document.createElement('wave'), {
-                            position: 'absolute',
-                            zIndex: 3,
-                            left: 0,
-                            top: 0,
-                            bottom: 0,
-                            width: '0',
-                            display: 'block',
-                            borderRightStyle: 'solid',
-                            borderRightWidth: 1 + 'px',
-                            borderRightColor: 'black',
-                            opacity: '.25',
-                            pointerEvents: 'none'
-                        })
-                    );
-                };
-            }
-
-            init() {
-                // drawer already existed, just call initialisation code
-                if (this.wavesurfer.drawer) {
-                    this._onDrawerCreated();
-                }
-
-                // the drawer was initialised, call the initialisation code
-                this.wavesurfer.on('drawer-created', this._onDrawerCreated);
-            }
-
-            destroy() {
-                this.wavesurfer.un('drawer-created', this._onDrawerCreated);
-
-                // if cursor was appended, remove it
-                if (this.cursor) {
-                    this.cursor.parentNode.removeChild(this.cursor);
-                }
-
-                // if the drawer existed (the cached version referenced in the init code),
-                // remove the event listeners attached to it
-                if (this.drawer) {
-                    this.wrapper.removeEventListener('mousemove', this._onMousemove);
-                    this.wrapper.removeEventListener('mouseenter', this._onMouseenter);
-                    this.wrapper.removeEventListener('mouseleave', this._onMouseleave);
-                }
-            }
-
-            updateCursorPosition(progress) {
-                const pos = Math.round(this.drawer.width * progress) / this.drawer.params.pixelRatio - 1;
-                this.style(this.cursor, {
-                    left: `${pos}px`
-                });
-            }
-
-            showCursor() {
-                this.style(this.cursor, {
-                    display: 'block'
-                });
-            }
-
-            hideCursor() {
-                this.style(this.cursor, {
-                    display: 'none'
-                });
-            }
-        }
+        instance: CursorPlugin
     };
 }

--- a/src/plugin/elan.js
+++ b/src/plugin/elan.js
@@ -1,4 +1,254 @@
 /**
+ * Elan plugin class
+ *
+ * @implements {PluginClass}
+ * @extends {Observer}
+ */
+export class ElanPlugin {
+    Types = {
+        ALIGNABLE_ANNOTATION: 'ALIGNABLE_ANNOTATION',
+        REF_ANNOTATION: 'REF_ANNOTATION'
+    }
+
+    constructor(params, ws) {
+        this.data = null;
+        this.params = params;
+        this.container = 'string' == typeof params.container ?
+            document.querySelector(params.container) : params.container;
+
+        if (!this.container) {
+            throw Error('No container for ELAN');
+        }
+    }
+
+    init() {
+        this.bindClick();
+
+        if (this.params.url) {
+            this.load(this.params.url);
+        }
+    }
+
+    destroy() {
+        this.container.removeEventListener('click', this._onClick);
+        this.container.removeChild(this.table);
+    }
+
+    load(url) {
+        this.loadXML(url, xml => {
+            this.data = this.parseElan(xml);
+            this.render();
+            this.fireEvent('ready', this.data);
+        });
+    }
+
+    loadXML(url, callback) {
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', url, true);
+        xhr.responseType = 'document';
+        xhr.send();
+        xhr.addEventListener('load', e => {
+            callback && callback(e.target.responseXML);
+        });
+    }
+
+    parseElan(xml) {
+        const _forEach = Array.prototype.forEach;
+        const _map = Array.prototype.map;
+
+        const data = {
+            media: {},
+            timeOrder: {},
+            tiers: [],
+            annotations: {},
+            alignableAnnotations: []
+        };
+
+        const header = xml.querySelector('HEADER');
+        const inMilliseconds = header.getAttribute('TIME_UNITS') == 'milliseconds';
+        const media = header.querySelector('MEDIA_DESCRIPTOR');
+        data.media.url = media.getAttribute('MEDIA_URL');
+        data.media.type = media.getAttribute('MIME_TYPE');
+
+        const timeSlots = xml.querySelectorAll('TIME_ORDER TIME_SLOT');
+        const timeOrder = {};
+        _forEach.call(timeSlots, slot => {
+            let value = parseFloat(slot.getAttribute('TIME_VALUE'));
+            // If in milliseconds, convert to seconds with rounding
+            if (inMilliseconds) {
+                value = Math.round(value * 1e2) / 1e5;
+            }
+            timeOrder[slot.getAttribute('TIME_SLOT_ID')] = value;
+        });
+
+        data.tiers = _map.call(xml.querySelectorAll('TIER'), tier => ({
+            id: tier.getAttribute('TIER_ID'),
+            linguisticTypeRef: tier.getAttribute('LINGUISTIC_TYPE_REF'),
+            defaultLocale: tier.getAttribute('DEFAULT_LOCALE'),
+            annotations: _map.call(
+                tier.querySelectorAll('REF_ANNOTATION, ALIGNABLE_ANNOTATION'), node => {
+                    const annot = {
+                        type: node.nodeName,
+                        id: node.getAttribute('ANNOTATION_ID'),
+                        ref: node.getAttribute('ANNOTATION_REF'),
+                        value: node.querySelector('ANNOTATION_VALUE')
+                            .textContent.trim()
+                    };
+
+                    if (this.Types.ALIGNABLE_ANNOTATION == annot.type) {
+                        // Add start & end to alignable annotation
+                        annot.start = timeOrder[node.getAttribute('TIME_SLOT_REF1')];
+                        annot.end = timeOrder[node.getAttribute('TIME_SLOT_REF2')];
+                        // Add to the list of alignable annotations
+                        data.alignableAnnotations.push(annot);
+                    }
+
+                    // Additionally, put into the flat map of all annotations
+                    data.annotations[annot.id] = annot;
+
+                    return annot;
+                }
+            )
+        }));
+
+        // Create JavaScript references between annotations
+        data.tiers.forEach(tier => {
+            tier.annotations.forEach(annot => {
+                if (null != annot.ref) {
+                    annot.reference = data.annotations[annot.ref];
+                }
+            });
+        });
+
+        // Sort alignable annotations by start & end
+        data.alignableAnnotations.sort((a, b) => {
+            let d = a.start - b.start;
+            if (d == 0) {
+                d = b.end - a.end;
+            }
+            return d;
+        });
+
+        data.length = data.alignableAnnotations.length;
+
+        return data;
+    }
+
+    render() {
+        // apply tiers filter
+        let tiers = this.data.tiers;
+        if (this.params.tiers) {
+            tiers = tiers.filter(tier => tier.id in this.params.tiers);
+        }
+
+        // denormalize references to alignable annotations
+        const backRefs = {};
+        let indeces = {};
+        tiers.forEach((tier, index) => {
+            tier.annotations.forEach(annot => {
+                if (annot.reference && annot.reference.type == this.Types.ALIGNABLE_ANNOTATION) {
+                    if (!(annot.reference.id in backRefs)) {
+                        backRefs[annot.ref] = {};
+                    }
+                    backRefs[annot.ref][index] = annot;
+                    indeces[index] = true;
+                }
+            });
+        });
+        indeces = Object.keys(indeces).sort();
+
+        this.renderedAlignable = this.data.alignableAnnotations.filter(alignable => backRefs[alignable.id]);
+
+        // table
+        const table = this.table = document.createElement('table');
+        table.className = 'wavesurfer-annotations';
+
+        // head
+        const thead = document.createElement('thead');
+        const headRow = document.createElement('tr');
+        thead.appendChild(headRow);
+        table.appendChild(thead);
+        const th = document.createElement('th');
+        th.textContent = 'Time';
+        th.className = 'wavesurfer-time';
+        headRow.appendChild(th);
+        indeces.forEach(index => {
+            const tier = tiers[index];
+            const th = document.createElement('th');
+            th.className = 'wavesurfer-tier-' + tier.id;
+            th.textContent = tier.id;
+            th.style.width = this.params.tiers[tier.id];
+            headRow.appendChild(th);
+        });
+
+        // body
+        const tbody = document.createElement('tbody');
+        table.appendChild(tbody);
+        this.renderedAlignable.forEach(alignable => {
+            const row = document.createElement('tr');
+            row.id = 'wavesurfer-alignable-' + alignable.id;
+            tbody.appendChild(row);
+
+            const td = document.createElement('td');
+            td.className = 'wavesurfer-time';
+            td.textContent = alignable.start.toFixed(1) + '–' +
+                alignable.end.toFixed(1);
+            row.appendChild(td);
+
+            const backRef = backRefs[alignable.id];
+            indeces.forEach(index => {
+                const tier = tiers[index];
+                const td = document.createElement('td');
+                const annotation = backRef[index];
+                if (annotation) {
+                    td.id = 'wavesurfer-annotation-' + annotation.id;
+                    td.dataset.ref = alignable.id;
+                    td.dataset.start = alignable.start;
+                    td.dataset.end = alignable.end;
+                    td.textContent = annotation.value;
+                }
+                td.className = 'wavesurfer-tier-' + tier.id;
+                row.appendChild(td);
+            });
+        });
+
+        this.container.innerHTML = '';
+        this.container.appendChild(table);
+    }
+
+    bindClick() {
+        this._onClick = e => {
+            const ref = e.target.dataset.ref;
+            if (null != ref) {
+                const annot = this.data.annotations[ref];
+                if (annot) {
+                    this.fireEvent('select', annot.start, annot.end);
+                }
+            }
+        };
+        this.container.addEventListener('click', this._onClick);
+    }
+
+    getRenderedAnnotation(time) {
+        let result;
+        this.renderedAlignable.some(annotation => {
+            if (annotation.start <= time && annotation.end >= time) {
+                result = annotation;
+                return true;
+            }
+            return false;
+        });
+        return result;
+    }
+
+    getAnnotationNode(annotation) {
+        return document.getElementById(
+            'wavesurfer-alignable-' + annotation.id
+        );
+    }
+}
+
+/**
  * @typedef {Object} ElanPluginParams
  * @property {string|HTMLElement} container CSS selector or HTML element where
  * the ELAN information should be renderer.
@@ -14,254 +264,11 @@
  * @param  {ElanPluginParams} params parameters use to initialise the plugin
  * @return {PluginDefinition} an object representing the plugin
  */
-export default function(params = {}) {
+export default function createElan(params) {
     return {
         name: 'elan',
         deferInit: params && params.deferInit ? params.deferInit : false,
-        extends: 'observer',
-        instance: Observer => class ElanPlugin extends Observer {
-            Types = {
-                ALIGNABLE_ANNOTATION: 'ALIGNABLE_ANNOTATION',
-                REF_ANNOTATION: 'REF_ANNOTATION'
-            }
-
-            constructor(wavesurfer) {
-                super();
-                this.data = null;
-                this.params = params;
-                this.container = 'string' == typeof params.container ?
-                document.querySelector(params.container) : params.container;
-
-                if (!this.container) {
-                    throw Error('No container for ELAN');
-                }
-            }
-
-            init() {
-                this.bindClick();
-
-                if (params.url) {
-                    this.load(params.url);
-                }
-            }
-
-            destroy() {
-                this.container.removeEventListener('click', this._onClick);
-                this.container.removeChild(this.table);
-            }
-
-            load(url) {
-                this.loadXML(url, xml => {
-                    this.data = this.parseElan(xml);
-                    this.render();
-                    this.fireEvent('ready', this.data);
-                });
-            }
-
-            loadXML(url, callback) {
-                const xhr = new XMLHttpRequest();
-                xhr.open('GET', url, true);
-                xhr.responseType = 'document';
-                xhr.send();
-                xhr.addEventListener('load', e => {
-                    callback && callback(e.target.responseXML);
-                });
-            }
-
-            parseElan(xml) {
-                const _forEach = Array.prototype.forEach;
-                const _map = Array.prototype.map;
-
-                const data = {
-                    media: {},
-                    timeOrder: {},
-                    tiers: [],
-                    annotations: {},
-                    alignableAnnotations: []
-                };
-
-                const header = xml.querySelector('HEADER');
-                const inMilliseconds = header.getAttribute('TIME_UNITS') == 'milliseconds';
-                const media = header.querySelector('MEDIA_DESCRIPTOR');
-                data.media.url = media.getAttribute('MEDIA_URL');
-                data.media.type = media.getAttribute('MIME_TYPE');
-
-                const timeSlots = xml.querySelectorAll('TIME_ORDER TIME_SLOT');
-                const timeOrder = {};
-                _forEach.call(timeSlots, slot => {
-                    let value = parseFloat(slot.getAttribute('TIME_VALUE'));
-                    // If in milliseconds, convert to seconds with rounding
-                    if (inMilliseconds) {
-                        value = Math.round(value * 1e2) / 1e5;
-                    }
-                    timeOrder[slot.getAttribute('TIME_SLOT_ID')] = value;
-                });
-
-                data.tiers = _map.call(xml.querySelectorAll('TIER'), tier => ({
-                    id: tier.getAttribute('TIER_ID'),
-                    linguisticTypeRef: tier.getAttribute('LINGUISTIC_TYPE_REF'),
-                    defaultLocale: tier.getAttribute('DEFAULT_LOCALE'),
-                    annotations: _map.call(
-                        tier.querySelectorAll('REF_ANNOTATION, ALIGNABLE_ANNOTATION'), node => {
-                            const annot = {
-                                type: node.nodeName,
-                                id: node.getAttribute('ANNOTATION_ID'),
-                                ref: node.getAttribute('ANNOTATION_REF'),
-                                value: node.querySelector('ANNOTATION_VALUE')
-                                .textContent.trim()
-                            };
-
-                            if (this.Types.ALIGNABLE_ANNOTATION == annot.type) {
-                                // Add start & end to alignable annotation
-                                annot.start = timeOrder[node.getAttribute('TIME_SLOT_REF1')];
-                                annot.end = timeOrder[node.getAttribute('TIME_SLOT_REF2')];
-                                // Add to the list of alignable annotations
-                                data.alignableAnnotations.push(annot);
-                            }
-
-                            // Additionally, put into the flat map of all annotations
-                            data.annotations[annot.id] = annot;
-
-                            return annot;
-                        }
-                    )
-                }));
-
-                // Create JavaScript references between annotations
-                data.tiers.forEach(tier => {
-                    tier.annotations.forEach(annot => {
-                        if (null != annot.ref) {
-                            annot.reference = data.annotations[annot.ref];
-                        }
-                    });
-                });
-
-                // Sort alignable annotations by start & end
-                data.alignableAnnotations.sort((a, b) => {
-                    let d = a.start - b.start;
-                    if (d == 0) {
-                        d = b.end - a.end;
-                    }
-                    return d;
-                });
-
-                data.length = data.alignableAnnotations.length;
-
-                return data;
-            }
-
-            render() {
-                // apply tiers filter
-                let tiers = this.data.tiers;
-                if (this.params.tiers) {
-                    tiers = tiers.filter(tier => tier.id in this.params.tiers);
-                }
-
-                // denormalize references to alignable annotations
-                const backRefs = {};
-                let indeces = {};
-                tiers.forEach((tier, index) => {
-                    tier.annotations.forEach(annot => {
-                        if (annot.reference && annot.reference.type == this.Types.ALIGNABLE_ANNOTATION) {
-                            if (!(annot.reference.id in backRefs)) {
-                                backRefs[annot.ref] = {};
-                            }
-                            backRefs[annot.ref][index] = annot;
-                            indeces[index] = true;
-                        }
-                    });
-                });
-                indeces = Object.keys(indeces).sort();
-
-                this.renderedAlignable = this.data.alignableAnnotations.filter(alignable => backRefs[alignable.id]);
-
-                // table
-                const table = this.table = document.createElement('table');
-                table.className = 'wavesurfer-annotations';
-
-                // head
-                const thead = document.createElement('thead');
-                const headRow = document.createElement('tr');
-                thead.appendChild(headRow);
-                table.appendChild(thead);
-                const th = document.createElement('th');
-                th.textContent = 'Time';
-                th.className = 'wavesurfer-time';
-                headRow.appendChild(th);
-                indeces.forEach(index => {
-                    const tier = tiers[index];
-                    const th = document.createElement('th');
-                    th.className = 'wavesurfer-tier-' + tier.id;
-                    th.textContent = tier.id;
-                    th.style.width = this.params.tiers[tier.id];
-                    headRow.appendChild(th);
-                });
-
-                // body
-                const tbody = document.createElement('tbody');
-                table.appendChild(tbody);
-                this.renderedAlignable.forEach(alignable => {
-                    const row = document.createElement('tr');
-                    row.id = 'wavesurfer-alignable-' + alignable.id;
-                    tbody.appendChild(row);
-
-                    const td = document.createElement('td');
-                    td.className = 'wavesurfer-time';
-                    td.textContent = alignable.start.toFixed(1) + '–' +
-                    alignable.end.toFixed(1);
-                    row.appendChild(td);
-
-                    const backRef = backRefs[alignable.id];
-                    indeces.forEach(index => {
-                        const tier = tiers[index];
-                        const td = document.createElement('td');
-                        const annotation = backRef[index];
-                        if (annotation) {
-                            td.id = 'wavesurfer-annotation-' + annotation.id;
-                            td.dataset.ref = alignable.id;
-                            td.dataset.start = alignable.start;
-                            td.dataset.end = alignable.end;
-                            td.textContent = annotation.value;
-                        }
-                        td.className = 'wavesurfer-tier-' + tier.id;
-                        row.appendChild(td);
-                    });
-                });
-
-                this.container.innerHTML = '';
-                this.container.appendChild(table);
-            }
-
-            bindClick() {
-                this._onClick = e => {
-                    const ref = e.target.dataset.ref;
-                    if (null != ref) {
-                        const annot = this.data.annotations[ref];
-                        if (annot) {
-                            this.fireEvent('select', annot.start, annot.end);
-                        }
-                    }
-                };
-                this.container.addEventListener('click', this._onClick);
-            }
-
-            getRenderedAnnotation(time) {
-                let result;
-                this.renderedAlignable.some(annotation => {
-                    if (annotation.start <= time && annotation.end >= time) {
-                        result = annotation;
-                        return true;
-                    }
-                    return false;
-                });
-                return result;
-            }
-
-            getAnnotationNode(annotation) {
-                return document.getElementById(
-                    'wavesurfer-alignable-' + annotation.id
-                );
-            }
-        }
+        params: params,
+        instance: ElanPlugin
     };
 }

--- a/src/plugin/microphone.js
+++ b/src/plugin/microphone.js
@@ -1,4 +1,304 @@
 /**
+ * Microphone plugin class
+ *
+ * @implements {PluginClass}
+ * @extends {Observer}
+ */
+export class MicrophonePlugin {
+    constructor(params, ws) {
+        this.params = params;
+        this.wavesurfer = ws;
+
+        this.active = false;
+        this.paused = false;
+        this.reloadBufferFunction = e => this.reloadBuffer(e);
+
+        // cross-browser getUserMedia
+        const promisifiedOldGUM = (constraints, successCallback, errorCallback) => {
+            // get ahold of getUserMedia, if present
+            const getUserMedia = (navigator.getUserMedia ||
+                navigator.webkitGetUserMedia ||
+                navigator.mozGetUserMedia ||
+                navigator.msGetUserMedia
+            );
+            // Some browsers just don't implement it - return a rejected
+            // promise with an error to keep a consistent interface
+            if (!getUserMedia) {
+                return Promise.reject(
+                    new Error('getUserMedia is not implemented in this browser')
+                );
+            }
+            // otherwise, wrap the call to the old navigator.getUserMedia with
+            // a Promise
+            return new Promise((successCallback, errorCallback) => {
+                getUserMedia.call(navigator, constraints, successCallback, errorCallback);
+            });
+        };
+        // Older browsers might not implement mediaDevices at all, so we set an
+        // empty object first
+        if (navigator.mediaDevices === undefined) {
+            navigator.mediaDevices = {};
+        }
+        // Some browsers partially implement mediaDevices. We can't just assign
+        // an object with getUserMedia as it would overwrite existing
+        // properties. Here, we will just add the getUserMedia property if it's
+        // missing.
+        if (navigator.mediaDevices.getUserMedia === undefined) {
+            navigator.mediaDevices.getUserMedia = promisifiedOldGUM;
+        }
+        this.constraints = this.params.constraints || {
+            video: false,
+            audio: true
+        };
+        this.bufferSize = this.params.bufferSize || 4096;
+        this.numberOfInputChannels = this.params.numberOfInputChannels || 1;
+        this.numberOfOutputChannels = this.params.numberOfOutputChannels || 1;
+
+        this._onBackendCreated = () => {
+            // wavesurfer's AudioContext where we'll route the mic signal to
+            this.micContext = this.wavesurfer.backend.getAudioContext();
+        };
+    }
+
+    init() {
+        this.wavesurfer.on('backend-created', this._onBackendCreated);
+        if (this.wavesurfer.backend) {
+            this._onBackendCreated();
+        }
+    }
+
+    /**
+     * Destroy the microphone plugin.
+     */
+    destroy() {
+        // make sure the buffer is not redrawn during
+        // cleanup and demolition of this plugin.
+        this.paused = true;
+
+        this.wavesurfer.un('backend-created', this._onBackendCreated);
+        this.stop();
+    }
+
+    /**
+    * Allow user to select audio input device, eg. microphone, and
+    * start the visualization.
+    */
+    start() {
+        navigator.mediaDevices.getUserMedia(this.constraints)
+            .then((data) => this.gotStream(data))
+            .catch((data) => this.deviceError(data));
+    }
+
+    /**
+    * Pause/resume visualization.
+    */
+    togglePlay() {
+        if (!this.active) {
+            // start it first
+            this.start();
+        } else {
+            // toggle paused
+            this.paused = !this.paused;
+
+            if (this.paused) {
+                this.pause();
+            } else {
+                this.play();
+            }
+        }
+    }
+
+    /**
+    * Play visualization.
+    */
+    play() {
+        this.paused = false;
+
+        this.connect();
+    }
+
+    /**
+    * Pause visualization.
+    */
+    pause() {
+        this.paused = true;
+
+        // disconnect sources so they can be used elsewhere
+        // (eg. during audio playback)
+        this.disconnect();
+    }
+
+    /**
+    * Stop the device stream and remove any remaining waveform drawing from
+    * the wavesurfer canvas.
+    */
+    stop() {
+        if (this.active) {
+            // stop visualization and device
+            this.stopDevice();
+
+            // empty last frame
+            this.wavesurfer.empty();
+        }
+    }
+
+    /**
+    * Stop the device and the visualization.
+    */
+    stopDevice() {
+        this.active = false;
+
+        // stop visualization
+        this.disconnect();
+
+        // stop stream from device
+        if (this.stream) {
+            const result = this.detectBrowser();
+            // MediaStream.stop is deprecated since:
+            // - Firefox 44 (https://www.fxsitecompat.com/en-US/docs/2015/mediastream-stop-has-been-deprecated/)
+            // - Chrome 45 (https://developers.google.com/web/updates/2015/07/mediastream-deprecations)
+            if ((result.browser === 'chrome' && result.version >= 45) ||
+                (result.browser === 'firefox' && result.version >= 44) ||
+                (result.browser === 'edge')) {
+                if (this.stream.getTracks) { // note that this should not be a call
+                    this.stream.getTracks().forEach(stream => stream.stop());
+                    return;
+                }
+            }
+
+            this.stream.stop();
+        }
+    }
+
+    /**
+    * Connect the media sources that feed the visualization.
+    */
+    connect() {
+        if (this.stream !== undefined) {
+            // Create an AudioNode from the stream.
+            this.mediaStreamSource = this.micContext.createMediaStreamSource(this.stream);
+
+            this.levelChecker = this.micContext.createScriptProcessor(
+                this.bufferSize,
+                this.numberOfInputChannels,
+                this.numberOfOutputChannels
+            );
+            this.mediaStreamSource.connect(this.levelChecker);
+
+            this.levelChecker.connect(this.micContext.destination);
+            this.levelChecker.onaudioprocess = this.reloadBufferFunction;
+        }
+    }
+
+    /**
+    * Disconnect the media sources that feed the visualization.
+    */
+    disconnect() {
+        if (this.mediaStreamSource !== undefined) {
+            this.mediaStreamSource.disconnect();
+        }
+
+        if (this.levelChecker !== undefined) {
+            this.levelChecker.disconnect();
+            this.levelChecker.onaudioprocess = undefined;
+        }
+    }
+
+    /**
+    * Redraw the waveform.
+    */
+    reloadBuffer(event) {
+        if (!this.paused) {
+            this.wavesurfer.empty();
+            this.wavesurfer.loadDecodedBuffer(event.inputBuffer);
+        }
+    }
+
+    /**
+    * Audio input device is ready.
+    *
+    * @param {LocalMediaStream} stream The microphone's media stream.
+    */
+    gotStream(stream) {
+        this.stream = stream;
+        this.active = true;
+
+        // start visualization
+        this.play();
+
+        // notify listeners
+        this.fireEvent('deviceReady', stream);
+    }
+
+    /**
+    * Device error callback.
+    */
+    deviceError(code) {
+        // notify listeners
+        this.fireEvent('deviceError', code);
+    }
+
+    /**
+    * Extract browser version out of the provided user agent string.
+    * @param {!string} uastring userAgent string.
+    * @param {!string} expr Regular expression used as match criteria.
+    * @param {!number} pos position in the version string to be returned.
+    * @return {!number} browser version.
+    */
+    extractVersion(uastring, expr, pos) {
+        const match = uastring.match(expr);
+        return match && match.length >= pos && parseInt(match[pos], 10);
+    }
+
+    /**
+    * Browser detector.
+    * @return {object} result containing browser, version and minVersion
+    *     properties.
+    */
+    detectBrowser() {
+        // Returned result object.
+        const result = {};
+        result.browser = null;
+        result.version = null;
+        result.minVersion = null;
+
+        // Non supported browser.
+        if (typeof window === 'undefined' || !window.navigator) {
+            result.browser = 'Not a supported browser.';
+            return result;
+        }
+
+        // Firefox.
+        if (navigator.mozGetUserMedia) {
+            result.browser = 'firefox';
+            result.version = this.extractVersion(navigator.userAgent, /Firefox\/([0-9]+)\./, 1);
+            result.minVersion = 31;
+            return result;
+        }
+
+        // Chrome/Chromium/Webview.
+        if (navigator.webkitGetUserMedia && window.webkitRTCPeerConnection) {
+            result.browser = 'chrome';
+            result.version = this.extractVersion(navigator.userAgent, /Chrom(e|ium)\/([0-9]+)\./, 2);
+            result.minVersion = 38;
+            return result;
+        }
+
+        // Edge.
+        if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
+            result.browser = 'edge';
+            result.version = this.extractVersion(navigator.userAgent, /Edge\/(\d+).(\d+)$/, 2);
+            result.minVersion = 10547;
+            return result;
+        }
+
+        // Non supported browser default.
+        result.browser = 'Not a supported browser.';
+        return result;
+    }
+}
+
+/**
  * @typedef {Object} MicrophonePluginParams
  * @property {MediaStreamConstraints} constraints The constraints parameter is a
  * MediaStreamConstaints object with two members: video and audio, describing
@@ -18,304 +318,11 @@
  * @param  {MicrophonePluginParams} params parameters use to initialise the plugin
  * @return {PluginDefinition} an object representing the plugin
  */
-export default function(params = {}) {
+export default function createMicrophone(params) {
     return {
         name: 'microphone',
         deferInit: params && params.deferInit ? params.deferInit : false,
-        extends: 'observer',
-        instance: Observer => class MicrophonePlugin extends Observer {
-            constructor(wavesurfer) {
-                super();
-                this.params = params;
-                this.wavesurfer = wavesurfer;
-
-                this.active = false;
-                this.paused = false;
-                this.reloadBufferFunction = e => this.reloadBuffer(e);
-
-                // cross-browser getUserMedia
-                const promisifiedOldGUM = (constraints, successCallback, errorCallback) => {
-                    // get ahold of getUserMedia, if present
-                    const getUserMedia = (navigator.getUserMedia ||
-                        navigator.webkitGetUserMedia ||
-                        navigator.mozGetUserMedia ||
-                        navigator.msGetUserMedia
-                    );
-                    // Some browsers just don't implement it - return a rejected
-                    // promise with an error to keep a consistent interface
-                    if (!getUserMedia) {
-                        return Promise.reject(
-                            new Error('getUserMedia is not implemented in this browser')
-                        );
-                    }
-                    // otherwise, wrap the call to the old navigator.getUserMedia with
-                    // a Promise
-                    return new Promise((successCallback, errorCallback) => {
-                        getUserMedia.call(navigator, constraints, successCallback, errorCallback);
-                    });
-                };
-                // Older browsers might not implement mediaDevices at all, so we set an
-                // empty object first
-                if (navigator.mediaDevices === undefined) {
-                    navigator.mediaDevices = {};
-                }
-                // Some browsers partially implement mediaDevices. We can't just assign
-                // an object with getUserMedia as it would overwrite existing
-                // properties. Here, we will just add the getUserMedia property if it's
-                // missing.
-                if (navigator.mediaDevices.getUserMedia === undefined) {
-                    navigator.mediaDevices.getUserMedia = promisifiedOldGUM;
-                }
-                this.constraints = this.params.constraints || {
-                    video: false,
-                    audio: true
-                };
-                this.bufferSize = this.params.bufferSize || 4096;
-                this.numberOfInputChannels = this.params.numberOfInputChannels || 1;
-                this.numberOfOutputChannels = this.params.numberOfOutputChannels || 1;
-
-                this._onBackendCreated = () => {
-                    // wavesurfer's AudioContext where we'll route the mic signal to
-                    this.micContext = this.wavesurfer.backend.getAudioContext();
-                };
-            }
-
-            init() {
-                this.wavesurfer.on('backend-created', this._onBackendCreated);
-                if (this.wavesurfer.backend) {
-                    this._onBackendCreated();
-                }
-            }
-
-            /**
-             * Destroy the microphone plugin.
-             */
-            destroy() {
-                // make sure the buffer is not redrawn during
-                // cleanup and demolition of this plugin.
-                this.paused = true;
-
-                this.wavesurfer.un('backend-created', this._onBackendCreated);
-                this.stop();
-            }
-
-            /**
-            * Allow user to select audio input device, eg. microphone, and
-            * start the visualization.
-            */
-            start() {
-                navigator.mediaDevices.getUserMedia(this.constraints)
-                    .then((data) => this.gotStream(data))
-                    .catch((data) => this.deviceError(data));
-            }
-
-            /**
-            * Pause/resume visualization.
-            */
-            togglePlay() {
-                if (!this.active) {
-                    // start it first
-                    this.start();
-                } else {
-                    // toggle paused
-                    this.paused = !this.paused;
-
-                    if (this.paused) {
-                        this.pause();
-                    } else {
-                        this.play();
-                    }
-                }
-            }
-
-            /**
-            * Play visualization.
-            */
-            play() {
-                this.paused = false;
-
-                this.connect();
-            }
-
-            /**
-            * Pause visualization.
-            */
-            pause() {
-                this.paused = true;
-
-                // disconnect sources so they can be used elsewhere
-                // (eg. during audio playback)
-                this.disconnect();
-            }
-
-            /**
-            * Stop the device stream and remove any remaining waveform drawing from
-            * the wavesurfer canvas.
-            */
-            stop() {
-                if (this.active) {
-                    // stop visualization and device
-                    this.stopDevice();
-
-                    // empty last frame
-                    this.wavesurfer.empty();
-                }
-            }
-
-            /**
-            * Stop the device and the visualization.
-            */
-            stopDevice() {
-                this.active = false;
-
-                // stop visualization
-                this.disconnect();
-
-                // stop stream from device
-                if (this.stream) {
-                    const result = this.detectBrowser();
-                    // MediaStream.stop is deprecated since:
-                    // - Firefox 44 (https://www.fxsitecompat.com/en-US/docs/2015/mediastream-stop-has-been-deprecated/)
-                    // - Chrome 45 (https://developers.google.com/web/updates/2015/07/mediastream-deprecations)
-                    if ((result.browser === 'chrome' && result.version >= 45) ||
-                    (result.browser === 'firefox' && result.version >= 44) ||
-                    (result.browser === 'edge')) {
-                        if (this.stream.getTracks) { // note that this should not be a call
-                            this.stream.getTracks().forEach(stream => stream.stop());
-                            return;
-                        }
-                    }
-
-                    this.stream.stop();
-                }
-            }
-
-            /**
-            * Connect the media sources that feed the visualization.
-            */
-            connect() {
-                if (this.stream !== undefined) {
-                    // Create an AudioNode from the stream.
-                    this.mediaStreamSource = this.micContext.createMediaStreamSource(this.stream);
-
-                    this.levelChecker = this.micContext.createScriptProcessor(
-                        this.bufferSize,
-                        this.numberOfInputChannels,
-                        this.numberOfOutputChannels
-                    );
-                    this.mediaStreamSource.connect(this.levelChecker);
-
-                    this.levelChecker.connect(this.micContext.destination);
-                    this.levelChecker.onaudioprocess = this.reloadBufferFunction;
-                }
-            }
-
-            /**
-            * Disconnect the media sources that feed the visualization.
-            */
-            disconnect() {
-                if (this.mediaStreamSource !== undefined) {
-                    this.mediaStreamSource.disconnect();
-                }
-
-                if (this.levelChecker !== undefined) {
-                    this.levelChecker.disconnect();
-                    this.levelChecker.onaudioprocess = undefined;
-                }
-            }
-
-            /**
-            * Redraw the waveform.
-            */
-            reloadBuffer(event) {
-                if (!this.paused) {
-                    this.wavesurfer.empty();
-                    this.wavesurfer.loadDecodedBuffer(event.inputBuffer);
-                }
-            }
-
-            /**
-            * Audio input device is ready.
-            *
-            * @param {LocalMediaStream} stream: the microphone's media stream.
-            */
-            gotStream(stream) {
-                this.stream = stream;
-                this.active = true;
-
-                // start visualization
-                this.play();
-
-                // notify listeners
-                this.fireEvent('deviceReady', stream);
-            }
-
-            /**
-            * Device error callback.
-            */
-            deviceError(code) {
-                // notify listeners
-                this.fireEvent('deviceError', code);
-            }
-
-            /**
-            * Extract browser version out of the provided user agent string.
-            * @param {!string} uastring userAgent string.
-            * @param {!string} expr Regular expression used as match criteria.
-            * @param {!number} pos position in the version string to be returned.
-            * @return {!number} browser version.
-            */
-            extractVersion(uastring, expr, pos) {
-                const match = uastring.match(expr);
-                return match && match.length >= pos && parseInt(match[pos], 10);
-            }
-
-            /**
-            * Browser detector.
-            * @return {object} result containing browser, version and minVersion
-            *     properties.
-            */
-            detectBrowser() {
-                // Returned result object.
-                const result = {};
-                result.browser = null;
-                result.version = null;
-                result.minVersion = null;
-
-                // Non supported browser.
-                if (typeof window === 'undefined' || !window.navigator) {
-                    result.browser = 'Not a supported browser.';
-                    return result;
-                }
-
-                // Firefox.
-                if (navigator.mozGetUserMedia) {
-                    result.browser = 'firefox';
-                    result.version = this.extractVersion(navigator.userAgent, /Firefox\/([0-9]+)\./, 1);
-                    result.minVersion = 31;
-                    return result;
-                }
-
-                // Chrome/Chromium/Webview.
-                if (navigator.webkitGetUserMedia && window.webkitRTCPeerConnection) {
-                    result.browser = 'chrome';
-                    result.version = this.extractVersion(navigator.userAgent, /Chrom(e|ium)\/([0-9]+)\./, 2);
-                    result.minVersion = 38;
-                    return result;
-                }
-
-                // Edge.
-                if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
-                    result.browser = 'edge';
-                    result.version = this.extractVersion(navigator.userAgent, /Edge\/(\d+).(\d+)$/, 2);
-                    result.minVersion = 10547;
-                    return result;
-                }
-
-                // Non supported browser default.
-                result.browser = 'Not a supported browser.';
-                return result;
-            }
-        }
+        params: params,
+        instance: MicrophonePlugin
     };
 }

--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -1,6 +1,258 @@
 /**
+ * Minimap plugin class
+ *
+ * @implements {PluginClass}
+ * @extends {Observer}
+ */
+export class MinimapPlugin {
+    constructor(params, ws) {
+        this.params = ws.util.extend(
+            {}, ws.params, {
+                showRegions: false,
+                showOverview: false,
+                overviewBorderColor: 'green',
+                overviewBorderSize: 2,
+                // the container should be different
+                container: false,
+                height: Math.max(Math.round(ws.params.height / 4), 20)
+            }, params, {
+                scrollParent: false,
+                fillParent: true
+            }
+        );
+        // if no container is specified add a new element and insert it
+        if (!params.container) {
+            this.params.container = ws.util.style(document.createElement('minimap'), {
+                display: 'block'
+            });
+        }
+        this.drawer = new (ws.Drawer)(this.params.container, this.params);
+        this.wavesurfer = ws;
+        this.util = ws.util;
+        /**
+         * Minimap needs to register to ready and waveform-ready events to
+         * work with MediaElement, the time when ready is called is different
+         * (peaks can not be got)
+         *
+         * @type {string}
+         * @see https://github.com/katspaugh/wavesurfer.js/issues/736
+         */
+        this.renderEvent = ws.params.backend === 'MediaElement' ? 'waveform-ready' : 'ready';
+
+        // ws ready event listener
+        this._onShouldRender = () => {
+            if (!document.body.contains(this.params.container)) {
+                ws.container.insertBefore(this.params.container, null);
+            }
+            this.drawer.createWrapper();
+            this.createElements();
+            this.bindWavesurferEvents();
+            this.bindMinimapEvents();
+            if (this.wavesurfer.regions && this.params.showRegions) {
+                this.regions();
+            }
+            this.render();
+        };
+
+        this._onAudioprocess = currentTime => {
+            this.drawer.progress(this.wavesurfer.backend.getPlayedPercents());
+        };
+
+        // ws seek event listener
+        this._onSeek = () => this.drawer.progress(ws.backend.getPlayedPercents());
+
+        // event listeners for the overview region
+        this._onScroll = e => {
+            if (!this.draggingOverview) {
+                this.moveOverviewRegion(e.target.scrollLeft / this.ratio);
+            }
+        };
+        this._onMouseover = e => {
+            if (this.draggingOverview) {
+                this.draggingOverview = false;
+            }
+        };
+        let prevWidth = 0;
+        this._onResize = () => {
+            if (prevWidth != this.drawer.wrapper.clientWidth) {
+                prevWidth = this.drawer.wrapper.clientWidth;
+                this.render();
+                this.drawer.progress(ws.backend.getPlayedPercents());
+            }
+        };
+    }
+
+    init() {
+        if (this.wavesurfer.isReady) {
+            this._onShouldRender();
+        }
+        this.wavesurfer.on(this.renderEvent, this._onShouldRender);
+    }
+
+    destroy() {
+        window.removeEventListener('resize', this._onResize, true);
+        this.wavesurfer.drawer.wrapper.removeEventListener('mouseover', this._onMouseover);
+        this.wavesurfer.un(this.renderEvent, this._onShouldRender);
+        this.wavesurfer.un('seek', this._onSeek);
+        this.wavesurfer.un('scroll', this._onScroll);
+        this.wavesurfer.un('audioprocess', this._onAudioprocess);
+        this.drawer.destroy();
+        this.overviewRegion = null;
+        this.unAll();
+    }
+
+    regions() {
+        this.regions = {};
+
+        this.wavesurfer.on('region-created', region => {
+            this.regions[region.id] = region;
+            this.renderRegions();
+        });
+
+        this.wavesurfer.on('region-updated', region => {
+            this.regions[region.id] = region;
+            this.renderRegions();
+        });
+
+        this.wavesurfer.on('region-removed', region => {
+            delete this.regions[region.id];
+            this.renderRegions();
+        });
+    }
+
+    renderRegions() {
+        const regionElements = this.drawer.wrapper.querySelectorAll('region');
+        let i;
+        for (i = 0; i < regionElements.length; ++i) {
+            this.drawer.wrapper.removeChild(regionElements[i]);
+        }
+
+        Object.keys(this.regions).forEach(id => {
+            const region = this.regions[id];
+            const width = (this.drawer.width * ((region.end - region.start) / this.wavesurfer.getDuration()));
+            const left = (this.drawer.width * (region.start / this.wavesurfer.getDuration()));
+            const regionElement = this.util.style(document.createElement('region'), {
+                height: 'inherit',
+                backgroundColor: region.color,
+                width: width + 'px',
+                left: left + 'px',
+                display: 'block',
+                position: 'absolute'
+            });
+            regionElement.classList.add(id);
+            this.drawer.wrapper.appendChild(regionElement);
+        });
+    }
+
+    createElements() {
+        this.drawer.createElements();
+        if (this.params.showOverview) {
+            this.overviewRegion = this.util.style(document.createElement('overview'), {
+                height: (this.drawer.wrapper.offsetHeight - (this.params.overviewBorderSize * 2)) + 'px',
+                width: '0px',
+                display: 'block',
+                position: 'absolute',
+                cursor: 'move',
+                border: this.params.overviewBorderSize + 'px solid ' + this.params.overviewBorderColor,
+                zIndex: 2,
+                opacity: this.params.overviewOpacity
+            });
+            this.drawer.wrapper.appendChild(this.overviewRegion);
+        }
+    }
+
+    bindWavesurferEvents() {
+        window.addEventListener('resize', this._onResize, true);
+        this.wavesurfer.on('audioprocess', this._onAudioprocess);
+        this.wavesurfer.on('seek', this._onSeek);
+        if (this.params.showOverview) {
+            this.wavesurfer.on('scroll', this._onScroll);
+            this.wavesurfer.drawer.wrapper.addEventListener('mouseover', this._onMouseover);
+        }
+    }
+
+    bindMinimapEvents() {
+        const positionMouseDown = {
+            clientX: 0,
+            clientY: 0
+        };
+        let relativePositionX = 0;
+        let seek = true;
+
+        // the following event listeners will be destroyed by using
+        // this.unAll() and nullifying the DOM node references after
+        // removing them
+        this.on('click', (e, position) => {
+            if (seek) {
+                this.progress(position);
+                this.wavesurfer.seekAndCenter(position);
+            } else {
+                seek = true;
+            }
+        });
+
+        if (this.params.showOverview) {
+            this.overviewRegion.addEventListener('mousedown', event => {
+                this.draggingOverview = true;
+                relativePositionX = event.layerX;
+                positionMouseDown.clientX = event.clientX;
+                positionMouseDown.clientY = event.clientY;
+            });
+
+            this.drawer.wrapper.addEventListener('mousemove', event => {
+                if (this.draggingOverview) {
+                    this.moveOverviewRegion(event.clientX - this.drawer.container.getBoundingClientRect().left - relativePositionX);
+                }
+            });
+
+            this.drawer.wrapper.addEventListener('mouseup', event => {
+                if (positionMouseDown.clientX - event.clientX === 0 && positionMouseDown.clientX - event.clientX === 0) {
+                    seek = true;
+                    this.draggingOverview = false;
+                } else if (this.draggingOverview) {
+                    seek = false;
+                    this.draggingOverview = false;
+                }
+            });
+        }
+    }
+
+    render() {
+        const len = this.drawer.getWidth();
+        const peaks = this.wavesurfer.backend.getPeaks(len, 0, len);
+        this.drawer.drawPeaks(peaks, len, 0, len);
+
+        if (this.params.showOverview) {
+            //get proportional width of overview region considering the respective
+            //width of the drawers
+            this.ratio = this.wavesurfer.drawer.width / this.drawer.width;
+            this.waveShowedWidth = this.wavesurfer.drawer.width / this.ratio;
+            this.waveWidth = this.wavesurfer.drawer.width;
+            this.overviewWidth = (this.drawer.width / this.ratio);
+            this.overviewPosition = 0;
+            this.moveOverviewRegion(this.wavesurfer.drawer.wrapper.scrollLeft / this.ratio);
+            this.overviewRegion.style.width = (this.overviewWidth - (this.params.overviewBorderSize * 2)) + 'px';
+        }
+    }
+
+    moveOverviewRegion(pixels) {
+        if (pixels < 0) {
+            this.overviewPosition = 0;
+        } else if (pixels + this.overviewWidth < this.drawer.width) {
+            this.overviewPosition = pixels;
+        } else {
+            this.overviewPosition = (this.drawer.width - this.overviewWidth);
+        }
+        this.overviewRegion.style.left = this.overviewPosition + 'px';
+        if (this.draggingOverview) {
+            this.wavesurfer.drawer.wrapper.scrollLeft = this.overviewPosition * this.ratio;
+        }
+    }
+}
+
+/**
  * @typedef {Object} MinimapPluginParams
- * @desc Extends WavesurferParams
+ * @desc Extends the `WavesurferParams` wavesurfer was initialised with
  * @property {?string|HTMLElement} container CSS selector or HTML element where
  * the ELAN information should be renderer. By default it is simply appended
  * after the waveform.
@@ -14,251 +266,18 @@
  * @param  {MinimapPluginParams} params parameters use to initialise the plugin
  * @return {PluginDefinition} an object representing the plugin
  */
-export default function(params = {}) {
+export default function createMinimap(params) {
     return {
         name: 'minimap',
         deferInit: params && params.deferInit ? params.deferInit : false,
-        static: {
+        params: params,
+        staticProps: {
             initMinimap(customConfig) {
-                console.warn('Deprecated initMinimap! Use wavesurfer.initPlugins("minimap") instead!');
+                console.warn('Deprecated initMinimap! Use ws.initPlugins("minimap") instead!');
                 params = customConfig;
                 this.initPlugins('minimap');
             }
         },
-        extends: 'drawer',
-        instance: Drawer => class MinimapPlugin extends Drawer {
-            constructor(wavesurfer) {
-                params = wavesurfer.util.extend(
-                    {}, wavesurfer.params, {
-                        showRegions: false,
-                        showOverview: false,
-                        overviewBorderColor: 'green',
-                        overviewBorderSize: 2,
-                        // the container should be different
-                        container: false,
-                        height: Math.max(Math.round(wavesurfer.params.height / 4), 20)
-                    }, params, {
-                        scrollParent: false,
-                        fillParent: true
-                    }
-                );
-                // if no container is specified add a new element and insert it
-                if (!params.container) {
-                    params.container = wavesurfer.util.style(document.createElement('minimap'), {
-                        display: 'block'
-                    });
-                }
-                // initialise drawer superclass
-                super(params.container, params);
-                this.wavesurfer = wavesurfer;
-
-                // wavesurfer ready event listener
-                this._onReady = () => {
-                    if (!document.body.contains(params.container)) {
-                        wavesurfer.container.insertBefore(params.container, null);
-                    }
-                    super.init();
-                    if (this.wavesurfer.regions && this.params.showRegions) {
-                        this.regions();
-                    }
-                    this.bindWaveSurferEvents();
-                    this.bindMinimapEvents();
-                    this.render();
-                };
-
-                this._onAudioprocess = currentTime => {
-                    this.progress(this.wavesurfer.backend.getPlayedPercents());
-                };
-
-                // wavesurfer seek event listener
-                this._onSeek = () => this.progress(this.wavesurfer.backend.getPlayedPercents());
-
-                // event listeners for the overview region
-                this._onScroll = e => {
-                    if (!this.draggingOverview) {
-                        this.moveOverviewRegion(e.target.scrollLeft / this.ratio);
-                    }
-                };
-                this._onMouseover = e => {
-                    if (this.draggingOverview) {
-                        this.draggingOverview = false;
-                    }
-                };
-                let prevWidth = 0;
-                this._onResize = () => {
-                    if (prevWidth != this.wrapper.clientWidth) {
-                        prevWidth = this.wrapper.clientWidth;
-                        this.render();
-                        this.progress(this.wavesurfer.backend.getPlayedPercents());
-                    }
-                };
-            }
-
-            init() {
-                if (this.wavesurfer.isReady) {
-                    this._onReady();
-                }
-                this.wavesurfer.on('ready', this._onReady);
-            }
-
-            destroy() {
-                window.removeEventListener('resize', this._onResize, true);
-                this.wavesurfer.drawer.wrapper.removeEventListener('mouseover', this._onMouseover);
-                this.wavesurfer.un('ready', this._onReady);
-                this.wavesurfer.un('seek', this._onSeek);
-                this.wavesurfer.un('scroll', this._onSeek);
-                this.wavesurfer.un('audioprocess', this._onAudioprocess);
-                this.wrapper.parentNode.removeChild(this.wrapper);
-                this.wrapper = null;
-                this.overviewRegion = null;
-                this.unAll();
-            }
-
-            regions() {
-                this.regions = {};
-
-                this.wavesurfer.on('region-created', region => {
-                    this.regions[region.id] = region;
-                    this.renderRegions();
-                });
-
-                this.wavesurfer.on('region-updated', region => {
-                    this.regions[region.id] = region;
-                    this.renderRegions();
-                });
-
-                this.wavesurfer.on('region-removed', region => {
-                    delete this.regions[region.id];
-                    this.renderRegions();
-                });
-            }
-
-            renderRegions() {
-                const regionElements = this.wrapper.querySelectorAll('region');
-                let i;
-                for (i = 0; i < regionElements.length; ++i) {
-                    this.wrapper.removeChild(regionElements[i]);
-                }
-
-                Object.keys(this.regions).forEach(id => {
-                    const region = this.regions[id];
-                    const width = (this.width * ((region.end - region.start) / this.wavesurfer.getDuration()));
-                    const left = (this.width * (region.start / this.wavesurfer.getDuration()));
-                    const regionElement = this.style(document.createElement('region'), {
-                        height: 'inherit',
-                        backgroundColor: region.color,
-                        width: width + 'px',
-                        left: left + 'px',
-                        display: 'block',
-                        position: 'absolute'
-                    });
-                    regionElement.classList.add(id);
-                    this.wrapper.appendChild(regionElement);
-                });
-            }
-
-            createElements() {
-                super.createElements();
-                if (this.params.showOverview) {
-                    this.overviewRegion = this.style(document.createElement('overview'), {
-                        height: (this.wrapper.offsetHeight - (this.params.overviewBorderSize * 2)) + 'px',
-                        width: '0px',
-                        display: 'block',
-                        position: 'absolute',
-                        cursor: 'move',
-                        border: this.params.overviewBorderSize + 'px solid ' + this.params.overviewBorderColor,
-                        zIndex: 2,
-                        opacity: this.params.overviewOpacity
-                    });
-
-                    this.wrapper.appendChild(this.overviewRegion);
-                }
-            }
-
-            bindWaveSurferEvents() {
-                window.addEventListener('resize', this._onResize, true);
-                this.wavesurfer.on('audioprocess', this._onAudioprocess);
-                this.wavesurfer.on('seek', this._onSeek);
-                if (this.params.showOverview) {
-                    this.wavesurfer.on('scroll', this._onSeek);
-                    this.wavesurfer.drawer.wrapper.addEventListener('mouseover', this._onMouseover);
-                }
-            }
-
-            bindMinimapEvents() {
-                const positionMouseDown = {
-                    clientX: 0,
-                    clientY: 0
-                };
-                let relativePositionX = 0;
-                let seek = true;
-
-                // the following event listeners will be destroyed by using
-                // this.unAll() and nullifying the DOM node references after
-                // removing them
-                this.on('click', (e, position) => {
-                    if (seek) {
-                        this.progress(position);
-                        this.wavesurfer.seekAndCenter(position);
-                    } else {
-                        seek = true;
-                    }
-                });
-
-                if (this.params.showOverview) {
-                    this.overviewRegion.addEventListener('mousedown', event => {
-                        this.draggingOverview = true;
-                        relativePositionX = event.layerX;
-                        positionMouseDown.clientX = event.clientX;
-                        positionMouseDown.clientY = event.clientY;
-                    });
-
-                    this.wrapper.addEventListener('mousemove', event => {
-                        if (this.draggingOverview) {
-                            this.moveOverviewRegion(event.clientX - this.container.getBoundingClientRect().left - relativePositionX);
-                        }
-                    });
-
-                    this.wrapper.addEventListener('mouseup', event => {
-                        if (positionMouseDown.clientX - event.clientX === 0 && positionMouseDown.clientX - event.clientX === 0) {
-                            seek = true;
-                            this.draggingOverview = false;
-                        } else if (this.draggingOverview) {
-                            seek = false;
-                            this.draggingOverview = false;
-                        }
-                    });
-                }
-            }
-
-            render() {
-                const len = this.getWidth();
-                const peaks = this.wavesurfer.backend.getPeaks(len, 0, len);
-                this.drawPeaks(peaks, len, 0, len);
-
-                if (this.params.showOverview) {
-                    //get proportional width of overview region considering the respective
-                    //width of the drawers
-                    this.ratio = this.wavesurfer.drawer.width / this.width;
-                    this.waveShowedWidth = this.wavesurfer.drawer.width / this.ratio;
-                    this.waveWidth = this.wavesurfer.drawer.width;
-                    this.overviewWidth = (this.width / this.ratio);
-                    this.overviewPosition = 0;
-                    this.overviewRegion.style.width = (this.overviewWidth - (this.params.overviewBorderSize * 2)) + 'px';
-                }
-            }
-
-            moveOverviewRegion(pixels) {
-                if (pixels < 0) {
-                    this.overviewPosition = 0;
-                } else if (pixels + this.overviewWidth < this.width) {
-                    this.overviewPosition = pixels;
-                } else {
-                    this.overviewPosition = (this.width - this.overviewWidth);
-                }
-                this.overviewRegion.style.left = this.overviewPosition + 'px';
-                this.wavesurfer.drawer.wrapper.scrollLeft = this.overviewPosition * this.ratio;
-            }
-        }
+        instance: MinimapPlugin
     };
 }

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -1,369 +1,510 @@
 /**
- * Generate Region class
+ * (Single) Region plugin class
  *
- * @param {Observer} Observer
- * @return {Region}
+ * Must be turned into an observer before instantiating. This is done in
+ * RegionsPlugin (main plugin class)
+ *
+ * @extends {Observer}
  */
-function regionFactory(Observer) {
-    return class Region extends Observer {
-        init(params, wavesurfer) {
-            this.wavesurfer = wavesurfer;
-            this.wrapper = wavesurfer.drawer.wrapper;
-            this.style = wavesurfer.util.style;
+export class Region {
+    constructor(params, ws) {
+        this.wavesurfer = ws;
+        this.wrapper = ws.drawer.wrapper;
+        this.style = ws.util.style;
 
-            this.id = params.id == null ? wavesurfer.util.getId() : params.id;
-            this.start = Number(params.start) || 0;
-            this.end = params.end == null ?
-                // small marker-like region
-                this.start + (4 / this.wrapper.scrollWidth) * this.wavesurfer.getDuration() :
-                Number(params.end);
-            this.resize = params.resize === undefined ? true : Boolean(params.resize);
-            this.drag = params.drag === undefined ? true : Boolean(params.drag);
+        this.id = params.id == null ? ws.util.getId() : params.id;
+        this.start = Number(params.start) || 0;
+        this.end = params.end == null ?
+            // small marker-like region
+            this.start + (4 / this.wrapper.scrollWidth) * this.wavesurfer.getDuration() :
+            Number(params.end);
+        this.resize = params.resize === undefined ? true : Boolean(params.resize);
+        this.drag = params.drag === undefined ? true : Boolean(params.drag);
+        this.loop = Boolean(params.loop);
+        this.color = params.color || 'rgba(0, 0, 0, 0.1)';
+        this.data = params.data || {};
+        this.attributes = params.attributes || {};
+
+        this.maxLength = params.maxLength;
+        this.minLength = params.minLength;
+
+        this.bindInOut();
+        this.render();
+        this.wavesurfer.on('zoom', () => this.updateRender());
+        this.wavesurfer.fireEvent('region-created', this);
+
+    }
+
+    /* Update region params. */
+    update(params) {
+        if (null != params.start) {
+            this.start = Number(params.start);
+        }
+        if (null != params.end) {
+            this.end = Number(params.end);
+        }
+        if (null != params.loop) {
             this.loop = Boolean(params.loop);
-            this.color = params.color || 'rgba(0, 0, 0, 0.1)';
-            this.data = params.data || {};
-            this.attributes = params.attributes || {};
-
-            this.maxLength = params.maxLength;
-            this.minLength = params.minLength;
-
-            this.bindInOut();
-            this.render();
-            this.wavesurfer.on('zoom', () => this.updateRender());
-            this.wavesurfer.fireEvent('region-created', this);
-
+        }
+        if (null != params.color) {
+            this.color = params.color;
+        }
+        if (null != params.data) {
+            this.data = params.data;
+        }
+        if (null != params.resize) {
+            this.resize = Boolean(params.resize);
+        }
+        if (null != params.drag) {
+            this.drag = Boolean(params.drag);
+        }
+        if (null != params.maxLength) {
+            this.maxLength = Number(params.maxLength);
+        }
+        if (null != params.minLength) {
+            this.minLength = Number(params.minLength);
+        }
+        if (null != params.attributes) {
+            this.attributes = params.attributes;
         }
 
-        /* Update region params. */
-        update(params) {
-            if (null != params.start) {
-                this.start = Number(params.start);
-            }
-            if (null != params.end) {
-                this.end = Number(params.end);
-            }
-            if (null != params.loop) {
-                this.loop = Boolean(params.loop);
-            }
-            if (null != params.color) {
-                this.color = params.color;
-            }
-            if (null != params.data) {
-                this.data = params.data;
-            }
-            if (null != params.resize) {
-                this.resize = Boolean(params.resize);
-            }
-            if (null != params.drag) {
-                this.drag = Boolean(params.drag);
-            }
-            if (null != params.maxLength) {
-                this.maxLength = Number(params.maxLength);
-            }
-            if (null != params.minLength) {
-                this.minLength = Number(params.minLength);
-            }
-            if (null != params.attributes) {
-                this.attributes = params.attributes;
-            }
+        this.updateRender();
+        this.fireEvent('update');
+        this.wavesurfer.fireEvent('region-updated', this);
+    }
 
-            this.updateRender();
-            this.fireEvent('update');
-            this.wavesurfer.fireEvent('region-updated', this);
+    /* Remove a single region. */
+    remove() {
+        if (this.element) {
+            this.wrapper.removeChild(this.element);
+            this.element = null;
+            this.fireEvent('remove');
+            this.wavesurfer.un('zoom', pxPerSec => this.updateRender(pxPerSec));
+            this.wavesurfer.fireEvent('region-removed', this);
+        }
+    }
+
+    /* Play the audio region. */
+    play() {
+        this.wavesurfer.play(this.start, this.end);
+        this.fireEvent('play');
+        this.wavesurfer.fireEvent('region-play', this);
+    }
+
+    /* Play the region in loop. */
+    playLoop() {
+        this.play();
+        this.once('out', () => this.playLoop());
+    }
+
+    /* Render a region as a DOM element. */
+    render() {
+        const regionEl = document.createElement('region');
+        regionEl.className = 'wavesurfer-region';
+        regionEl.title = this.formatTime(this.start, this.end);
+        regionEl.setAttribute('data-id', this.id);
+
+        for (const attrname in this.attributes) {
+            regionEl.setAttribute('data-region-' + attrname, this.attributes[attrname]);
         }
 
-        /* Remove a single region. */
-        remove() {
-            if (this.element) {
-                this.wrapper.removeChild(this.element);
-                this.element = null;
-                this.fireEvent('remove');
-                this.wavesurfer.un('zoom', pxPerSec => this.updateRender(pxPerSec));
-                this.wavesurfer.fireEvent('region-removed', this);
-            }
-        }
+        const width = this.wrapper.scrollWidth;
+        this.style(regionEl, {
+            position: 'absolute',
+            zIndex: 2,
+            height: '100%',
+            top: '0px'
+        });
 
-        /* Play the audio region. */
-        play() {
-            this.wavesurfer.play(this.start, this.end);
-            this.fireEvent('play');
-            this.wavesurfer.fireEvent('region-play', this);
-        }
-
-        /* Play the region in loop. */
-        playLoop() {
-            this.play();
-            this.once('out', () => this.playLoop());
-        }
-
-        /* Render a region as a DOM element. */
-        render() {
-            const regionEl = document.createElement('region');
-            regionEl.className = 'wavesurfer-region';
-            regionEl.title = this.formatTime(this.start, this.end);
-            regionEl.setAttribute('data-id', this.id);
-
-            for (const attrname in this.attributes) {
-                regionEl.setAttribute('data-region-' + attrname, this.attributes[attrname]);
-            }
-
-            const width = this.wrapper.scrollWidth;
-            this.style(regionEl, {
+        /* Resize handles */
+        if (this.resize) {
+            const handleLeft = regionEl.appendChild(document.createElement('handle'));
+            const handleRight = regionEl.appendChild(document.createElement('handle'));
+            handleLeft.className = 'wavesurfer-handle wavesurfer-handle-start';
+            handleRight.className = 'wavesurfer-handle wavesurfer-handle-end';
+            const css = {
+                cursor: 'col-resize',
                 position: 'absolute',
-                zIndex: 2,
-                height: '100%',
-                top: '0px'
+                left: '0px',
+                top: '0px',
+                width: '1%',
+                maxWidth: '4px',
+                height: '100%'
+            };
+            this.style(handleLeft, css);
+            this.style(handleRight, css);
+            this.style(handleRight, {
+                left: '100%'
             });
-
-            /* Resize handles */
-            if (this.resize) {
-                const handleLeft = regionEl.appendChild(document.createElement('handle'));
-                const handleRight = regionEl.appendChild(document.createElement('handle'));
-                handleLeft.className = 'wavesurfer-handle wavesurfer-handle-start';
-                handleRight.className = 'wavesurfer-handle wavesurfer-handle-end';
-                const css = {
-                    cursor: 'col-resize',
-                    position: 'absolute',
-                    left: '0px',
-                    top: '0px',
-                    width: '1%',
-                    maxWidth: '4px',
-                    height: '100%'
-                };
-                this.style(handleLeft, css);
-                this.style(handleRight, css);
-                this.style(handleRight, {
-                    left: '100%'
-                });
-            }
-
-            this.element = this.wrapper.appendChild(regionEl);
-            this.updateRender();
-            this.bindEvents(regionEl);
         }
 
-        formatTime(start, end) {
-            return (start == end ? [start] : [start, end]).map(time => [
-                Math.floor((time % 3600) / 60), // minutes
-                ('00' + Math.floor(time % 60)).slice(-2) // seconds
-            ].join(':')).join('-');
+        this.element = this.wrapper.appendChild(regionEl);
+        this.updateRender();
+        this.bindEvents(regionEl);
+    }
+
+    formatTime(start, end) {
+        return (start == end ? [start] : [start, end]).map(time => [
+            Math.floor((time % 3600) / 60), // minutes
+            ('00' + Math.floor(time % 60)).slice(-2) // seconds
+        ].join(':')).join('-');
+    }
+
+    /* Update element's position, width, color. */
+    updateRender(pxPerSec) {
+        const dur = this.wavesurfer.getDuration();
+        let width;
+        if (pxPerSec) {
+            width = Math.round(this.wavesurfer.getDuration() * pxPerSec);
+        } else {
+            width = this.wrapper.scrollWidth;
         }
 
-        /* Update element's position, width, color. */
-        updateRender(pxPerSec) {
-            const dur = this.wavesurfer.getDuration();
-            let width;
-            if (pxPerSec) {
-                width = Math.round(this.wavesurfer.getDuration() * pxPerSec);
-            } else {
-                width = this.wrapper.scrollWidth;
-            }
+        if (this.start < 0) {
+            this.start = 0;
+            this.end = this.end - this.start;
+        }
+        if (this.end > dur) {
+            this.end = dur;
+            this.start = dur - (this.end - this.start);
+        }
 
-            if (this.start < 0) {
-                this.start = 0;
-                this.end = this.end - this.start;
-            }
-            if (this.end > dur) {
-                this.end = dur;
-                this.start = dur - (this.end - this.start);
-            }
+        if (this.minLength != null) {
+            this.end = Math.max(this.start + this.minLength, this.end);
+        }
 
-            if (this.minLength != null) {
-                this.end = Math.max(this.start + this.minLength, this.end);
-            }
+        if (this.maxLength != null) {
+            this.end = Math.min(this.start + this.maxLength, this.end);
+        }
 
-            if (this.maxLength != null) {
-                this.end = Math.min(this.start + this.maxLength, this.end);
-            }
-
-            if (this.element != null) {
-                // Calculate the left and width values of the region such that
-                // no gaps appear between regions.
-                const left = Math.round(this.start / dur * width);
-                const regionWidth =
+        if (this.element != null) {
+            // Calculate the left and width values of the region such that
+            // no gaps appear between regions.
+            const left = Math.round(this.start / dur * width);
+            const regionWidth =
                 Math.round(this.end / dur * width) - left;
 
-                this.style(this.element, {
-                    left: left + 'px',
-                    width: regionWidth + 'px',
-                    backgroundColor: this.color,
-                    cursor: this.drag ? 'move' : 'default'
-                });
+            this.style(this.element, {
+                left: left + 'px',
+                width: regionWidth + 'px',
+                backgroundColor: this.color,
+                cursor: this.drag ? 'move' : 'default'
+            });
 
-                for (const attrname in this.attributes) {
-                    this.element.setAttribute('data-region-' + attrname, this.attributes[attrname]);
-                }
-
-                this.element.title = this.formatTime(this.start, this.end);
+            for (const attrname in this.attributes) {
+                this.element.setAttribute('data-region-' + attrname, this.attributes[attrname]);
             }
+
+            this.element.title = this.formatTime(this.start, this.end);
         }
+    }
 
-        /* Bind audio events. */
-        bindInOut() {
-            this.firedIn = false;
-            this.firedOut = false;
+    /* Bind audio events. */
+    bindInOut() {
+        this.firedIn = false;
+        this.firedOut = false;
 
-            const onProcess = time => {
-                if (!this.firedOut && this.firedIn && (this.start >= Math.round(time * 100) / 100 || this.end <= Math.round(time * 100) / 100)) {
-                    this.firedOut = true;
-                    this.firedIn = false;
-                    this.fireEvent('out');
-                    this.wavesurfer.fireEvent('region-out', this);
+        const onProcess = time => {
+            if (!this.firedOut && this.firedIn && (this.start >= Math.round(time * 100) / 100 || this.end <= Math.round(time * 100) / 100)) {
+                this.firedOut = true;
+                this.firedIn = false;
+                this.fireEvent('out');
+                this.wavesurfer.fireEvent('region-out', this);
+            }
+            if (!this.firedIn && this.start <= time && this.end > time) {
+                this.firedIn = true;
+                this.firedOut = false;
+                this.fireEvent('in');
+                this.wavesurfer.fireEvent('region-in', this);
+            }
+        };
+
+        this.wavesurfer.backend.on('audioprocess', onProcess);
+
+        this.on('remove', () => {
+            this.wavesurfer.backend.un('audioprocess', onProcess);
+        });
+
+        /* Loop playback. */
+        this.on('out', () => {
+            if (this.loop) {
+                this.wavesurfer.play(this.start);
+            }
+        });
+    }
+
+    /* Bind DOM events. */
+    bindEvents() {
+        this.element.addEventListener('mouseenter', e => {
+            this.fireEvent('mouseenter', e);
+            this.wavesurfer.fireEvent('region-mouseenter', this, e);
+        });
+
+        this.element.addEventListener('mouseleave', e => {
+            this.fireEvent('mouseleave', e);
+            this.wavesurfer.fireEvent('region-mouseleave', this, e);
+        });
+
+        this.element.addEventListener('click', e => {
+            e.preventDefault();
+            this.fireEvent('click', e);
+            this.wavesurfer.fireEvent('region-click', this, e);
+        });
+
+        this.element.addEventListener('dblclick', e => {
+            e.stopPropagation();
+            e.preventDefault();
+            this.fireEvent('dblclick', e);
+            this.wavesurfer.fireEvent('region-dblclick', this, e);
+        });
+
+        /* Drag or resize on mousemove. */
+        (this.drag || this.resize) && (() => {
+            const duration = this.wavesurfer.getDuration();
+            let startTime;
+            let touchId;
+            let drag;
+            let resize;
+
+            const onDown = e => {
+                if (e.touches && e.touches.length > 1) { return; }
+                touchId = e.targetTouches ? e.targetTouches[0].identifier : null;
+
+                e.stopPropagation();
+                startTime = this.wavesurfer.drawer.handleEvent(e, true) * duration;
+
+                if (e.target.tagName.toLowerCase() == 'handle') {
+                    if (e.target.classList.contains('wavesurfer-handle-start')) {
+                        resize = 'start';
+                    } else {
+                        resize = 'end';
+                    }
+                } else {
+                    drag = true;
+                    resize = false;
                 }
-                if (!this.firedIn && this.start <= time && this.end > time) {
-                    this.firedIn = true;
-                    this.firedOut = false;
-                    this.fireEvent('in');
-                    this.wavesurfer.fireEvent('region-in', this);
+            };
+            const onUp = e => {
+                if (e.touches && e.touches.length > 1) { return; }
+
+                if (drag || resize) {
+                    drag = false;
+                    resize = false;
+
+                    this.fireEvent('update-end', e);
+                    this.wavesurfer.fireEvent('region-update-end', this, e);
+                }
+            };
+            const onMove = e => {
+                if (e.touches && e.touches.length > 1) { return; }
+                if (e.targetTouches && e.targetTouches[0].identifier != touchId) { return; }
+
+                if (drag || resize) {
+                    const time = this.wavesurfer.drawer.handleEvent(e) * duration;
+                    const delta = time - startTime;
+                    startTime = time;
+
+                    // Drag
+                    if (this.drag && drag) {
+                        this.onDrag(delta);
+                    }
+
+                    // Resize
+                    if (this.resize && resize) {
+                        this.onResize(delta, resize);
+                    }
                 }
             };
 
-            this.wavesurfer.backend.on('audioprocess', onProcess);
+            this.element.addEventListener('mousedown', onDown);
+            this.element.addEventListener('touchstart', onDown);
+
+            this.wrapper.addEventListener('mousemove', onMove);
+            this.wrapper.addEventListener('touchmove', onMove);
+
+            document.body.addEventListener('mouseup', onUp);
+            document.body.addEventListener('touchend', onUp);
 
             this.on('remove', () => {
-                this.wavesurfer.backend.un('audioprocess', onProcess);
+                document.body.removeEventListener('mouseup', onUp);
+                document.body.removeEventListener('touchend', onUp);
+                this.wrapper.removeEventListener('mousemove', onMove);
+                this.wrapper.removeEventListener('touchmove', onMove);
             });
 
-            /* Loop playback. */
-            this.on('out', () => {
-                if (this.loop) {
-                    this.wavesurfer.play(this.start);
-                }
+            this.wavesurfer.on('destroy', () => {
+                document.body.removeEventListener('mouseup', onUp);
+                document.body.removeEventListener('touchend', onUp);
             });
+        })();
+    }
+
+    onDrag(delta) {
+        const maxEnd = this.wavesurfer.getDuration();
+        if ((this.end + delta) > maxEnd || (this.start + delta) < 0) {
+            return;
         }
 
-        /* Bind DOM events. */
-        bindEvents() {
-            this.element.addEventListener('mouseenter', e => {
-                this.fireEvent('mouseenter', e);
-                this.wavesurfer.fireEvent('region-mouseenter', this, e);
-            });
+        this.update({
+            start: this.start + delta,
+            end: this.end + delta
+        });
+    }
 
-            this.element.addEventListener('mouseleave', e => {
-                this.fireEvent('mouseleave', e);
-                this.wavesurfer.fireEvent('region-mouseleave', this, e);
-            });
-
-            this.element.addEventListener('click', e => {
-                e.preventDefault();
-                this.fireEvent('click', e);
-                this.wavesurfer.fireEvent('region-click', this, e);
-            });
-
-            this.element.addEventListener('dblclick', e => {
-                e.stopPropagation();
-                e.preventDefault();
-                this.fireEvent('dblclick', e);
-                this.wavesurfer.fireEvent('region-dblclick', this, e);
-            });
-
-            /* Drag or resize on mousemove. */
-            (this.drag || this.resize) && (() => {
-                const duration = this.wavesurfer.getDuration();
-                let startTime;
-                let touchId;
-                let drag;
-                let resize;
-
-                const onDown = e => {
-                    if (e.touches && e.touches.length > 1) { return; }
-                    touchId = e.targetTouches ? e.targetTouches[0].identifier : null;
-
-                    e.stopPropagation();
-                    startTime = this.wavesurfer.drawer.handleEvent(e, true) * duration;
-
-                    if (e.target.tagName.toLowerCase() == 'handle') {
-                        if (e.target.classList.contains('wavesurfer-handle-start')) {
-                            resize = 'start';
-                        } else {
-                            resize = 'end';
-                        }
-                    } else {
-                        drag = true;
-                        resize = false;
-                    }
-                };
-                const onUp = e => {
-                    if (e.touches && e.touches.length > 1) { return; }
-
-                    if (drag || resize) {
-                        drag = false;
-                        resize = false;
-
-                        this.fireEvent('update-end', e);
-                        this.wavesurfer.fireEvent('region-update-end', this, e);
-                    }
-                };
-                const onMove = e => {
-                    if (e.touches && e.touches.length > 1) { return; }
-                    if (e.targetTouches && e.targetTouches[0].identifier != touchId) { return; }
-
-                    if (drag || resize) {
-                        const time = this.wavesurfer.drawer.handleEvent(e) * duration;
-                        const delta = time - startTime;
-                        startTime = time;
-
-                        // Drag
-                        if (this.drag && drag) {
-                            this.onDrag(delta);
-                        }
-
-                        // Resize
-                        if (this.resize && resize) {
-                            this.onResize(delta, resize);
-                        }
-                    }
-                };
-
-                this.element.addEventListener('mousedown', onDown);
-                this.element.addEventListener('touchstart', onDown);
-
-                this.wrapper.addEventListener('mousemove', onMove);
-                this.wrapper.addEventListener('touchmove', onMove);
-
-                document.body.addEventListener('mouseup', onUp);
-                document.body.addEventListener('touchend', onUp);
-
-                this.on('remove', () => {
-                    document.body.removeEventListener('mouseup', onUp);
-                    document.body.removeEventListener('touchend', onUp);
-                    this.wrapper.removeEventListener('mousemove', onMove);
-                    this.wrapper.removeEventListener('touchmove', onMove);
-                });
-
-                this.wavesurfer.on('destroy', () => {
-                    document.body.removeEventListener('mouseup', onUp);
-                    document.body.removeEventListener('touchend', onUp);
-                });
-            })();
-        }
-
-        onDrag(delta) {
-            const maxEnd = this.wavesurfer.getDuration();
-            if ((this.end + delta) > maxEnd || (this.start + delta) < 0) {
-                return;
-            }
-
+    onResize(delta, direction) {
+        if (direction == 'start') {
             this.update({
-                start: this.start + delta,
-                end: this.end + delta
+                start: Math.min(this.start + delta, this.end),
+                end: Math.max(this.start + delta, this.end)
+            });
+        } else {
+            this.update({
+                start: Math.min(this.end + delta, this.start),
+                end: Math.max(this.end + delta, this.start)
             });
         }
+    }
+}
 
-        onResize(delta, direction) {
-            if (direction == 'start') {
-                this.update({
-                    start: Math.min(this.start + delta, this.end),
-                    end: Math.max(this.start + delta, this.end)
-                });
-            } else {
-                this.update({
-                    start: Math.min(this.end + delta, this.start),
-                    end: Math.max(this.end + delta, this.start)
+/**
+ * Regions plugin class
+ *
+ * @implements {PluginClass}
+ * @extends {Observer}
+ */
+export class RegionsPlugin {
+    constructor(params, ws) {
+        this.params = params;
+        this.wavesurfer = ws;
+        this.util = ws.util;
+
+        // turn the plugin instance into an observer
+        const observerPrototypeKeys = Object.getOwnPropertyNames(this.util.Observer.prototype);
+        observerPrototypeKeys.forEach(key => {
+            Region.prototype[key] = this.util.Observer.prototype[key];
+        });
+        this.wavesurfer.Region = Region;
+
+        // Id-based hash of regions.
+        this.list = {};
+        this._onReady = () => {
+            this.wrapper = this.wavesurfer.drawer.wrapper;
+            if (this.params.regions) {
+                this.params.regions.forEach(region => {
+                    this.add(region);
                 });
             }
+            if (this.params.dragSelection) {
+                this.enableDragSelection(this.params.dragSelection);
+            }
+        };
+    }
+
+    init() {
+        // Check if ws is ready
+        if (this.wavesurfer.isReady) {
+            this._onReady();
         }
-    };
+        this.wavesurfer.on('ready', this._onReady);
+    }
+
+    destroy() {
+        this.wavesurfer.un('ready', this._onReady);
+        this.disableDragSelection();
+        this.clear();
+    }
+    /* Add a region. */
+    add(params) {
+        const region = new this.wavesurfer.Region(params, this.wavesurfer);
+
+        this.list[region.id] = region;
+
+        region.on('remove', () => {
+            delete this.list[region.id];
+        });
+
+        return region;
+    }
+
+    /* Remove all regions. */
+    clear() {
+        Object.keys(this.list).forEach(id => {
+            this.list[id].remove();
+        });
+    }
+
+    enableDragSelection(params) {
+        const slop = params.slop || 2;
+        let drag;
+        let start;
+        let region;
+        let touchId;
+        let pxMove = 0;
+
+        const eventDown = e => {
+            if (e.touches && e.touches.length > 1) { return; }
+            touchId = e.targetTouches ? e.targetTouches[0].identifier : null;
+
+            drag = true;
+            start = this.wavesurfer.drawer.handleEvent(e, true);
+            region = null;
+        };
+        this.wrapper.addEventListener('mousedown', eventDown);
+        this.wrapper.addEventListener('touchstart', eventDown);
+        this.on('disable-drag-selection', () => {
+            this.wrapper.removeEventListener('touchstart', eventDown);
+            this.wrapper.removeEventListener('mousedown', eventDown);
+        });
+
+        const eventUp = e => {
+            if (e.touches && e.touches.length > 1) { return; }
+
+            drag = false;
+            pxMove = 0;
+
+            if (region) {
+                region.fireEvent('update-end', e);
+                this.wavesurfer.fireEvent('region-update-end', region, e);
+            }
+
+            region = null;
+        };
+        this.wrapper.addEventListener('mouseup', eventUp);
+        this.wrapper.addEventListener('touchend', eventUp);
+        this.on('disable-drag-selection', () => {
+            this.wrapper.removeEventListener('touchend', eventUp);
+            this.wrapper.removeEventListener('mouseup', eventUp);
+        });
+
+        const eventMove = e => {
+            if (!drag) { return; }
+            if (++pxMove <= slop) { return; }
+
+            if (e.touches && e.touches.length > 1) { return; }
+            if (e.targetTouches && e.targetTouches[0].identifier != touchId) { return; }
+
+            if (!region) {
+                region = this.add(params || {});
+            }
+
+            const duration = this.wavesurfer.getDuration();
+            const end = this.wavesurfer.drawer.handleEvent(e);
+            region.update({
+                start: Math.min(end * duration, start * duration),
+                end: Math.max(end * duration, start * duration)
+            });
+        };
+        this.wrapper.addEventListener('mousemove', eventMove);
+        this.wrapper.addEventListener('touchmove', eventMove);
+        this.on('disable-drag-selection', () => {
+            this.wrapper.removeEventListener('touchmove', eventMove);
+            this.wrapper.removeEventListener('mousemove', eventMove);
+        });
+    }
+
+    disableDragSelection() {
+        this.fireEvent('disable-drag-selection');
+    }
 }
 
 /**
@@ -396,12 +537,12 @@ function regionFactory(Observer) {
  * @param {RegionsPluginParams} params parameters use to initialise the plugin
  * @return {PluginDefinition} an object representing the plugin
  */
-export default function regions(params = {}) {
+export default function createRegions(params) {
     return {
         name: 'regions',
         deferInit: params && params.deferInit ? params.deferInit : false,
-        extends: 'observer',
-        static: {
+        params: params,
+        staticProps: {
             initRegions() {
                 console.warn('Deprecated initRegions! Use wavesurfer.initPlugins("regions") instead!');
                 this.initPlugin('regions');
@@ -429,136 +570,6 @@ export default function regions(params = {}) {
                 this.regions.disableDragSelection();
             }
         },
-        instance: Observer => class RegionsPlugin extends Observer {
-            constructor(wavesurfer) {
-                super();
-                this.params = params;
-                this.wavesurfer = wavesurfer;
-
-                // generate Region class from Observer
-                this.wavesurfer.Region = regionFactory(wavesurfer.util.Observer);
-
-                // Id-based hash of regions.
-                this.list = {};
-                this._onReady = () => {
-                    this.wrapper = this.wavesurfer.drawer.wrapper;
-                    if (this.params.regions) {
-                        this.params.regions.forEach(region => {
-                            this.add(region);
-                        });
-                    }
-                    if (this.params.dragSelection) {
-                        this.enableDragSelection(this.params.dragSelection);
-                    }
-                };
-            }
-
-            init() {
-                // Check if ws is ready
-                if (this.wavesurfer.isReady) {
-                    this._onReady();
-                }
-                this.wavesurfer.on('ready', this._onReady);
-            }
-
-            destroy() {
-                this.wavesurfer.un('ready', this._onReady);
-                this.disableDragSelection();
-                this.clear();
-            }
-            /* Add a region. */
-            add(params) {
-                const region = new this.wavesurfer.Region();
-                region.init(params, this.wavesurfer);
-
-                this.list[region.id] = region;
-
-                region.on('remove', () => {
-                    delete this.list[region.id];
-                });
-
-                return region;
-            }
-
-            /* Remove all regions. */
-            clear() {
-                Object.keys(this.list).forEach(id => {
-                    this.list[id].remove();
-                });
-            }
-
-            enableDragSelection(params) {
-                const slop = params.slop || 2;
-                let drag;
-                let start;
-                let region;
-                let touchId;
-                let pxMove = 0;
-
-                const eventDown = e => {
-                    if (e.touches && e.touches.length > 1) { return; }
-                    touchId = e.targetTouches ? e.targetTouches[0].identifier : null;
-
-                    drag = true;
-                    start = this.wavesurfer.drawer.handleEvent(e, true);
-                    region = null;
-                };
-                this.wrapper.addEventListener('mousedown', eventDown);
-                this.wrapper.addEventListener('touchstart', eventDown);
-                this.on('disable-drag-selection', () => {
-                    this.wrapper.removeEventListener('touchstart', eventDown);
-                    this.wrapper.removeEventListener('mousedown', eventDown);
-                });
-
-                const eventUp = e => {
-                    if (e.touches && e.touches.length > 1) { return; }
-
-                    drag = false;
-                    pxMove = 0;
-
-                    if (region) {
-                        region.fireEvent('update-end', e);
-                        this.wavesurfer.fireEvent('region-update-end', region, e);
-                    }
-
-                    region = null;
-                };
-                this.wrapper.addEventListener('mouseup', eventUp);
-                this.wrapper.addEventListener('touchend', eventUp);
-                this.on('disable-drag-selection', () => {
-                    this.wrapper.removeEventListener('touchend', eventUp);
-                    this.wrapper.removeEventListener('mouseup', eventUp);
-                });
-
-                const eventMove = e => {
-                    if (!drag) { return; }
-                    if (++pxMove <= slop) { return; }
-
-                    if (e.touches && e.touches.length > 1) { return; }
-                    if (e.targetTouches && e.targetTouches[0].identifier != touchId) { return; }
-
-                    if (!region) {
-                        region = this.add(params || {});
-                    }
-
-                    const duration = this.wavesurfer.getDuration();
-                    const end = this.wavesurfer.drawer.handleEvent(e);
-                    region.update({
-                        start: Math.min(end * duration, start * duration),
-                        end: Math.max(end * duration, start * duration)
-                    });
-                };
-                this.wrapper.addEventListener('mousemove', eventMove);
-                this.wrapper.addEventListener('touchmove', eventMove);
-                this.on('disable-drag-selection', () => {
-                    this.wrapper.removeEventListener('touchmove', eventMove);
-                    this.wrapper.removeEventListener('mousemove', eventMove);
-                });
-            }
-
-            disableDragSelection() {
-                this.fireEvent('disable-drag-selection');
-            }
-        }
+        instance: RegionsPlugin
     };
 }

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -1,6 +1,303 @@
 /**
+ * Timeline plugin class
+ *
+ * @implements {PluginClass}
+ * @extends {Observer}
+ */
+export class TimelinePlugin {
+    constructor(params, ws) {
+        this.container = 'string' == typeof params.container
+            ? document.querySelector(params.container)
+            : params.container;
+
+        if (!this.container) {
+            throw new Error('No container for wavesurfer timeline');
+        }
+        this.wavesurfer = ws;
+        this.util = ws.util;
+        this.params = this.util.extend({}, {
+            height: 20,
+            notchPercentHeight: 90,
+            primaryColor: '#000',
+            secondaryColor: '#c0c0c0',
+            primaryFontColor: '#000',
+            secondaryFontColor: '#000',
+            fontFamily: 'Arial',
+            fontSize: 10,
+            formatTimeCallback(seconds) {
+                if (seconds / 60 > 1) {
+                    // calculate minutes and seconds from seconds count
+                    const minutes = parseInt(seconds / 60, 10);
+                    seconds = parseInt(seconds % 60, 10);
+                    // fill up seconds with zeroes
+                    seconds = (seconds < 10) ? '0' + seconds : seconds;
+                    return `${minutes}:${seconds}`;
+                }
+                return seconds;
+            },
+            timeInterval(pxPerSec) {
+                if (pxPerSec >= 25) {
+                    return 1;
+                } else if (pxPerSec * 5 >= 25) {
+                    return 5;
+                } else if (pxPerSec * 15 >= 25) {
+                    return 15;
+                }
+                return 60;
+            },
+            primaryLabelInterval(pxPerSec) {
+                if (pxPerSec >= 25) {
+                    return 10;
+                } else if (pxPerSec * 5 >= 25) {
+                    return 6;
+                } else if (pxPerSec * 15 >= 25) {
+                    return 4;
+                }
+                return 4;
+            },
+            secondaryLabelInterval(pxPerSec) {
+                if (pxPerSec >= 25) {
+                    return 5;
+                } else if (pxPerSec * 5 >= 25) {
+                    return 2;
+                } else if (pxPerSec * 15 >= 25) {
+                    return 2;
+                }
+                return 2;
+            }
+        }, params);
+
+        this.canvases = [];
+
+        this._onScroll = () => {
+            this.wrapper.scrollLeft = this.drawer.wrapper.scrollLeft;
+        };
+        this._onRedraw = () => this.render();
+        this._onReady = () => {
+            this.drawer = ws.drawer;
+            this.pixelRatio = ws.drawer.params.pixelRatio;
+            this.maxCanvasWidth = ws.drawer.maxCanvasWidth || ws.drawer.width;
+            this.maxCanvasElementWidth = ws.drawer.maxCanvasElementWidth || Math.round(this.maxCanvasWidth / this.pixelRatio);
+
+            this.createWrapper();
+            this.render();
+            ws.drawer.wrapper.addEventListener('scroll', this._onScroll);
+            ws.on('redraw', this._onRedraw);
+        };
+    }
+
+    init() {
+        this.wavesurfer.on('ready', this._onReady);
+        // Check if ws is ready
+        if (this.wavesurfer.isReady) {
+            this._onReady();
+        }
+    }
+
+    destroy() {
+        this.unAll();
+        this.wavesurfer.un('redraw', this._onRedraw);
+        this.wavesurfer.un('ready', this._onReady);
+        this.wavesurfer.drawer.wrapper.removeEventListener('scroll', this._onScroll);
+        if (this.wrapper && this.wrapper.parentNode) {
+            this.wrapper.parentNode.removeChild(this.wrapper);
+            this.wrapper = null;
+        }
+    }
+
+    createWrapper() {
+        const wsParams = this.wavesurfer.params;
+        this.wrapper = this.container.appendChild(
+            document.createElement('timeline')
+        );
+        this.util.style(this.wrapper, {
+            display: 'block',
+            position: 'relative',
+            userSelect: 'none',
+            webkitUserSelect: 'none',
+            height: `${this.params.height}px`
+        });
+
+        if (wsParams.fillParent || wsParams.scrollParent) {
+            this.util.style(this.wrapper, {
+                width: '100%',
+                overflowX: 'hidden',
+                overflowY: 'hidden'
+            });
+        }
+
+        this._onClick = e => {
+            e.preventDefault();
+            const relX = 'offsetX' in e ? e.offsetX : e.layerX;
+            this.fireEvent('click', (relX / this.wrapper.scrollWidth) || 0);
+        };
+        this.wrapper.addEventListener('click', this._onClick);
+    }
+
+    removeOldCanvases() {
+        while (this.canvases.length > 0) {
+            const canvas = this.canvases.pop();
+            canvas.parentElement.removeChild(canvas);
+        }
+    }
+
+    createCanvases() {
+        this.removeOldCanvases();
+
+        const totalWidth = Math.round(this.drawer.wrapper.scrollWidth);
+        const requiredCanvases = Math.ceil(totalWidth / this.maxCanvasElementWidth);
+        let i;
+
+        for (i = 0; i < requiredCanvases; i++) {
+            const canvas = this.wrapper.appendChild(document.createElement('canvas'));
+            this.canvases.push(canvas);
+            this.util.style(canvas, {
+                position: 'absolute',
+                zIndex: 4
+            });
+        }
+    }
+
+    render() {
+        this.createCanvases();
+        this.updateCanvasStyle();
+        this.drawTimeCanvases();
+    }
+
+    updateCanvasStyle() {
+        const requiredCanvases = this.canvases.length;
+        let i;
+        for (i = 0; i < requiredCanvases; i++) {
+            const canvas = this.canvases[i];
+            let canvasWidth = this.maxCanvasElementWidth;
+
+            if (i === requiredCanvases - 1) {
+                canvasWidth = this.drawer.wrapper.scrollWidth - (this.maxCanvasElementWidth * (requiredCanvases - 1));
+            }
+
+            canvas.width = canvasWidth * this.pixelRatio;
+            canvas.height = this.params.height * this.pixelRatio;
+            this.util.style(canvas, {
+                width: `${canvasWidth}px`,
+                height: `${this.params.height}px`,
+                left: `${i * this.maxCanvasElementWidth}px`
+            });
+        }
+    }
+
+    drawTimeCanvases() {
+        const backend = this.wavesurfer.backend;
+        const wsParams = this.wavesurfer.params;
+        const duration = this.wavesurfer.backend.getDuration();
+        const totalSeconds = parseInt(duration, 10) + 1;
+        const width = wsParams.fillParent && !wsParams.scrollParent
+            ? this.drawer.getWidth()
+            : this.drawer.wrapper.scrollWidth * wsParams.pixelRatio;
+        const pixelsPerSecond = width / duration;
+
+        const formatTime = this.params.formatTimeCallback;
+        // if parameter is function, call the function with
+        // pixelsPerSecond, otherwise simply take the value as-is
+        const intervalFnOrVal = option => (typeof option === 'function' ? option(pixelsPerSecond) : option);
+        const timeInterval = intervalFnOrVal(this.params.timeInterval);
+        const primaryLabelInterval = intervalFnOrVal(this.params.primaryLabelInterval);
+        const secondaryLabelInterval = intervalFnOrVal(this.params.secondaryLabelInterval);
+
+        let curPixel = 0;
+        let curSeconds = 0;
+
+        if (duration <= 0) {
+            return;
+        }
+
+        const height1 = this.params.height - 4;
+        const height2 = (this.params.height * (this.params.notchPercentHeight / 100)) - 4;
+        const fontSize = this.params.fontSize * wsParams.pixelRatio;
+        let i;
+
+        for (i = 0; i < totalSeconds / timeInterval; i++) {
+            if (i % primaryLabelInterval == 0) {
+                this.setFillStyles(this.params.primaryColor);
+                this.fillRect(curPixel, 0, 1, height1);
+                this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
+                this.setFillStyles(this.params.primaryFontColor);
+                this.fillText(formatTime(curSeconds), curPixel + 5, height1);
+            } else if (i % secondaryLabelInterval == 0) {
+                this.setFillStyles(this.params.secondaryColor);
+                this.fillRect(curPixel, 0, 1, height1);
+                this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
+                this.setFillStyles(this.params.secondaryFontColor);
+                this.fillText(formatTime(curSeconds), curPixel + 5, height1);
+            } else {
+                this.setFillStyles(this.params.secondaryColor);
+                this.fillRect(curPixel, 0, 1, height2);
+            }
+
+            curSeconds += timeInterval;
+            curPixel += pixelsPerSecond * timeInterval;
+        }
+    }
+
+    setFillStyles(fillStyle) {
+        this.canvases.forEach(canvas => {
+            canvas.getContext('2d').fillStyle = fillStyle;
+        });
+    }
+
+    setFonts(font) {
+        this.canvases.forEach(canvas => {
+            canvas.getContext('2d').font = font;
+        });
+    }
+
+    fillRect(x, y, width, height) {
+        this.canvases.forEach((canvas, i) => {
+            const leftOffset = i * this.maxCanvasWidth;
+
+            const intersection = {
+                x1: Math.max(x, i * this.maxCanvasWidth),
+                y1: y,
+                x2: Math.min(x + width, i * this.maxCanvasWidth + canvas.width),
+                y2: y + height
+            };
+
+            if (intersection.x1 < intersection.x2) {
+                canvas.getContext('2d').fillRect(
+                    intersection.x1 - leftOffset,
+                    intersection.y1,
+                    intersection.x2 - intersection.x1,
+                    intersection.y2 - intersection.y1
+                );
+            }
+        });
+    }
+
+    fillText(text, x, y) {
+        let textWidth;
+        let xOffset = 0;
+        let i;
+
+        for (i in this.canvases) {
+            const context = this.canvases[i].getContext('2d');
+            const canvasWidth = context.canvas.width;
+
+            if (xOffset > x + textWidth) {
+                break;
+            }
+
+            if (xOffset + canvasWidth > x) {
+                textWidth = context.measureText(text).width;
+                context.fillText(text, x - xOffset, y);
+            }
+
+            xOffset += canvasWidth;
+        }
+    }
+}
+
+/**
  * @typedef {Object} TimelinePluginParams
- * @desc Extends WavesurferParams
+ * @desc Extends the `WavesurferParams` wavesurfer was initialised with
  * @property {!string|HTMLElement} container CSS selector or HTML element where
  * the timeline should be drawn. This is the only required parameter.
  * @property {number} notchPercentHeight=90 Height of notches in percent
@@ -24,304 +321,11 @@
  * @param  {TimelinePluginParams} params parameters use to initialise the plugin
  * @return {PluginDefinition} an object representing the plugin
  */
-export default function(params = {}) {
+export default function createTimeline(params) {
     return {
         name: 'timeline',
         deferInit: params && params.deferInit ? params.deferInit : false,
-        extends: 'observer',
-        instance: Observer => class TimelinePlugin extends Observer {
-            constructor(wavesurfer) {
-                super();
-                this.params = params;
-                this.wavesurfer = wavesurfer;
-                this.style = wavesurfer.util.style;
-
-                this.container = 'string' == typeof params.container
-                    ? document.querySelector(params.container)
-                    : params.container;
-
-                if (!this.container) {
-                    throw new Error('No container for WaveSurfer timeline');
-                }
-
-                this.params = wavesurfer.util.extend({}, {
-                    height: 20,
-                    notchPercentHeight: 90,
-                    primaryColor: '#000',
-                    secondaryColor: '#c0c0c0',
-                    primaryFontColor: '#000',
-                    secondaryFontColor: '#000',
-                    fontFamily: 'Arial',
-                    fontSize: 10,
-                    formatTimeCallback(seconds) {
-                        if (seconds / 60 > 1) {
-                            // calculate minutes and seconds from seconds count
-                            const minutes = parseInt(seconds / 60, 10);
-                            seconds = parseInt(seconds % 60, 10);
-                            // fill up seconds with zeroes
-                            seconds = (seconds < 10) ? '0' + seconds : seconds;
-                            return `${minutes}:${seconds}`;
-                        }
-                        return seconds;
-                    },
-                    timeInterval(pxPerSec) {
-                        if (pxPerSec >= 25) {
-                            return 1;
-                        } else if (pxPerSec * 5 >= 25) {
-                            return 5;
-                        } else if (pxPerSec * 15 >= 25) {
-                            return 15;
-                        }
-                        return 60;
-                    },
-                    primaryLabelInterval(pxPerSec) {
-                        if (pxPerSec >= 25) {
-                            return 10;
-                        } else if (pxPerSec * 5 >= 25) {
-                            return 6;
-                        } else if (pxPerSec * 15 >= 25) {
-                            return 4;
-                        }
-                        return 4;
-                    },
-                    secondaryLabelInterval(pxPerSec) {
-                        if (pxPerSec >= 25) {
-                            return 5;
-                        } else if (pxPerSec * 5 >= 25) {
-                            return 2;
-                        } else if (pxPerSec * 15 >= 25) {
-                            return 2;
-                        }
-                        return 2;
-                    }
-                }, params);
-
-                this.canvases = [];
-
-                this._onScroll = () => {
-                    this.wrapper.scrollLeft = this.drawer.wrapper.scrollLeft;
-                };
-                this._onRedraw = () => this.render();
-                this._onReady = () => {
-                    this.drawer = wavesurfer.drawer;
-                    this.pixelRatio = wavesurfer.drawer.params.pixelRatio;
-                    this.maxCanvasWidth = wavesurfer.drawer.maxCanvasWidth || wavesurfer.drawer.width;
-                    this.maxCanvasElementWidth = wavesurfer.drawer.maxCanvasElementWidth || Math.round(this.maxCanvasWidth / this.pixelRatio);
-
-                    this.createWrapper();
-                    this.render();
-                    wavesurfer.drawer.wrapper.addEventListener('scroll', this._onScroll);
-                    wavesurfer.on('redraw', this._onRedraw);
-                };
-            }
-
-            init() {
-                this.wavesurfer.on('ready', this._onReady);
-                // Check if ws is ready
-                if (this.wavesurfer.isReady) {
-                    this._onReady();
-                }
-            }
-
-            destroy() {
-                this.unAll();
-                this.wavesurfer.un('redraw', this._onRedraw);
-                this.wavesurfer.un('ready', this._onReady);
-                this.wavesurfer.drawer.wrapper.removeEventListener('scroll', this._onScroll);
-                if (this.wrapper && this.wrapper.parentNode) {
-                    this.wrapper.parentNode.removeChild(this.wrapper);
-                    this.wrapper = null;
-                }
-            }
-
-            createWrapper() {
-                const wsParams = this.wavesurfer.params;
-                this.wrapper = this.container.appendChild(
-                    document.createElement('timeline')
-                );
-                this.style(this.wrapper, {
-                    display: 'block',
-                    position: 'relative',
-                    userSelect: 'none',
-                    webkitUserSelect: 'none',
-                    height: `${this.params.height}px`
-                });
-
-                if (wsParams.fillParent || wsParams.scrollParent) {
-                    this.style(this.wrapper, {
-                        width: '100%',
-                        overflowX: 'hidden',
-                        overflowY: 'hidden'
-                    });
-                }
-
-                this._onClick = e => {
-                    e.preventDefault();
-                    const relX = 'offsetX' in e ? e.offsetX : e.layerX;
-                    this.fireEvent('click', (relX / this.wrapper.scrollWidth) || 0);
-                };
-                this.wrapper.addEventListener('click', this._onClick);
-            }
-
-            removeOldCanvases() {
-                while (this.canvases.length > 0) {
-                    const canvas = this.canvases.pop();
-                    canvas.parentElement.removeChild(canvas);
-                }
-            }
-
-            createCanvases() {
-                this.removeOldCanvases();
-
-                const totalWidth = Math.round(this.drawer.wrapper.scrollWidth);
-                const requiredCanvases = Math.ceil(totalWidth / this.maxCanvasElementWidth);
-                let i;
-
-                for (i = 0; i < requiredCanvases; i++) {
-                    const canvas = this.wrapper.appendChild(document.createElement('canvas'));
-                    this.canvases.push(canvas);
-                    this.style(canvas, {
-                        position: 'absolute',
-                        zIndex: 4
-                    });
-                }
-            }
-
-            render() {
-                this.createCanvases();
-                this.updateCanvasStyle();
-                this.drawTimeCanvases();
-            }
-
-            updateCanvasStyle() {
-                const requiredCanvases = this.canvases.length;
-                let i;
-                for (i = 0; i < requiredCanvases; i++) {
-                    const canvas = this.canvases[i];
-                    let canvasWidth = this.maxCanvasElementWidth;
-
-                    if (i === requiredCanvases - 1) {
-                        canvasWidth = this.drawer.wrapper.scrollWidth - (this.maxCanvasElementWidth * (requiredCanvases - 1));
-                    }
-
-                    canvas.width = canvasWidth * this.pixelRatio;
-                    canvas.height = this.params.height * this.pixelRatio;
-                    this.style(canvas, {
-                        width: `${canvasWidth}px`,
-                        height: `${this.params.height}px`,
-                        left: `${i * this.maxCanvasElementWidth}px`
-                    });
-                }
-            }
-
-            drawTimeCanvases() {
-                const backend = this.wavesurfer.backend;
-                const wsParams = this.wavesurfer.params;
-                const duration = this.wavesurfer.backend.getDuration();
-                const totalSeconds = parseInt(duration, 10) + 1;
-                const width = wsParams.fillParent && !wsParams.scrollParent
-                    ? this.drawer.getWidth()
-                    : this.drawer.wrapper.scrollWidth * wsParams.pixelRatio;
-                const pixelsPerSecond = width / duration;
-
-                const formatTime = this.params.formatTimeCallback;
-                // if parameter is function, call the function with
-                // pixelsPerSecond, otherwise simply take the value as-is
-                const intervalFnOrVal = option => (typeof option === 'function' ? option(pixelsPerSecond) : option);
-                const timeInterval = intervalFnOrVal(this.params.timeInterval);
-                const primaryLabelInterval = intervalFnOrVal(this.params.primaryLabelInterval);
-                const secondaryLabelInterval = intervalFnOrVal(this.params.secondaryLabelInterval);
-
-                let curPixel = 0;
-                let curSeconds = 0;
-
-                if (duration <= 0) {
-                    return;
-                }
-
-                const height1 = this.params.height - 4;
-                const height2 = (this.params.height * (this.params.notchPercentHeight / 100)) - 4;
-                const fontSize = this.params.fontSize * wsParams.pixelRatio;
-                let i;
-
-                for (i = 0; i < totalSeconds / timeInterval; i++) {
-                    if (i % primaryLabelInterval == 0) {
-                        this.setFillStyles(this.params.primaryColor);
-                        this.fillRect(curPixel, 0, 1, height1);
-                        this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
-                        this.setFillStyles(this.params.primaryFontColor);
-                        this.fillText(formatTime(curSeconds), curPixel + 5, height1);
-                    } else if (i % secondaryLabelInterval == 0) {
-                        this.setFillStyles(this.params.secondaryColor);
-                        this.fillRect(curPixel, 0, 1, height1);
-                        this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
-                        this.setFillStyles(this.params.secondaryFontColor);
-                        this.fillText(formatTime(curSeconds), curPixel + 5, height1);
-                    } else {
-                        this.setFillStyles(this.params.secondaryColor);
-                        this.fillRect(curPixel, 0, 1, height2);
-                    }
-
-                    curSeconds += timeInterval;
-                    curPixel += pixelsPerSecond * timeInterval;
-                }
-            }
-
-            setFillStyles(fillStyle) {
-                this.canvases.forEach(canvas => {
-                    canvas.getContext('2d').fillStyle = fillStyle;
-                });
-            }
-
-            setFonts(font) {
-                this.canvases.forEach(canvas => {
-                    canvas.getContext('2d').font = font;
-                });
-            }
-
-            fillRect(x, y, width, height) {
-                this.canvases.forEach((canvas, i) => {
-                    const leftOffset = i * this.maxCanvasWidth;
-
-                    const intersection = {
-                        x1: Math.max(x, i * this.maxCanvasWidth),
-                        y1: y,
-                        x2: Math.min(x + width, i * this.maxCanvasWidth + canvas.width),
-                        y2: y + height
-                    };
-
-                    if (intersection.x1 < intersection.x2) {
-                        canvas.getContext('2d').fillRect(
-                            intersection.x1 - leftOffset,
-                            intersection.y1,
-                            intersection.x2 - intersection.x1,
-                            intersection.y2 - intersection.y1
-                        );
-                    }
-                });
-            }
-
-            fillText(text, x, y) {
-                let textWidth;
-                let xOffset = 0;
-                let i;
-
-                for (i in this.canvases) {
-                    const context = this.canvases[i].getContext('2d');
-                    const canvasWidth = context.canvas.width;
-
-                    if (xOffset > x + textWidth) {
-                        break;
-                    }
-
-                    if (xOffset + canvasWidth > x) {
-                        textWidth = context.measureText(text).width;
-                        context.fillText(text, x - xOffset, y);
-                    }
-
-                    xOffset += canvasWidth;
-                }
-            }
-        }
+        params: params,
+        instance: TimelinePlugin
     };
 }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -80,20 +80,46 @@ import PeakCache from './peakcache';
  * @example wavesurfer.addPlugin(pluginDefinition);
  * @property {string} name The name of the plugin, the plugin instance will be
  * added as a property to the wavesurfer instance under this name
- * @property {boolean} deferInit=params.deferInit||false Don't initialise plugin
+ * @property {?Object} staticProps The properties that should be added to the
+ * wavesurfer instance as static properties
+ * @property {?boolean} deferInit Don't initialise plugin
  * automatically
- * @property {string} extends `'observer'|'drawer'` The name of the object to
- * inject into the plugin instance factory. Currently only the observer and
- * drawer objects are possible.
+ * @property {Object} params={} The plugin parameters, they are the first parameter
+ * passed to the plugin class constructor function
  * @property {PluginClass} instance The plugin instance factory, is called with
  * the dependency specified in extends. Returns the plugin class.
  */
 
 /**
- * @typedef {function} PluginClass
- * @property {function} init The method to initialise the plugin
- * @property {function} destroy Destroy the plugin instance
+ * @interface PluginClass
+ *
+ * This is the interface which is implemented by all plugin classes
+ *
+ * @extends {Observer}
  */
+class PluginClass {
+    /**
+     * Construct the plugin
+     *
+     * @param {Object} ws The wavesurfer instance
+     * @param {Object} params={} The plugin params (specific to the plugin)
+     */
+    constructor(ws, params) {}
+    /**
+     * Initialise the plugin
+     *
+     * Start doing something. This is called by
+     * `wavesurfer.initPlugin(pluginName)`
+     */
+    init() {}
+    /**
+     * Destroy the plugin instance
+     *
+     * Stop doing something. This is called by
+     * `wavesurfer.destroyPlugin(pluginName)`
+     */
+    destroy() {}
+}
 
 /**
  * WaveSurfer core library class

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -53,7 +53,6 @@ const config = {
         umdNamedDefine: true
     },
     devServer: {
-        hot: true,
         contentBase: [
             path.join(__dirname)
         ],
@@ -90,8 +89,7 @@ const config = {
     },
 
     plugins: [
-        bannerPlugin,
-        new webpack.HotModuleReplacementPlugin()
+        bannerPlugin
     ],
 };
 
@@ -113,7 +111,7 @@ export default function (options) {
     if (options) {
         if (options.test) {
             mergeDeep(config, {
-                devtool: 'inline-source-map',
+                devtool: 'source-map',
                 // @TODO: Remove this and allow normal linting for tests and fix
                 // the linting issues. (test files should have the same rules
                 // property as the rest of the code)


### PR DESCRIPTION
### Short description of changes:
* For the reasons described here: https://github.com/katspaugh/wavesurfer.js/pull/1015#issuecomment-283609182 the plugin definition format was updated.
  * There is no `extends` property anymore in the plugin definition format
  * All plugins automatically inherit from the observer
  * Minimap instantiates a drawer using `this.drawer = wavesurfer.Drawer(el, params);` and doesn't directly inherit from drawer.
  * Plugin files export the plugin definition factory and the plugin class. This has the `@inherits {Observer}` jsdoc tag so the documentation generator gets things right.
  * Plugin class constructor functions are called with `wavesurfer` and `params` parameters by the core lib
* Other minor changes:
  * Fixed wrong source map config and disabled hot module reloading
  * Plugin files now export the factory function (the function which returns the plugin definition) as `default`, the plugin classes are exported as `PluginNameClass` – This results in the following code
  * Fixed an issue related to https://github.com/katspaugh/wavesurfer.js/issues/736 (minimap does not render on initial load with backend `MediaElement`) by checking which backend is used and using the correct event to hook into. (`ready` or `waveform-ready`)
  * Updated jsdoc comments and added a correct `PluginClass` interface class (is removed in minified build by build system)

### Breaking in the external API:
* The plugin factory function is now always the `default` export, this means code needs to be adjusted (see Code example)

### Breaking changes in the internal API:
* See above, but should be fixed everywhere

### Todos/Notes:
* Esdoc now parses the plugin classes, this has caused the documentation coverage to decrease to `52.94% (171/323)`
* Upgrade guide needs to be updated
* Example HTML needs to be updated

### Code example

```javascript
// common js
const pluginFactory = require('wavesurfer.js/dist/plugin/cursor.wavesurfer.js').default;

//  es6
import pluginFactory from 'wavesurfer.js/dist/plugin/cursor.wavesurfer.js';

// oldschool, (WaveSurfer is a global variable)
const pluginFactory = WaveSurfer.cursor.default;

const wavesurfer = WaveSurfer.create({
  plugins: [
    pluginFactory(pluginParams);
  ]
});
```
