### PR TITLE
Check AC State

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -287,7 +287,7 @@ WaveSurfer.WebAudio = {
         // not passed in as a parameter
         if (!this.params.audioContext) {
             // check if browser supports AudioContext.close()
-            if (typeof this.ac.close === 'function') {
+            if (typeof this.ac.close === 'function' && this.ac.state != 'closed') {
                 this.ac.close();
             }
         }


### PR DESCRIPTION
Should not close audiocontext when it's already closed. Chrome throws a warning if done so.
