### PR TITLE
fixes safari browser missing buffer when using webaudio

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -223,6 +223,12 @@ WaveSurfer.WebAudio = {
 
         this.setLength(length);
 
+       /**
+        * The following snippet fixes a buffering data issue on the Safari browser which returned undefined
+        * It creates the missing buffer based on 1 channel, 4096 samples and the sampleRate from the current webaudio context
+        * 4096 samples seemed to be the best fit for rendering
+        * will review this code once a stable version of Safari TP is out
+        */
         if (!this.buffer.length) {
             var newBuffer = this.createBuffer(1, 4096, this.sampleRate);
             this.buffer = newBuffer.buffer;

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -224,7 +224,7 @@ WaveSurfer.WebAudio = {
         this.setLength(length);
 
         if (!this.buffer.length) {
-            var newBuffer = this.createBuffer(1, 1, this.sampleRate);
+            var newBuffer = this.createBuffer(1, 4096, this.sampleRate);
             this.buffer = newBuffer.buffer;
         }
 

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -225,8 +225,7 @@ WaveSurfer.WebAudio = {
 
         if (!this.buffer.length) {
             var newBuffer = this.createBuffer(1, 1, this.sampleRate);
-            var newBufferSource = this.createBufferSource();
-            this.buffer = newBufferSource.buffer;
+            this.buffer = newBuffer.buffer;
         }
 
         var sampleSize = this.buffer.length / length;

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -223,6 +223,12 @@ WaveSurfer.WebAudio = {
 
         this.setLength(length);
 
+        if (!this.buffer.length) {
+            var newBuffer = this.createBuffer(1, 1, this.sampleRate);
+            var newBufferSource = this.createBufferSource();
+            this.buffer = newBufferSource.buffer;
+        }
+
         var sampleSize = this.buffer.length / length;
         var sampleStep = ~~(sampleSize / 10) || 1;
         var channels = this.buffer.numberOfChannels;


### PR DESCRIPTION
fixes #952 safari buffer undefined

```
var newBuffer = this.createBuffer(1, 4096, this.sampleRate);
```
- it creates the missing buffer based on 1 channel, 4096 samples and the sampleRate from the current webaudio context.