### PR TITLE
HTML structural change + invertTransparency option...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,8 +109,7 @@ module.exports = function (grunt) {
             },
             ignore_warning: {
                 options: {
-                    '-W083': true,
-                    // Don't make functions within a loop.
+                    // {a} is already defined.
                     '-W004': true,
                     // Expected an assignment or function call and instead saw an expression.
                     '-W030': true,
@@ -118,10 +117,14 @@ module.exports = function (grunt) {
                     '-W038': true,
                     // Use '!==' to compare with ''.
                     '-W041': true,
+                    // Bad constructor.
                     '-W056': true,
                     // Missing '()' invoking a constructor.
                     '-W058': true,
+                    // Use the function form of 'use strict'.
                     '-W079': true,
+                    // Don't make functions within a loop.
+                    '-W083': true,
                     // Use the function form of 'use strict'.
                     '-W097': true
                 },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,18 +109,20 @@ module.exports = function (grunt) {
             },
             ignore_warning: {
                 options: {
+                    '-W294': false,
+                    // Don't make functions within a loop.
                     '-W004': true,
-                    // Expected an assignment or function call and instead saw an expression
+                    // Expected an assignment or function call and instead saw an expression.
                     '-W030': true,
-                    // {a} used out of scope
+                    // {a} used out of scope.
                     '-W038': true,
-                    // Use '!==' to compare with ''
+                    // Use '!==' to compare with ''.
                     '-W041': true,
                     '-W056': true,
                     // Missing '()' invoking a constructor.
                     '-W058': true,
                     '-W079': true,
-                    // Use the function form of 'use strict'
+                    // Use the function form of 'use strict'.
                     '-W097': true
                 },
                 src: [ '<%= concat.dist.src %>', 'plugin/*.js', 'spec/*.spec.js' ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,7 +109,7 @@ module.exports = function (grunt) {
             },
             ignore_warning: {
                 options: {
-                    '-W294': false,
+                    '-W294': true,
                     // Don't make functions within a loop.
                     '-W004': true,
                     // Expected an assignment or function call and instead saw an expression.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,7 +109,7 @@ module.exports = function (grunt) {
             },
             ignore_warning: {
                 options: {
-                    '-W294': true,
+                    '-W083': true,
                     // Don't make functions within a loop.
                     '-W004': true,
                     // Expected an assignment or function call and instead saw an expression.

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -215,8 +215,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
     invertTransparency: function () {
         this.canvases.forEach (function (canvasGroup) {
-            var waveTypeList = ['wave'].concat(canvasGroup.progressWaveCtx ? ['progressWave'] : []);
-            waveTypeList.forEach (function (waveType) {
+            ['wave'].concat(canvas.progressWaveCtx ? ['progressWave'] : []).forEach (function (waveType) {
                 var canvas = canvasGroup[waveType];
                 var temp = document.createElement('canvas');
                 temp.width = canvas.width; temp.height = canvas.height;
@@ -292,8 +291,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
             if (intersection.x1 < intersection.x2) {
                 this.setFillStyles(canvas);
-                var waveTypeList = ['wave'].concat(canvas.progressWaveCtx ? ['progressWave'] : []);
-                waveTypeList.forEach (function (waveType) {
+                ['wave'].concat(canvas.progressWaveCtx ? ['progressWave'] : []).forEach (function (waveType) {
                     this.fillRectToContext(canvas[waveType + 'Ctx'],
                         intersection.x1 - leftOffset,
                         intersection.y1,

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -106,7 +106,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
         this.style(this.wave, {height: height / this.params.pixelRatio + 'px'});
         this.style(canvas.waveCtx.canvas, {width: elementWidth + 'px'});
         this.style(this.cursor, {display: 'block'});
-        
+
         if (!canvas.progressWaveCtx) { return; }
         this.style(this.progressWave, {height: height / this.params.pixelRatio + 'px'});
         canvas.progressWaveCtx.canvas.width  = width;
@@ -255,7 +255,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
         var first = Math.round(length * canvas.start);
         var last = Math.round(length * canvas.end);
         if (first > end || last < start) { return; }
-        
+
         var canvasStart = Math.max(first, start);
         var canvasEnd = Math.min(last, end);
 

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -20,152 +20,121 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
     },
 
     createElements: function () {
-        this.progressWave = this.wrapper.appendChild(
-            this.style(document.createElement('wave'), {
-                position: 'absolute',
-                zIndex: 2,
-                left: 0,
-                top: 0,
-                bottom: 0,
-                overflow: 'hidden',
-                width: '0',
+        ['wave', 'progressWave'].forEach(function (waveType) {
+            this[waveType] = this.wrapper.appendChild(
+                this.style(document.createElement('wave'), {
+                    position: 'absolute',
+                    zIndex: 2,
+                    left: 0,
+                    top: 0,
+                    height: '100%',
+                    overflow: 'hidden',
+                    width: (waveType == 'progressWave') ? '100%' : '0',
+                    boxSizing: 'border-box',
+                    pointerEvents: 'none'
+                })
+            );
+            if (waveType == 'progressWave') this.style(this[waveType], {
                 display: 'none',
-                boxSizing: 'border-box',
                 borderRightStyle: 'solid',
                 borderRightWidth: this.params.cursorWidth + 'px',
-                borderRightColor: this.params.cursorColor,
-                pointerEvents: 'none'
-            })
-        );
-
+                borderRightColor: this.params.cursorColor
+            });
+        }, this);
         this.addCanvas();
     },
 
     updateSize: function () {
-        var totalWidth = Math.round(this.width / this.params.pixelRatio),
-            requiredCanvases = Math.ceil(totalWidth / this.maxCanvasElementWidth);
+        var totalWidth = Math.round(this.width / this.params.pixelRatio)
+        var requiredCanvases = Math.ceil(totalWidth / this.maxCanvasElementWidth);
 
-        while (this.canvases.length < requiredCanvases) {
-            this.addCanvas();
-        }
+        while (this.canvases.length < requiredCanvases) { this.addCanvas(); }
+        while (this.canvases.length > requiredCanvases) { this.removeCanvas(); }
 
-        while (this.canvases.length > requiredCanvases) {
-            this.removeCanvas();
-        }
-
-        this.canvases.forEach(function (entry, i) {
-            // Add some overlap to prevent vertical white stripes, keep the width even for simplicity.
-            var canvasWidth = this.maxCanvasWidth + 2 * Math.ceil(this.params.pixelRatio / 2);
-
-            if (i == this.canvases.length - 1) {
-                canvasWidth = this.width - (this.maxCanvasWidth * (this.canvases.length - 1));
+        this.canvases.forEach (function (canvas, i) {
+            // Add some overlap to prevent vertical white stripes; keep the width even for simplicity.
+            if (i != this.canvases.length - 1) {
+                var canvasWidth = this.maxCanvasWidth + 2 * Math.ceil(this.params.pixelRatio / 2);
+            } else {
+                var canvasWidth = this.width - (this.maxCanvasWidth * (this.canvases.length - 1));
             }
-
-            this.updateDimensions(entry, canvasWidth, this.height);
-            this.clearWaveForEntry(entry);
+            this.updateDimensions(canvas, canvasWidth, this.height);
+            this.clearWaveForEntry(canvas);
         }, this);
     },
 
     addCanvas: function () {
-        var entry = {},
-            leftOffset = this.maxCanvasElementWidth * this.canvases.length;
-
-        entry.wave = this.wrapper.appendChild(
-            this.style(document.createElement('canvas'), {
-                position: 'absolute',
-                zIndex: 2,
-                left: leftOffset + 'px',
-                top: 0,
-                bottom: 0,
-                height: '100%',
-                pointerEvents: 'none'
-            })
-        );
-        entry.waveCtx = entry.wave.getContext('2d');
-
-        if (this.hasProgressCanvas) {
-            entry.progress = this.progressWave.appendChild(
+        var entry = {};
+        var leftOffset = this.maxCanvasElementWidth * this.canvases.length;
+        ['wave', 'progressWave'].forEach (function (waveType) {
+            entry[waveType] = this[waveType].appendChild(
                 this.style(document.createElement('canvas'), {
                     position: 'absolute',
                     left: leftOffset + 'px',
-                    top: 0,
-                    bottom: 0,
-                    height: '100%'
-                })
-            );
-            entry.progressCtx = entry.progress.getContext('2d');
-        }
-
+                    top: !this.invertTransparency ? 0 : (this.halfPixel / 2) + 'px', // Add a small buffer to prevent gaps.
+                    height: !this.invertTransparency ? '100%' : 'calc(100% + ' + this.halfPixel + 'px)'
+                }));
+            entry[waveType + 'Ctx'] = entry[waveType].getContext('2d');
+        }, this);
         this.canvases.push(entry);
     },
 
     removeCanvas: function () {
         var lastEntry = this.canvases.pop();
         lastEntry.wave.parentElement.removeChild(lastEntry.wave);
-        if (this.hasProgressCanvas) {
-            lastEntry.progress.parentElement.removeChild(lastEntry.progress);
-        }
+        if (lastEntry.progressWave) { lastEntry.progressWave.parentElement.removeChild(lastEntry.progressWave); }
     },
 
-    updateDimensions: function (entry, width, height) {
-        var elementWidth = Math.round(width / this.params.pixelRatio),
-            totalWidth = Math.round(this.width / this.params.pixelRatio);
+    updateDimensions: function (canvas, width, height) {
+        var elementWidth = Math.round(width / this.params.pixelRatio);
+        var totalWidth   = Math.round(this.width / this.params.pixelRatio);
 
-        // Where the canvas starts and ends in the waveform, represented as a decimal between 0 and 1.
-        entry.start = (entry.waveCtx.canvas.offsetLeft / totalWidth) || 0;
-        entry.end = entry.start + elementWidth / totalWidth;
+        // Specify where the canvas starts and ends in the waveform, represented as a decimal between 0 and 1.
+        canvas.start = (canvas.waveCtx.canvas.offsetLeft / totalWidth) || 0;
+        canvas.end = canvas.start + elementWidth / totalWidth;
 
-        entry.waveCtx.canvas.width = width;
-        entry.waveCtx.canvas.height = height;
-        this.style(entry.waveCtx.canvas, { width: elementWidth + 'px' });
+        canvas.waveCtx.canvas.width = width;
+        canvas.waveCtx.canvas.height = height;
+        
+        this.style(this.wave, {height: height / this.params.pixelRatio + 'px'});
+        this.style(canvas.waveCtx.canvas, {width: elementWidth + 'px'});
 
-        this.style(this.progressWave, { display: 'block' });
-
-        if (this.hasProgressCanvas) {
-            entry.progressCtx.canvas.width = width;
-            entry.progressCtx.canvas.height = height;
-            this.style(entry.progressCtx.canvas, { width: elementWidth + 'px' });
-        }
+        if (!canvas.progressWaveCtx) return;
+        this.style(this.progressWave, {height: height / this.params.pixelRatio + 'px'});
+        canvas.progressWaveCtx.canvas.width  = width;
+        canvas.progressWaveCtx.canvas.height = height;
+        this.style(canvas.progressWaveCtx.canvas, {width: elementWidth + 'px'});
+        this.style(this.progressWave, {display: 'block'});
     },
 
     clearWave: function () {
-        this.canvases.forEach(function (entry) {
-            this.clearWaveForEntry(entry);
-        }, this);
+        my.canvases.forEach (function (canvas) { my.clearWaveForEntry(canvas); }, this);
     },
 
-    clearWaveForEntry: function (entry) {
-        entry.waveCtx.clearRect(0, 0, entry.waveCtx.canvas.width, entry.waveCtx.canvas.height);
-        if (this.hasProgressCanvas) {
-            entry.progressCtx.clearRect(0, 0, entry.progressCtx.canvas.width, entry.progressCtx.canvas.height);
-        }
+    clearWaveForEntry: function (canvas) {
+        canvas.waveCtx.clearRect(0, 0, canvas.waveCtx.canvas.width, canvas.waveCtx.canvas.height);
+        if (!canvas.progressWaveCtx) return
+        canvas.progressWaveCtx.clearRect(0, 0, canvas.progressWaveCtx.canvas.width, canvas.progressWaveCtx.canvas.height);
     },
 
     drawBars: WaveSurfer.util.frame(function (peaks, channelIndex, start, end) {
-        // Split channels
-        if (peaks[0] instanceof Array) {
+        // Split channels if they exist.
+        if (this.params.splitChannels) {
             var channels = peaks;
-            if (this.params.splitChannels) {
-                this.setHeight(channels.length * this.params.height * this.params.pixelRatio);
-                channels.forEach(function(channelPeaks, i) {
-                    this.drawBars(channelPeaks, i, start, end);
-                }, this);
-                return;
-            } else {
-                peaks = channels[0];
-            }
+            this.setHeight(channels.length * this.params.height * this.params.pixelRatio);
+            channels.forEach(function(channelPeaks, i) { this.drawBars(channelPeaks, i, start, end); }, this);
+            return;
         }
+        // Extract peaks if it's in an array.
+        if (peaks[0] instanceof Array) {peaks = peaks[0]; }
 
         // Bar wave draws the bottom only as a reflection of the top,
-        // so we don't need negative values
+        // so we don't need negative values.
         var hasMinVals = [].some.call(peaks, function (val) {return val < 0;});
         // Skip every other value if there are negatives.
-        var peakIndexScale = 1;
-        if (hasMinVals) {
-            peakIndexScale = 2;
-        }
+        var peakIndexScale = (hasMinVals) ? 2 : 1;
 
-        // A half-pixel offset makes lines crisp
+        // A half-pixel offset makes lines crisp.
         var width = this.width;
         var height = this.params.height * this.params.pixelRatio;
         var offsetY = height * channelIndex || 0;
@@ -175,11 +144,12 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
         var gap = Math.max(this.params.pixelRatio, ~~(bar / 2));
         var step = bar + gap;
 
-        var absmax = 1 / this.params.barHeight;
-        if (this.params.normalize) {
+        if (!this.params.normalize) {
+            var absmax = 1 / this.params.barHeight;
+        } else {
             var max = WaveSurfer.util.max(peaks);
             var min = WaveSurfer.util.min(peaks);
-            absmax = -min > max ? -min : max;
+            var absmax = -min > max ? -min : max;
         }
 
         var scale = length / width;
@@ -189,24 +159,21 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
             var h = Math.round(peak / absmax * halfH);
             this.fillRect(i + this.halfPixel, halfH - h + offsetY, bar + this.halfPixel, h * 2);
         }
+
+        if (this.params.invertTransparency) this.invertTransparency()
     }),
 
     drawWave: WaveSurfer.util.frame(function (peaks, channelIndex, start, end) {
-        // Split channels
-        if (peaks[0] instanceof Array) {
-            var channels = peaks;
-            if (this.params.splitChannels) {
-                this.setHeight(channels.length * this.params.height * this.params.pixelRatio);
-                channels.forEach(function(channelPeaks, i) {
-                    this.drawWave(channelPeaks, i, start, end);
-                }, this);
-                return;
-            } else {
-                peaks = channels[0];
-            }
+        // Split channels if they exist.
+        if (this.params.splitChannels) {
+            this.setHeight(channels.length * this.params.height * this.params.pixelRatio);
+            channels.forEach(function(channelPeaks, i) { this.drawWave(channelPeaks, i, start, end); }, this);
+            return;
         }
+        // Extract peaks if it's in an array.
+        if (peaks[0] instanceof Array) { peaks = peaks[0]; }
 
-        // Support arrays without negative peaks
+        // Support arrays without negative peaks.
         var hasMinValues = [].some.call(peaks, function (val) { return val < 0; });
         if (!hasMinValues) {
             var reflectedPeaks = [];
@@ -217,45 +184,64 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
             peaks = reflectedPeaks;
         }
 
-        // A half-pixel offset makes lines crisp
+        // A half-pixel offset makes lines crisp.
         var height = this.params.height * this.params.pixelRatio;
         var offsetY = height * channelIndex || 0;
         var halfH = height / 2;
 
-        var absmax = 1 / this.params.barHeight;
-        if (this.params.normalize) {
+        if (!this.params.normalize) {
+            var absmax = 1 / this.params.barHeight;
+        } else {
             var max = WaveSurfer.util.max(peaks);
             var min = WaveSurfer.util.min(peaks);
-            absmax = -min > max ? -min : max;
+            var absmax = -min > max ? -min : max;
         }
 
         this.drawLine(peaks, absmax, halfH, offsetY, start, end);
 
-        // Always draw a median line
+        // Always draw a median line.
         this.fillRect(0, halfH + offsetY - this.halfPixel, this.width, this.halfPixel);
+        
+        if (this.params.invertTransparency) this.invertTransparency()
     }),
 
-    drawLine: function (peaks, absmax, halfH, offsetY, start, end) {
-        this.canvases.forEach (function (entry) {
-            this.setFillStyles(entry);
-            this.drawLineToContext(entry, entry.waveCtx, peaks, absmax, halfH, offsetY, start, end);
-            this.drawLineToContext(entry, entry.progressCtx, peaks, absmax, halfH, offsetY, start, end);
+    invertTransparency: function () {
+        this.canvases.forEach (function (canvasGroup) {
+            ['wave'].concat(canvasGroup['progressWaveCtx'] ? ['progressWave'] : []).forEach (function (waveType) {
+                var canvas = canvasGroup[waveType];
+                var temp = document.createElement('canvas');
+                temp.width = canvas.width; temp.height = canvas.height;
+                temp.getContext('2d').drawImage (canvas, 0, 0);
+                var ctx = canvas.getContext('2d');
+                ctx.fillStyle = (waveType == 'wave' || this.params.progressColor === undefined) ? this.params.waveColor : this.params.progressColor;
+                ctx.fillRect(0, 0, canvas.width, canvas.height); 
+                ctx.globalCompositeOperation = 'destination-out';
+                ctx.drawImage (temp, 0, 0);
+                ctx.globalCompositeOperation = 'source-in';
+            }, this)
         }, this);
     },
 
-    drawLineToContext: function (entry, ctx, peaks, absmax, halfH, offsetY, start, end) {
-        if (!ctx) { return; }
+    drawLine: function (peaks, absmax, halfH, offsetY, start, end) {
+        this.canvases.forEach (function (canvas) {
+            this.setFillStyles(canvas);
+            this.drawLineToContext(canvas, canvas.waveCtx, peaks, absmax, halfH, offsetY, start, end);
+            this.drawLineToContext(canvas, canvas.progressWaveCtx, peaks, absmax, halfH, offsetY, start, end);
+        }, this);
+    },
+
+    drawLineToContext: function (canvas, ctx, peaks, absmax, halfH, offsetY, start, end) {
+        if (!ctx) return;
 
         var length = peaks.length / 2;
 
         var scale = 1;
-        if (this.params.fillParent && this.width != length) {
-            scale = this.width / length;
-        }
+        if (this.params.fillParent && this.width != length) { scale = this.width / length; }
 
-        var first = Math.round(length * entry.start),
-            last = Math.round(length * entry.end);
+        var first = Math.round(length * canvas.start);
+        var last = Math.round(length * canvas.end);
         if (first > end || last < start) { return; }
+        
         var canvasStart = Math.max(first, start);
         var canvasEnd = Math.min(last, end);
 
@@ -282,50 +268,48 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
     fillRect: function (x, y, width, height) {
         var startCanvas = Math.floor(x / this.maxCanvasWidth);
-        var endCanvas = Math.min(Math.ceil((x + width) / this.maxCanvasWidth) + 1,
-                                this.canvases.length);
+        var endCanvas   = Math.min(Math.ceil((x + width) / this.maxCanvasWidth) + 1, this.canvases.length);
+        
         for (var i = startCanvas; i < endCanvas; i++) {
-            var entry = this.canvases[i],
-                leftOffset = i * this.maxCanvasWidth;
+            var canvas = this.canvases[i];
+            var leftOffset = i * this.maxCanvasWidth;
+
             var intersection = {
                 x1: Math.max(x, i * this.maxCanvasWidth),
                 y1: y,
-                x2: Math.min(x + width, i * this.maxCanvasWidth + entry.waveCtx.canvas.width),
+                x2: Math.min(x + width, i * this.maxCanvasWidth + canvas.waveCtx.canvas.width),
                 y2: y + height
             };
 
             if (intersection.x1 < intersection.x2) {
-                this.setFillStyles(entry);
-
-                this.fillRectToContext(entry.waveCtx,
+                this.setFillStyles(canvas);
+                ['wave'].concat(canvas['progressWaveCtx'] ? ['progressWave'] : []).forEach (function (waveType) {
+                    this.fillRectToContext(canvas[waveType + 'Ctx'],
                         intersection.x1 - leftOffset,
                         intersection.y1,
                         intersection.x2 - intersection.x1,
                         intersection.y2 - intersection.y1);
-
-                this.fillRectToContext(entry.progressCtx,
-                        intersection.x1 - leftOffset,
-                        intersection.y1,
-                        intersection.x2 - intersection.x1,
-                        intersection.y2 - intersection.y1);
+               }, this);
             }
         }
     },
 
     fillRectToContext: function (ctx, x, y, width, height) {
-        if (!ctx) { return; }
-        ctx.fillRect(x, y, width, height);
+        if (ctx) ctx.fillRect(x, y, width, height);
     },
 
-    setFillStyles: function (entry) {
-        entry.waveCtx.fillStyle = this.params.waveColor;
-        if (this.hasProgressCanvas) {
-            entry.progressCtx.fillStyle = this.params.progressColor;
-        }
+    setFillStyles: function (canvas) {
+        if (this.invertTransparency) { var cutColor = ('cutColor' in this.invertTransparency) ? this.invertTransparency.cutColor : '#fefefe'; }
+        canvas.waveCtx.fillStyle = this.invertTransparency ? cutColor : this.params.waveColor;
+        if (canvas.progressWaveCtx) { canvas.progressWaveCtx.fillStyle = this.invertTransparency ? cutColor : this.params.progressColor; }
     },
 
     updateProgress: function (pos) {
-        this.style(this.progressWave, { width: pos + 'px' });
+        this.style(this.wave, { left: pos + 'px', width: 'calc(100% - ' + pos + 'px)' });
+        this.canvases.forEach (function (canvas, i) {
+            this.style(canvas.wave, { left: -pos + 'px' });
+        }, this)
+        if (this.progressWave) this.style(this.progressWave, { width: pos + 'px' });
     },
 
     /**
@@ -337,8 +321,8 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
      */
     getImage: function (type, quality) {
         var availableCanvas = [];
-        this.canvases.forEach(function (entry) {
-            availableCanvas.push(entry.wave.toDataURL(type, quality));
+        this.canvases.forEach(function (canvas) {
+            availableCanvas.push(canvas.wave.toDataURL(type, quality));
         });
         return availableCanvas.length > 1 ? availableCanvas : availableCanvas[0];
     }

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -34,13 +34,19 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
                     pointerEvents: 'none'
                 })
             );
-            if (waveType == 'progressWave') this.style(this[waveType], {
-                display: 'none',
-                borderRightStyle: 'solid',
-                borderRightWidth: this.params.cursorWidth + 'px',
-                borderRightColor: this.params.cursorColor
-            });
+            if (waveType == 'progressWave') this[waveType].style.display = 'none';
         }, this);
+        this.cursor = this.wrapper.appendChild(
+            this.style(document.createElement('div'), {
+                backgroundColor: this.params.cursorColor,
+                position: 'absolute',
+                zIndex: 2,
+                width: this.params.cursorWidth + 'px',
+                height: '100%',
+                left: 0,
+                display: 'none'
+            })
+        );
         this.addCanvas();
     },
 
@@ -240,7 +246,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
         var first = Math.round(length * canvas.start);
         var last = Math.round(length * canvas.end);
         if (first > end || last < start) { return; }
-        
+
         var canvasStart = Math.max(first, start);
         var canvasEnd = Math.min(last, end);
 
@@ -307,7 +313,11 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
         this.style(this.wave, { left: pos + 'px', width: 'calc(100% - ' + pos + 'px)' });
         this.canvases.forEach (function (canvas, i) {
             this.style(canvas.wave, { left: -pos + 'px' });
-        }, this)
+        }, this);
+        var cursorPos = pos - ((this.params.cursorAlignment == 'right') ? 0
+            : (this.params.cursorAlignment == 'middle') ? (this.params.cursorWidth / 2)
+            : this.params.cursorWidth)
+        this.style(this.cursor, { left: cursorPos + 'px' });
         if (this.progressWave) this.style(this.progressWave, { width: pos + 'px' });
     },
 

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -215,7 +215,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
     invertTransparency: function () {
         this.canvases.forEach (function (canvasGroup) {
-            ['wave'].concat(canvas.progressWaveCtx ? ['progressWave'] : []).forEach (function (waveType) {
+            ['wave'].concat(canvasGroup.progressWaveCtx ? ['progressWave'] : []).forEach (function (waveType) {
                 var canvas = canvasGroup[waveType];
                 var temp = document.createElement('canvas');
                 temp.width = canvas.width; temp.height = canvas.height;

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -70,8 +70,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
             entry[waveType] = this[waveType].appendChild(
                 this.style(document.createElement('canvas'), {
                     position: 'absolute',
-                    left: leftOffset + 'px',
-                    top: !this.invertTransparency ? 0 : (this.halfPixel / 2) + 'px', // Add a small buffer to prevent gaps.
+                    left: leftOffset + 'px',top: !this.invertTransparency ? 0 : -(this.halfPixel / 2) + 'px', // Add a small buffer to prevent gaps.
                     height: !this.invertTransparency ? '100%' : 'calc(100% + ' + this.halfPixel + 'px)'
                 }));
             entry[waveType + 'Ctx'] = entry[waveType].getContext('2d');
@@ -214,7 +213,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
                 temp.getContext('2d').drawImage (canvas, 0, 0);
                 var ctx = canvas.getContext('2d');
                 ctx.fillStyle = (waveType == 'wave' || this.params.progressColor === undefined) ? this.params.waveColor : this.params.progressColor;
-                ctx.fillRect(0, 0, canvas.width, canvas.height); 
+                ctx.fillRect(0, 0, canvas.width, canvas.height);
                 ctx.globalCompositeOperation = 'destination-out';
                 ctx.drawImage (temp, 0, 0);
                 ctx.globalCompositeOperation = 'source-in';

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -291,7 +291,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
             if (intersection.x1 < intersection.x2) {
                 this.setFillStyles(canvas);
-                ['wave'].concat(canvas['progressWaveCtx'] ? ['progressWave'] : []).forEach (function (waveType) {
+                ['wave'].concat(canvas.progressWaveCtx ? ['progressWave'] : []).forEach (function (waveType) {
                     this.fillRectToContext(canvas[waveType + 'Ctx'],
                         intersection.x1 - leftOffset,
                         intersection.y1,
@@ -303,7 +303,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
     },
 
     fillRectToContext: function (ctx, x, y, width, height) {
-        if (ctx) ctx.fillRect(x, y, width, height);
+        if (ctx) { ctx.fillRect(x, y, width, height); }
     },
 
     setFillStyles: function (canvas) {
@@ -319,7 +319,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
         }, this);
         var cursorPos = pos - ((this.params.cursorAlignment == 'right') ? 0
             : (this.params.cursorAlignment == 'middle') ? (this.params.cursorWidth / 2)
-            : this.params.cursorWidth)
+            : this.params.cursorWidth);
         this.style(this.cursor, { left: cursorPos + 'px' });
         if (this.progressWave) { this.style(this.progressWave, { width: pos + 'px' }); }
     },

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -104,8 +104,8 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
         this.style(this.wave, {height: height / this.params.pixelRatio + 'px'});
         this.style(canvas.waveCtx.canvas, {width: elementWidth + 'px'});
-
         this.style(this.cursor, {display: 'block'});
+
         if (!canvas.progressWaveCtx) { return; }
         this.style(this.progressWave, {height: height / this.params.pixelRatio + 'px'});
         canvas.progressWaveCtx.canvas.width  = width;
@@ -225,7 +225,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
                 ctx.globalCompositeOperation = 'destination-out';
                 ctx.drawImage (temp, 0, 0);
-                ctx.globalCompositeOperation = 'source-in';
+                ctx.globalCompositeOperation = 'source-over';
             }, this);
         }, this);
     },

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -20,7 +20,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
     },
 
     createElements: function () {
-        ['wave', 'progressWave'].forEach(function (waveType) {
+        ['progressWave', 'wave'].forEach(function (waveType) {
             this[waveType] = this.wrapper.appendChild(
                 this.style(document.createElement('wave'), {
                     position: 'absolute',
@@ -34,7 +34,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
                     pointerEvents: 'none'
                 })
             );
-            if (waveType == 'progressWave') this[waveType].style.display = 'none';
+            if (waveType == 'progressWave') { this[waveType].style.display = 'none'; }
         }, this);
         this.cursor = this.wrapper.appendChild(
             this.style(document.createElement('div'), {
@@ -51,7 +51,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
     },
 
     updateSize: function () {
-        var totalWidth = Math.round(this.width / this.params.pixelRatio)
+        var totalWidth = Math.round(this.width / this.params.pixelRatio);
         var requiredCanvases = Math.ceil(totalWidth / this.maxCanvasElementWidth);
 
         while (this.canvases.length < requiredCanvases) { this.addCanvas(); }
@@ -72,11 +72,12 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
     addCanvas: function () {
         var entry = {};
         var leftOffset = this.maxCanvasElementWidth * this.canvases.length;
-        ['wave', 'progressWave'].forEach (function (waveType) {
+        ['progressWave', 'wave'].forEach (function (waveType) {
             entry[waveType] = this[waveType].appendChild(
                 this.style(document.createElement('canvas'), {
                     position: 'absolute',
-                    left: leftOffset + 'px',top: !this.invertTransparency ? 0 : -(this.halfPixel / 2) + 'px', // Add a small buffer to prevent gaps.
+                    left: leftOffset + 'px',
+                    top: !this.invertTransparency ? 0 : -(this.halfPixel / 2) + 'px', // Add a small buffer to prevent gaps.
                     height: !this.invertTransparency ? '100%' : 'calc(100% + ' + this.halfPixel + 'px)'
                 }));
             entry[waveType + 'Ctx'] = entry[waveType].getContext('2d');
@@ -100,11 +101,12 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
         canvas.waveCtx.canvas.width = width;
         canvas.waveCtx.canvas.height = height;
-        
+
         this.style(this.wave, {height: height / this.params.pixelRatio + 'px'});
         this.style(canvas.waveCtx.canvas, {width: elementWidth + 'px'});
 
-        if (!canvas.progressWaveCtx) return;
+        this.style(this.cursor, {display: 'block'});
+        if (!canvas.progressWaveCtx) { return; }
         this.style(this.progressWave, {height: height / this.params.pixelRatio + 'px'});
         canvas.progressWaveCtx.canvas.width  = width;
         canvas.progressWaveCtx.canvas.height = height;
@@ -113,12 +115,12 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
     },
 
     clearWave: function () {
-        my.canvases.forEach (function (canvas) { my.clearWaveForEntry(canvas); }, this);
+        this.canvases.forEach (function (canvas) { this.clearWaveForEntry(canvas); }, this);
     },
 
     clearWaveForEntry: function (canvas) {
         canvas.waveCtx.clearRect(0, 0, canvas.waveCtx.canvas.width, canvas.waveCtx.canvas.height);
-        if (!canvas.progressWaveCtx) return
+        if (!canvas.progressWaveCtx) { return; }
         canvas.progressWaveCtx.clearRect(0, 0, canvas.progressWaveCtx.canvas.width, canvas.progressWaveCtx.canvas.height);
     },
 
@@ -165,12 +167,13 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
             this.fillRect(i + this.halfPixel, halfH - h + offsetY, bar + this.halfPixel, h * 2);
         }
 
-        if (this.params.invertTransparency) this.invertTransparency()
+        if (this.params.invertTransparency) { this.invertTransparency(); }
     }),
 
     drawWave: WaveSurfer.util.frame(function (peaks, channelIndex, start, end) {
         // Split channels if they exist.
         if (this.params.splitChannels) {
+            var channels = peaks;
             this.setHeight(channels.length * this.params.height * this.params.pixelRatio);
             channels.forEach(function(channelPeaks, i) { this.drawWave(channelPeaks, i, start, end); }, this);
             return;
@@ -206,13 +209,13 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
         // Always draw a median line.
         this.fillRect(0, halfH + offsetY - this.halfPixel, this.width, this.halfPixel);
-        
-        if (this.params.invertTransparency) this.invertTransparency()
+
+        if (this.params.invertTransparency) { this.invertTransparency(); }
     }),
 
     invertTransparency: function () {
         this.canvases.forEach (function (canvasGroup) {
-            ['wave'].concat(canvasGroup['progressWaveCtx'] ? ['progressWave'] : []).forEach (function (waveType) {
+            (canvasGroup.progressWaveCtx ? ['progressWave'] : []).concat('wave').forEach (function (waveType) {
                 var canvas = canvasGroup[waveType];
                 var temp = document.createElement('canvas');
                 temp.width = canvas.width; temp.height = canvas.height;
@@ -223,7 +226,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
                 ctx.globalCompositeOperation = 'destination-out';
                 ctx.drawImage (temp, 0, 0);
                 ctx.globalCompositeOperation = 'source-in';
-            }, this)
+            }, this);
         }, this);
     },
 
@@ -236,7 +239,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
     },
 
     drawLineToContext: function (canvas, ctx, peaks, absmax, halfH, offsetY, start, end) {
-        if (!ctx) return;
+        if (!ctx) { return; }
 
         var length = peaks.length / 2;
 
@@ -246,7 +249,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
         var first = Math.round(length * canvas.start);
         var last = Math.round(length * canvas.end);
         if (first > end || last < start) { return; }
-
+        
         var canvasStart = Math.max(first, start);
         var canvasEnd = Math.min(last, end);
 
@@ -274,7 +277,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
     fillRect: function (x, y, width, height) {
         var startCanvas = Math.floor(x / this.maxCanvasWidth);
         var endCanvas   = Math.min(Math.ceil((x + width) / this.maxCanvasWidth) + 1, this.canvases.length);
-        
+
         for (var i = startCanvas; i < endCanvas; i++) {
             var canvas = this.canvases[i];
             var leftOffset = i * this.maxCanvasWidth;
@@ -318,7 +321,7 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
             : (this.params.cursorAlignment == 'middle') ? (this.params.cursorWidth / 2)
             : this.params.cursorWidth)
         this.style(this.cursor, { left: cursorPos + 'px' });
-        if (this.progressWave) this.style(this.progressWave, { width: pos + 'px' });
+        if (this.progressWave) { this.style(this.progressWave, { width: pos + 'px' }); }
     },
 
     /**

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -215,7 +215,8 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
     invertTransparency: function () {
         this.canvases.forEach (function (canvasGroup) {
-            (canvasGroup.progressWaveCtx ? ['progressWave'] : []).concat('wave').forEach (function (waveType) {
+            var waveTypeList = ['wave'].concat(canvasGroup.progressWaveCtx ? ['progressWave'] : []);
+            waveTypeList.forEach (function (waveType) {
                 var canvas = canvasGroup[waveType];
                 var temp = document.createElement('canvas');
                 temp.width = canvas.width; temp.height = canvas.height;
@@ -291,7 +292,8 @@ WaveSurfer.util.extend(WaveSurfer.Drawer.MultiCanvas, {
 
             if (intersection.x1 < intersection.x2) {
                 this.setFillStyles(canvas);
-                ['wave'].concat(canvas.progressWaveCtx ? ['progressWave'] : []).forEach (function (waveType) {
+                var waveTypeList = ['wave'].concat(canvas.progressWaveCtx ? ['progressWave'] : []);
+                waveTypeList.forEach (function (waveType) {
                     this.fillRectToContext(canvas[waveType + 'Ctx'],
                         intersection.x1 - leftOffset,
                         intersection.y1,

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -26,7 +26,6 @@ var WaveSurfer = {
         hideScrollbar : false,
         interact      : true,
         invertTransparency: false,
-        invertTransparencySettings: undefined,
         loopSelection : true,
         mediaContainer: null,
         mediaControls : false,

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -17,6 +17,7 @@ var WaveSurfer = {
         barHeight     : 1,
         closeAudioContext: false,
         container     : null,
+        cursorAlignment: 'middle',
         cursorColor   : '#333',
         cursorWidth   : 1,
         dragSelection : true,

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -15,6 +15,8 @@ var WaveSurfer = {
         autoCenter    : true,
         backend       : 'WebAudio',
         barHeight     : 1,
+        classList     : {},
+        styleList     : {},
         closeAudioContext: false,
         container     : null,
         cursorAlignment: 'middle',

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -25,6 +25,8 @@ var WaveSurfer = {
         height        : 128,
         hideScrollbar : false,
         interact      : true,
+        invertTransparency: false,
+        invertTransparencySettings: undefined,
         loopSelection : true,
         mediaContainer: null,
         mediaControls : false,


### PR DESCRIPTION
1) Now the HTML is structured like this:
````
<div class="wrapper">
 <wave>
  <wave><canvas/></wave> <--- regular wave
  <wave><canvas/></wave> <--- progress wave
 <wave>
</div>
````
Versus the old way:
````
<div class="wrapper">
 <wave>
  <wave><canvas/></wave> <--- progress wave
  <canvas/> <--- regular wave
 <wave>
</div>
````
2) I also added an `invertTransparency` option. It can be used like this: `invertTransparency: true` or `invertTransparency: {cutColor: 'black'}`
This will create a transparent area where the wave normally is. The `cutColor` (default `#fefefe`) slightly affects how the wave is cut out -- how crisp it is.

3) Miscellaneous structural changes...

4) Added `cursorAlignment` option. Default is "middle" (before this change, cursors always aligned to the left). Can be one of `left`, `middle`, or `right`. Anything other than `middle` or `right` is assumed to be `left`.