### PR TITLE
timeline plugin: Round to milliseconds

### DIFF
--- a/plugin/wavesurfer.timeline.js
+++ b/plugin/wavesurfer.timeline.js
@@ -174,7 +174,7 @@ WaveSurfer.Timeline = {
                     seconds = (seconds < 10) ? '0' + seconds : seconds;
                     return '' + minutes + ':' + seconds;
                 } else {
-                    return seconds;
+                    return Math.round(seconds * 1000) / 1000;
                 }
             };
 


### PR DESCRIPTION
I had problems with labels being things like "0.99999999999999999999" which may be extra precized, but are far from readable. Also, I think milliseconds precision is far from enough. :P

# Hey, thank you for contributing to wavesurfer.js!

To review/merge open PRs it is very helpful to know as much as possible about the changes which are being introduced. Reviewing PRs is very time consuming, please be patient, it can take some time to do properly.

**Title:** Please make sure the name of your PR is as descriptive as possible (Describe the feature that is introduced or the bug that is being fixed).

## Please make sure you provide the information below:

### Short description of changes:


### Breaking in the external API:


### Breaking changes in the internal API:


### Todos/Notes:


### Related Issues and other PRs:
