### PR TITLE
Update drawer.js -- make sure wrapper has the right parentNode.

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -287,7 +287,7 @@ export default class Drawer extends util.Observer {
     destroy() {
         this.unAll();
         if (this.wrapper) {
-            this.container.removeChild(this.wrapper);
+            if (this.wrapper.parentNode == this.container) this.container.removeChild(this.wrapper);
             this.wrapper = null;
         }
     }


### PR DESCRIPTION
`this.container.removeChild(this.wrapper);` ->
`if (this.wrapper.parentNode == this.container) this.container.removeChild(this.wrapper);`

Useful just in case. For example, I have a function that detaches everything in order for childList/removedNodes mutationObservers to fire.