### PR TITLE
Fix #745: Check seekTo progress parameter and return understandable error

### DIFF
--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -362,14 +362,13 @@ export default class TimelinePlugin {
     fillText(text, x, y) {
         let textWidth;
         let xOffset = 0;
-        let i;
 
         this.canvases.forEach(canvas => {
             const context = canvas.getContext('2d');
             const canvasWidth = context.canvas.width;
 
             if (xOffset > x + textWidth) {
-                break;
+                return;
             }
 
             if (xOffset + canvasWidth > x) {
@@ -378,6 +377,6 @@ export default class TimelinePlugin {
             }
 
             xOffset += canvasWidth;
-        }
+        });
     }
 }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -739,6 +739,16 @@ export default class WaveSurfer extends util.Observer {
      * wavesurfer.seekTo(0.5);
      */
     seekTo(progress) {
+        if (
+            typeof progress !== 'number' ||
+            !isFinite(progress) ||
+            progress < 0 ||
+            progress > 1
+        ) {
+            return console.error(
+                'Error calling wavesurfer.seekTo, parameter must be a number between 0 and 1!'
+            );
+        }
         this.fireEvent('interaction', () => this.seekTo(progress));
 
         const paused = this.backend.isPaused();

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -739,6 +739,7 @@ export default class WaveSurfer extends util.Observer {
      * wavesurfer.seekTo(0.5);
      */
     seekTo(progress) {
+        // return an error if progress is not a number between 0 and 1
         if (
             typeof progress !== 'number' ||
             !isFinite(progress) ||


### PR DESCRIPTION
### Short description of changes:
- Checks whether the progress parameter passed to `wavesurfer.seekTo` is
  - a number
  - not NaN
  - between 0 and 1


### Breaking in the external API:
/

### Breaking changes in the internal API:
/

### Todos/Notes:
Also includes the build fixing commit from #1233 in order to be able build.

### Related Issues and other PRs:
- "Fixes" #745 by providing a readable error message.
- "Fixes" #1228