### PR TITLE
Fixed references to static property audioBufferSize

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -219,9 +219,9 @@ export default class WebAudio extends util.Observer {
     /** @private */
     createScriptNode() {
         if (this.ac.createScriptProcessor) {
-            this.scriptNode = this.ac.createScriptProcessor(this.scriptBufferSize);
+            this.scriptNode = this.ac.createScriptProcessor(WebAudio.scriptBufferSize);
         } else {
-            this.scriptNode = this.ac.createJavaScriptNode(this.scriptBufferSize);
+            this.scriptNode = this.ac.createJavaScriptNode(WebAudio.scriptBufferSize);
         }
 
         this.scriptNode.connect(this.ac.destination);


### PR DESCRIPTION
### Short description of changes:
The way the static property `audioBufferSize` is referenced (through `this`) is not valid ES2015 code and generates an error in Safari iOS at least ("IndexSizeError (DOM Exception 1): The index is not in the allowed range." since undefined is not a valid buffer size)

My fix is using the class name to reference the property but we can also use `this.constructor`

### Breaking in the external API:
N/A

### Breaking changes in the internal API:
N/A
