### PR TITLE
Fixed playback reset on resizing

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -344,7 +344,6 @@ export default class WaveSurfer extends util.Observer {
         this._onResize = util.debounce(() => {
             if (prevWidth != this.drawer.wrapper.clientWidth) {
                 prevWidth = this.drawer.wrapper.clientWidth;
-                this.empty();
                 this.drawBuffer();
             }
         }, typeof this.params.responsive === 'number' ? this.params.responsive : 100);


### PR DESCRIPTION
This is a fork from V2 (next).
I removed the call to `.empty()`when handling the resize of the container when `responsive`is set to `true`.
This allow the playback to keep going when resizing the container.
I'm not sure about the side effects this could have in edge cases but it seems to work. Please have a look and tell me what you think.