### PR TITLE
Fix: changed the fired redraw event after drawBuffer to redrew

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -890,7 +890,7 @@ export default class WaveSurfer extends util.Observer {
      * Get the correct peaks for current wave viewport and render wave
      *
      * @private
-     * @emits WaveSurfer#redraw
+     * @emits WaveSurfer#redrew
      */
     drawBuffer() {
         const nominalWidth = Math.round(
@@ -937,7 +937,7 @@ export default class WaveSurfer extends util.Observer {
             peaks = this.backend.getPeaks(width, start, end);
             this.drawer.drawPeaks(peaks, width, start, end);
         }
-        this.fireEvent('redraw', peaks, width);
+        this.fireEvent('redrew', peaks, width);
     }
 
     /**


### PR DESCRIPTION
### Short description of changes:

Changed the fired `redraw` event at the end of `drawBuffer` to `redrew` otherwise there would be a hypothetical loop since `drawBuffer` is called when `redraw` is fired:
```javascript
// in createDrawer:
this.drawer.on('redraw', () => {
  this.drawBuffer();
  this.drawer.progress(this.backend.getPlayedPercents());
});
```

* `redraw` is fired in order to make the waveform rerender
* `redrew` is fired when the waveform was rerendered.

### Breaking in the external API:
* Hypothetically this could break code which relies on the "second" redraw event (= at the end of drawBuffer).

### Breaking changes in the internal API:
* See above. AFAIK none of the internal code actually broke.

### Todos/Notes:
* Contains parts of #1210

### Related Issues and other PRs:
/