### PR TITLE
Fix variable redeclaration in the timeline plugin

### DIFF
--- a/plugin/wavesurfer.timeline.js
+++ b/plugin/wavesurfer.timeline.js
@@ -169,8 +169,8 @@ WaveSurfer.Timeline = {
                 }
 
                 if (seconds/60 > 1) {
-                    var minutes = parseInt(seconds / 60),
-                        seconds = parseInt(seconds % 60);
+                    var minutes = parseInt(seconds / 60);
+                    seconds = parseInt(seconds % 60);
                     seconds = (seconds < 10) ? '0' + seconds : seconds;
                     return '' + minutes + ':' + seconds;
                 } else {


### PR DESCRIPTION
Fixes a variable redeclaration in the timeline plugin, allowing it compile in TypeScript without warnings.