### PR TITLE
requestAnimationFrame should be bound on window...

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -7,7 +7,7 @@ WaveSurfer.util = {
         window.oRequestAnimationFrame ||
         window.msRequestAnimationFrame ||
         function (callback, element) { setTimeout(callback, 1000 / 60); }
-    ),
+    ).bind(window),
 
     frame: function (func) {
         return function () {


### PR DESCRIPTION
Apparently...

https://stackoverflow.com/questions/10743596/why-are-certain-function-calls-termed-illegal-invocations-in-javascript