### PR TITLE
Fix: Removed unnecessary playback position calculation in seekTo

### DIFF
--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -362,14 +362,13 @@ export default class TimelinePlugin {
     fillText(text, x, y) {
         let textWidth;
         let xOffset = 0;
-        let i;
 
         this.canvases.forEach(canvas => {
             const context = canvas.getContext('2d');
             const canvasWidth = context.canvas.width;
 
             if (xOffset > x + textWidth) {
-                break;
+                return;
             }
 
             if (xOffset + canvasWidth > x) {
@@ -378,6 +377,6 @@ export default class TimelinePlugin {
             }
 
             xOffset += canvasWidth;
-        }
+        });
     }
 }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -750,7 +750,7 @@ export default class WaveSurfer extends util.Observer {
         const oldScrollParent = this.params.scrollParent;
         this.params.scrollParent = false;
         this.backend.seekTo(progress * this.getDuration());
-        this.drawer.progress(this.backend.getPlayedPercents());
+        this.drawer.progress(progress);
 
         if (!paused) {
             this.backend.play();


### PR DESCRIPTION
### Short description of changes:
- removed unnecessary `this.backend.getPlayedPercents()` in `wavesurfer.seekTo` – reuses the `progress` parameter which already represents the correct value.

### Breaking in the external API:
/

### Breaking changes in the internal API:
/

### Todos/Notes:
Also includes the build fixing commit from #1233 in order to be able build.

### Related Issues and other PRs:
/