### PR TITLE
Fix: Minimap rendering bug(s)

### DIFF
--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -92,17 +92,25 @@ export default class MinimapPlugin {
          * @see https://github.com/katspaugh/wavesurfer.js/issues/736
          */
         this.renderEvent = ws.params.backend === 'MediaElement' ? 'waveform-ready' : 'ready';
-        this.renderEvent = 'ready';
+        this.overviewRegion = null;
+
+        this.drawer.createWrapper();
+        this.createElements();
+
+        let isInitialised = false;
 
         // ws ready event listener
         this._onShouldRender = () => {
+            // only bind the events in the first run
+            if (!isInitialised) {
+                this.bindWavesurferEvents();
+                this.bindMinimapEvents();
+                isInitialised = true;
+            }
             if (!document.body.contains(this.params.container)) {
                 ws.container.insertBefore(this.params.container, null);
             }
-            this.drawer.createWrapper();
-            this.createElements();
-            this.bindWavesurferEvents();
-            this.bindMinimapEvents();
+
             if (this.wavesurfer.regions && this.params.showRegions) {
                 this.regions();
             }
@@ -275,6 +283,7 @@ export default class MinimapPlugin {
     }
 
     render() {
+        this.drawer.progress(0);
         const len = this.drawer.getWidth();
         const peaks = this.wavesurfer.backend.getPeaks(len, 0, len);
         this.drawer.drawPeaks(peaks, len, 0, len);

--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -283,10 +283,10 @@ export default class MinimapPlugin {
     }
 
     render() {
-        this.drawer.progress(0);
         const len = this.drawer.getWidth();
         const peaks = this.wavesurfer.backend.getPeaks(len, 0, len);
         this.drawer.drawPeaks(peaks, len, 0, len);
+        this.drawer.progress(this.wavesurfer.backend.getPlayedPercents());
 
         if (this.params.showOverview) {
             //get proportional width of overview region considering the respective

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1059,6 +1059,7 @@ export default class WaveSurfer extends util.Observer {
             this.backend.once('canplay', () => {
                 this.drawBuffer();
                 this.fireEvent('ready');
+                this.isReady = true;
             }),
             this.backend.once('error', err => this.fireEvent('error', err))
         );


### PR DESCRIPTION
### Short description of changes:

- Minimap waveform is completely removed and readded when new audio is loaded
- Minimap playback position is correctly set a) when the plugin is added dynamically and b) "statically"
- `wavesurfer.isReady` flag is also set when using the media element backend (this fixes another media element/minimap rendering bug)

### Breaking in the external API:

None.

### Breaking changes in the internal API:

None.

### Related Issues and other PRs:

- fixes #617
