### PR TITLE
Prevent waveform vertical scrolling in chrome

### DIFF
--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -75,7 +75,8 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
                 zIndex: 1,
                 left: leftOffset + 'px',
                 top: 0,
-                bottom: 0
+                bottom: 0,
+                height: '100%'
             })
         );
         entry.waveCtx = entry.wave.getContext('2d');
@@ -86,7 +87,8 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
                     position: 'absolute',
                     left: leftOffset + 'px',
                     top: 0,
-                    bottom: 0
+                    bottom: 0,
+                    height: '100%'
                 })
             );
             entry.progressCtx = entry.progress.getContext('2d');


### PR DESCRIPTION
The waveform is scrollable vertically in Chrome, however should only be scrollable horizontally, as is the case in Firefox. This can be observed here: http://codepen.io/katspaugh/pen/GozaaG, when the screen width is sufficiently reduced to result in horizontal scrolling.