### PR TITLE
ws.addRegion should return region

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -445,7 +445,7 @@ export default class RegionsPlugin {
                     if (!this.initialisedPluginList.regions) {
                         this.initPlugin('regions');
                     }
-                    this.regions.add(options);
+                    return this.regions.add(options);
                 },
 
                 clearRegions() {


### PR DESCRIPTION
### Short description of changes:
* The method `ws.addRegion` that the regions plugin adds to the wavesurfer instance should return the region added

### Breaking in the external API:
/

### Breaking changes in the internal API:
/

### Todos/Notes:
/

### Related Issues and other PRs:
* Fixes #1204 