### PR TITLE
add getPeaks background compatibility

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -217,7 +217,7 @@ WaveSurfer.WebAudio = {
      */
     getPeaks: function (length, first, last) {
         if (this.peaks) { return this.peaks; }
-        
+
         var first = first || 0;
         var last = last || length-1;
 

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -218,8 +218,8 @@ WaveSurfer.WebAudio = {
     getPeaks: function (length, first, last) {
         if (this.peaks) { return this.peaks; }
 
-        var first = first || 0;
-        var last = last || length-1;
+        first = first || 0;
+        last = last || length - 1;
 
         this.setLength(length);
 

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -217,6 +217,9 @@ WaveSurfer.WebAudio = {
      */
     getPeaks: function (length, first, last) {
         if (this.peaks) { return this.peaks; }
+        
+        var first = first || 0;
+        var last = last || length-1;
 
         this.setLength(length);
 


### PR DESCRIPTION
Fix to allow old style getPeaks(length) usage with new getPeaks(length,first,last).
If no `first` and `last` parameter is set it will set the default `0` and `length-1`.

#1067