### PR TITLE
Feature: Reset zoom/unzoom

### DIFF
--- a/spec/wavesurfer.spec.js
+++ b/spec/wavesurfer.spec.js
@@ -107,7 +107,7 @@ describe('WaveSurfer/playback:', function () {
     /** @test {WaveSurfer#zoom}  */
     it('should set unzoom parameters', function () {
         wavesurfer.zoom(false);
-        expect(wavesurfer.params.minPxPerSec).toEqual(null);
+        expect(wavesurfer.params.minPxPerSec).toEqual(wavesurfer.defaultParams.minPxPerSec);
         expect(wavesurfer.params.scrollParent).toBe(false);
     });
 });

--- a/spec/wavesurfer.spec.js
+++ b/spec/wavesurfer.spec.js
@@ -96,4 +96,18 @@ describe('WaveSurfer/playback:', function () {
         wavesurfer.setMute(false);
         expect(wavesurfer.isMuted).toBeFalse();
     });
+
+    /** @test {WaveSurfer#zoom}  */
+    it('should set zoom parameters', function () {
+        wavesurfer.zoom(20);
+        expect(wavesurfer.params.minPxPerSec).toEqual(20);
+        expect(wavesurfer.params.scrollParent).toBe(true);
+    });
+
+    /** @test {WaveSurfer#zoom}  */
+    it('should set unzoom parameters', function () {
+        wavesurfer.zoom(false);
+        expect(wavesurfer.params.minPxPerSec).toEqual(null);
+        expect(wavesurfer.params.scrollParent).toBe(false);
+    });
 });

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -910,16 +910,22 @@ export default class WaveSurfer extends util.Observer {
 
     /**
      * Horizontally zooms the waveform in and out. It also changes the parameter
-     * `minPxPerSec` and enables the `scrollParent` option.
+     * `minPxPerSec` and enables the `scrollParent` option. Calling the function
+     * with a falsey parameter will reset the zoom state.
      *
-     * @param {number} pxPerSec Number of horizontal pixels per second of audio
+     * @param {number?} pxPerSec Number of horizontal pixels per second of
+     * audio, if none is set the waveform returns to unzoomed state
      * @emits WaveSurfer#zoom
      * @example wavesurfer.zoom(20);
      */
     zoom(pxPerSec) {
-        this.params.minPxPerSec = pxPerSec;
-
-        this.params.scrollParent = true;
+        if (!pxPerSec) {
+            this.params.minPxPerSec = null;
+            this.params.scrollParent = false;
+        } else {
+            this.params.minPxPerSec = pxPerSec;
+            this.params.scrollParent = true;
+        }
 
         this.drawBuffer();
         this.drawer.progress(this.backend.getPlayedPercents());

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -920,7 +920,7 @@ export default class WaveSurfer extends util.Observer {
      */
     zoom(pxPerSec) {
         if (!pxPerSec) {
-            this.params.minPxPerSec = null;
+            this.params.minPxPerSec = this.defaultParams.minPxPerSec;
             this.params.scrollParent = false;
         } else {
             this.params.minPxPerSec = pxPerSec;

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -913,7 +913,7 @@ export default class WaveSurfer extends util.Observer {
      * `minPxPerSec` and enables the `scrollParent` option. Calling the function
      * with a falsey parameter will reset the zoom state.
      *
-     * @param {number?} pxPerSec Number of horizontal pixels per second of
+     * @param {?number} pxPerSec Number of horizontal pixels per second of
      * audio, if none is set the waveform returns to unzoomed state
      * @emits WaveSurfer#zoom
      * @example wavesurfer.zoom(20);


### PR DESCRIPTION
### Short description of changes:
* Adds the ability to call `wavesurfer.zoom` without a parameter (or with a falsey parameter) to reset zoom state
* Adds test for the properties set in the zoom method. (Doesn't currently test the right functions are being called)

### Breaking in the external API:
None.

### Breaking changes in the internal API:
None.