### PR TITLE
Waveform rendering bug

### DIFF
--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -72,7 +72,7 @@ export default class MultiCanvas extends Drawer {
         this.progressWave = this.wrapper.appendChild(
             this.style(document.createElement('wave'), {
                 position: 'absolute',
-                zIndex: 2,
+                zIndex: 3,
                 left: 0,
                 top: 0,
                 bottom: 0,

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -179,7 +179,7 @@ export default class WaveSurfer extends util.Observer {
         cursorWidth   : 1,
         dragSelection : true,
         fillParent    : true,
-        forceDecode   : true,
+        forceDecode   : false,
         height        : 128,
         hideScrollbar : false,
         interact      : true,

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -882,8 +882,7 @@ export default class WaveSurfer extends util.Observer {
         const parentWidth = this.drawer.getWidth();
         let width = nominalWidth;
         let start = this.drawer.getScrollX();
-        let end = Math.min(start + parentWidth, width);
-
+        let end = Math.max(start + parentWidth, width);
         // Fill container
         if (this.params.fillParent && (!this.params.scrollParent || nominalWidth < parentWidth)) {
             width = parentWidth;
@@ -900,8 +899,6 @@ export default class WaveSurfer extends util.Observer {
                 this.drawer.drawPeaks(peaks, width, newRanges[i][0], newRanges[i][1]);
             }
         } else {
-            start = 0;
-            end = width;
             peaks = this.backend.getPeaks(width, start, end);
             this.drawer.drawPeaks(peaks, width, start, end);
         }


### PR DESCRIPTION
### Short description of changes:
* Fixed the waveform cut off bug #1181
* Refactored drawing functions to use `prepareDraw` where the commonly used calculations are done, the actual rendering function is passed in as a callback. This is not critical for the fix but I did it to be able to bettter understand the differences and similiarities between `drawWave` and `drawBars` and I think it definitiely cleans up those functions quite a bit.
* Sets `forceDecode` param to false by default (see #1159 – that PR was merged to *next*, not to the *master*)– ( @katspaugh can you delete the next branch so there's less confusion, thanks)

I've checked this change locally ([Demo](https://www.webpackbin.com/bins/-KsYKsFIq8FjVe-HQec_)):
* Both backends
* With and without peaks
* partialRender
* Zooming
* Resizing
* Changing pixel ratio

… and I'm pretty happy with the way it's holding up. There are a few scenarios which I've noticed don't work but I think they didn't work beforehand and may even be partially unsolvable due to technical limitations. (See Notes below)

### Breaking in the external API:
Not that I'm aware of.

### Breaking changes in the internal API:
Not that I'm aware of.

### Todos/Notes:
- Combination of `partialRender=true`, `backend=MediaElement` and `no peaks` don't render sometimes. I haven't investigated in detail but I believe the peak data from the cache isn't available on the first render.
- Combination of `backend=WebAudio` and `peaks provided` aren't capable to rendering according to `minPxPerSec` param. I believe the WebAudio backend has no knowledge of the duration of the audio before decoding (unlike MediaElement which has through `audio.duration`) – So this might be unfixable without specifying an audio length property manually in the load property. But I'm not sure.

### Related Issues and other PRs:
- #1182 is a previous attempt at a fix.