### PR TITLE
Listen to and relay play and pause events on media element

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -119,7 +119,7 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
             my.fireEvent('play');
         });
 
-        media.addEventListener('ended', function () {
+        media.addEventListener('pause', function () {
             my.fireEvent('pause');
         });
 

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -181,7 +181,6 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
         this.seekTo(start);
         this.media.play();
         end && this.setPlayEnd(end);
-        this.fireEvent('play');
     },
 
     /**
@@ -190,7 +189,6 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
     pause: function () {
         this.media && this.media.pause();
         this.clearPlayEnd();
-        this.fireEvent('pause');
     },
 
     setPlayEnd: function (end) {

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -113,6 +113,16 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
             my.fireEvent('finish');
         });
 
+        // Listen to and relay play and pause events to enable
+        // playback control from the external media element
+        media.addEventListener('play', function () {
+            my.fireEvent('play');
+        });
+
+        media.addEventListener('ended', function () {
+            my.fireEvent('pause');
+        });
+
         this.media = media;
         this.peaks = peaks;
         this.onPlayEnd = null;


### PR DESCRIPTION
### Short description of changes: 
Added automatic listening to the `"play"` and `"pause"` events of the provided media element. In the current implementation, I can only control audio playback from within the context of `wavesurfer.js`. In the application I'm building, I want to have the media element be the single source of audio playback control, allowing the `wavesurfer.js` instance to be a single part of a group of visualizations rather than the main controller.

### Breaking in the external API:
None that I am aware of


### Breaking changes in the internal API:
None that I am aware of


### Todos/Notes: 
I don't know if this has any unexpected consequences but it worked perfectly for me with this simple change when running `wavesurfer.js` with the `{backend: "MediaElement"}` configuration.


### Related Issues and other PRs:
N/A
