### PR TITLE
Fix: Bugs with responsive parameter

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -30,11 +30,12 @@ class Region {
 
         this.maxLength = params.maxLength;
         this.minLength = params.minLength;
+        this._onRedraw = () => this.updateRender();
 
         this.bindInOut();
         this.render();
-        this.onZoom = this.updateRender.bind(this);
-        this.wavesurfer.on('zoom', this.onZoom);
+        this.wavesurfer.on('zoom', this._onRedraw);
+        this.wavesurfer.on('redraw', this._onRedraw);
         this.wavesurfer.fireEvent('region-created', this);
     }
 
@@ -82,7 +83,8 @@ class Region {
             this.wrapper.removeChild(this.element);
             this.element = null;
             this.fireEvent('remove');
-            this.wavesurfer.un('zoom', this.onZoom);
+            this.wavesurfer.un('zoom', this._onRedraw);
+            this.wavesurfer.un('redraw', this._onRedraw);
             this.wavesurfer.fireEvent('region-removed', this);
         }
     }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -524,7 +524,7 @@ export default class WaveSurfer extends util.Observer {
         this.drawer.init();
         this.fireEvent('drawer-created', this.drawer);
 
-        if (this.params.responsive) {
+        if (this.params.responsive !== false) {
             window.addEventListener('resize', this._onResize, true);
         }
 
@@ -1295,7 +1295,7 @@ export default class WaveSurfer extends util.Observer {
         this.cancelAjax();
         this.clearTmpEvents();
         this.unAll();
-        if (this.params.responsive) {
+        if (this.params.responsive !== false) {
             window.removeEventListener('resize', this._onResize, true);
         }
         this.backend.destroy();

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -354,7 +354,7 @@ export default class WaveSurfer extends util.Observer {
         this._onResize = util.debounce(() => {
             if (prevWidth != this.drawer.wrapper.clientWidth && !this.params.scrollParent) {
                 prevWidth = this.drawer.wrapper.clientWidth;
-                this.drawBuffer();
+                this.drawer.fireEvent('redraw');
             }
         }, typeof this.params.responsive === 'number' ? this.params.responsive : 100);
 

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -352,7 +352,10 @@ export default class WaveSurfer extends util.Observer {
         // timeout for the debounce function.
         let prevWidth = 0;
         this._onResize = util.debounce(() => {
-            if (prevWidth != this.drawer.wrapper.clientWidth && !this.params.scrollParent) {
+            if (
+                prevWidth != this.drawer.wrapper.clientWidth &&
+                !this.params.scrollParent
+            ) {
                 prevWidth = this.drawer.wrapper.clientWidth;
                 this.drawer.fireEvent('redraw');
             }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -529,6 +529,7 @@ export default class WaveSurfer extends util.Observer {
 
         if (this.params.responsive !== false) {
             window.addEventListener('resize', this._onResize, true);
+            window.addEventListener('orientationchange', this._onResize, true);
         }
 
         this.drawer.on('redraw', () => {
@@ -1300,6 +1301,11 @@ export default class WaveSurfer extends util.Observer {
         this.unAll();
         if (this.params.responsive !== false) {
             window.removeEventListener('resize', this._onResize, true);
+            window.removeEventListener(
+                'orientationchange',
+                this._onResize,
+                true
+            );
         }
         this.backend.destroy();
         this.drawer.destroy();

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -352,7 +352,7 @@ export default class WaveSurfer extends util.Observer {
         // timeout for the debounce function.
         let prevWidth = 0;
         this._onResize = util.debounce(() => {
-            if (prevWidth != this.drawer.wrapper.clientWidth) {
+            if (prevWidth != this.drawer.wrapper.clientWidth && !this.params.scrollParent) {
                 prevWidth = this.drawer.wrapper.clientWidth;
                 this.drawBuffer();
             }


### PR DESCRIPTION
### Short description of changes:
- The responsive parameter didn't accept `0` because it is a falsey value. This meant that a debounce timeout of `0` was not possible.
- Resizing function (when `responsive` is set) should only be called if `scrollParent` is not true
- Progress was incorrectly scaled when the waveform was resized. This was fixed by using the `redraw` event
- Regions didn't scale/reposition correctly when the wave was resized
- Resize also happens on `orientationchange` event

### Breaking in the external API:
/

### Breaking changes in the internal API:
/

### Todos/Notes:
- Contains parts of #1210 

### Related Issues and other PRs:
- See #1097 
- See #1146 