### PR TITLE
Fix:Timeline plugin incorrectly iterates over canvases

### DIFF
--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -364,8 +364,8 @@ export default class TimelinePlugin {
         let xOffset = 0;
         let i;
 
-        for (i in this.canvases) {
-            const context = this.canvases[i].getContext('2d');
+        this.canvases.forEach(canvas => {
+            const context = canvas.getContext('2d');
             const canvasWidth = context.canvas.width;
 
             if (xOffset > x + textWidth) {


### PR DESCRIPTION
### Short description of changes:
Changed for-in loop to forEach loop to avoid enumerating over Array's prototype attributes.


### Breaking in the external API:


### Breaking changes in the internal API:


### Todos/Notes:


### Related Issues and other PRs:
[#1222](https://github.com/katspaugh/wavesurfer.js/pull/1222)