### PR TITLE
Fix #973: Check whether preload attribute will be used and log warnings if not

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -71,13 +71,13 @@ export default class MediaElement extends WebAudio {
     }
 
     /**
-     *  Create media element with url as its source,
-     *  and append to container element.
+     * Create media element with url as its source,
+     * and append to container element.
      *
-     *  @param {string} url Path to media file
-     *  @param {HTMLElement} container HTML element
-     *  @param {Array} peaks Array of peak data
-     *  @param {string} preload HTML 5 preload attribute value
+     * @param {string} url Path to media file
+     * @param {HTMLElement} container HTML element
+     * @param {number[]|number[][]} peaks Array of peak data
+     * @param {string} preload HTML 5 preload attribute value
      */
     load(url, container, peaks, preload) {
         const media = document.createElement(this.mediaType);
@@ -97,10 +97,10 @@ export default class MediaElement extends WebAudio {
     }
 
     /**
-     *  Load existing media element.
+     * Load existing media element.
      *
-     *  @param {MediaElement} elt HTML5 Audio or Video element
-     *  @param {Array} peaks Array of peak data
+     * @param {HTMLMediaElement} elt HTML5 Audio or Video element
+     * @param {number[]|number[][]} peaks Array of peak data
      */
     loadElt(elt, peaks) {
         elt.controls = this.params.mediaControls;
@@ -110,17 +110,20 @@ export default class MediaElement extends WebAudio {
     }
 
     /**
-     *  Private method called by both load (from url)
-     *  and loadElt (existing media element).
+     * Private method called by both load (from url)
+     * and loadElt (existing media element).
      *
-     *  @param  {MediaElement}  media     HTML5 Audio or Video element
-     *  @param  {Array}         peaks   array of peak data
-     *  @private
+     * @param {HTMLMediaElement} media HTML5 Audio or Video element
+     * @param {number[]|number[][]} peaks Array of peak data
+     * @private
      */
     _load(media, peaks) {
         // load must be called manually on iOS, otherwise peaks won't draw
         // until a user interaction triggers load --> 'ready' event
         if (typeof media.load == 'function') {
+            // Resets the media element and restarts the media resource. Any
+            // pending events are discarded. How much media data is fetched is
+            // still affected by the preload attribute.
             media.load();
         }
 
@@ -229,9 +232,9 @@ export default class MediaElement extends WebAudio {
     /**
      * Plays the loaded audio region.
      *
-     * @param {Number} start Start offset in seconds, relative to the beginning
+     * @param {number} start Start offset in seconds, relative to the beginning
      * of a clip.
-     * @param {Number} end When to stop relative to the beginning of a clip.
+     * @param {number} end When to stop relative to the beginning of a clip.
      * @emits MediaElement#play
      */
     play(start, end) {

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -362,14 +362,13 @@ export default class TimelinePlugin {
     fillText(text, x, y) {
         let textWidth;
         let xOffset = 0;
-        let i;
 
         this.canvases.forEach(canvas => {
             const context = canvas.getContext('2d');
             const canvasWidth = context.canvas.width;
 
             if (xOffset > x + textWidth) {
-                break;
+                return;
             }
 
             if (xOffset + canvasWidth > x) {
@@ -378,6 +377,6 @@ export default class TimelinePlugin {
             }
 
             xOffset += canvasWidth;
-        }
+        });
     }
 }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -622,7 +622,7 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Set the current play time in seconds.
      *
-     * @param {Number} seconds A positive number in seconds. E.g. 10 means 10
+     * @param {number} seconds A positive number in seconds. E.g. 10 means 10
      * seconds, 60 means 1 minute
      */
     setCurrentTime(seconds) {
@@ -1021,9 +1021,10 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Loads audio and re-renders the waveform.
      *
-     * @param {string} url The url of the audio file
-     * @param {?number[]|number[][]} peaks Wavesurfer does not have to decode the audio to
-     * render the waveform if this is specified
+     * @param {string|HTMLMediaElement} url The url of the audio file or the
+     * audio element with the audio
+     * @param {?number[]|number[][]} peaks Wavesurfer does not have to decode
+     * the audio to render the waveform if this is specified
      * @param {?string} preload (Use with backend `MediaElement`)
      * `'none'|'metadata'|'auto'` Preload attribute for the media element
      * @example
@@ -1077,7 +1078,7 @@ export default class WaveSurfer extends util.Observer {
      * Either create a media element, or load an existing media element.
      *
      * @private
-     * @param {string|HTMLElement} urlOrElt Either a path to a media file, or an
+     * @param {string|HTMLMediaElement} urlOrElt Either a path to a media file, or an
      * existing HTML5 Audio/Video Element
      * @param {number[]|number[][]} peaks Array of peaks. Required to bypass web audio
      * dependency

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1042,6 +1042,30 @@ export default class WaveSurfer extends util.Observer {
         this.empty();
         this.isMuted = false;
 
+        if (preload) {
+            // check whether the preload attribute will be usable and if not log
+            // a warning listing the reasons why not and nullify the variable
+            const preloadIgnoreReasons = {
+                "Preload is not 'auto', 'none' or 'metadata'":
+                    ['auto', 'metadata', 'none'].indexOf(preload) === -1,
+                'Peaks are not provided': !peaks,
+                'Backend is not of type MediaElement':
+                    this.params.backend !== 'MediaElement',
+                'Url is not of type string': typeof url !== 'string'
+            };
+            const activeReasons = Object.keys(preloadIgnoreReasons).filter(
+                reason => preloadIgnoreReasons[reason]
+            );
+            if (activeReasons.length) {
+                console.warn(
+                    'Preload parameter of wavesurfer.load will be ignored because:\n\t- ' +
+                        activeReasons.join('\n\t- ')
+                );
+                // stop invalid values from being used
+                preload = null;
+            }
+        }
+
         switch (this.params.backend) {
             case 'WebAudio':
                 return this.loadBuffer(url, peaks);


### PR DESCRIPTION
### Short description of changes:
- Check whether preload attribute will be used and log warnings if not:
  - `preload` is not a valid value
  - `peaks` are not provided
  - backend is not of type `MediaElement`
  - url is not of type string
- Also updated jsdoc comments (mostly in `mediaelement.js`)

### Breaking in the external API:
/

### Breaking changes in the internal API:
/

### Todos/Notes:
/

### Related Issues and other PRs:
- Fixes the fixable part of #973 (providing informative warning messages) – Apparently the preload attribute is merely a hint to the browser and cannot prevent it from loading audio.
- Contains #1233 in order for the PR to be buildable