### PR TITLE
Wrap 'if' in curly braces

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -287,7 +287,9 @@ export default class Drawer extends util.Observer {
     destroy() {
         this.unAll();
         if (this.wrapper) {
-            if (this.wrapper.parentNode == this.container) this.container.removeChild(this.wrapper);
+            if (this.wrapper.parentNode == this.container) {
+                this.container.removeChild(this.wrapper);
+            }
             this.wrapper = null;
         }
     }


### PR DESCRIPTION
Solves the following warning in `npm run start`:
```ERROR in ./src/drawer.js

./wavesurfer.js/src/drawer.js
  290:13  error  Expected { after 'if' condition  curly

✖ 1 problem (1 error, 0 warnings)```

Signed-off-by: Dimid Duchovny <dimidd@gmail.com>