### PR TITLE
Fix #1226 #967: Refactoring of timeline plugin

### DIFF
--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -223,7 +223,7 @@ export default class TimelinePlugin {
     destroy() {
         this.unAll();
         this.wavesurfer.un('redraw', this._onRedraw);
-        this.wavesurfer.un('zoom', this._onRedraw);
+        this.wavesurfer.un('zoom', this._onZoom);
         this.wavesurfer.un('ready', this._onReady);
         this.wavesurfer.drawer.wrapper.removeEventListener(
             'scroll',

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -131,7 +131,7 @@ export default class TimelinePlugin {
 
         this.canvases = [];
 
-        this._onZoom = () => this.render();
+        this._onZoom = () => ws.util.debounce(() => this.render(), 100);
         this._onScroll = () => {
             if (this.wrapper && this.drawer.wrapper) {
                 this.wrapper.scrollLeft = this.drawer.wrapper.scrollLeft;

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -362,14 +362,13 @@ export default class TimelinePlugin {
     fillText(text, x, y) {
         let textWidth;
         let xOffset = 0;
-        let i;
 
         this.canvases.forEach(canvas => {
             const context = canvas.getContext('2d');
             const canvasWidth = context.canvas.width;
 
             if (xOffset > x + textWidth) {
-                break;
+                return;
             }
 
             if (xOffset + canvasWidth > x) {
@@ -378,6 +377,6 @@ export default class TimelinePlugin {
             }
 
             xOffset += canvasWidth;
-        }
+        });
     }
 }

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -62,6 +62,14 @@ export default class TimelinePlugin {
         };
     }
 
+    /**
+     * Creates an instance of TimelinePlugin.
+     *
+     * You probably want to use TimelinePlugin.create()
+     *
+     * @param {TimelinePluginParams} params Plugin parameters
+     * @param {object} ws Wavesurfer instance
+     */
     constructor(params, ws) {
         this.container =
             'string' == typeof params.container
@@ -154,6 +162,9 @@ export default class TimelinePlugin {
         };
     }
 
+    /**
+     * Initialisation function used by the plugin API
+     */
     init() {
         this.wavesurfer.on('ready', this._onReady);
         // Check if ws is ready
@@ -162,6 +173,9 @@ export default class TimelinePlugin {
         }
     }
 
+    /**
+     * Destroy function used by the plugin API
+     */
     destroy() {
         this.unAll();
         this.wavesurfer.un('redraw', this._onRedraw);
@@ -177,6 +191,11 @@ export default class TimelinePlugin {
         }
     }
 
+    /**
+     * Create a timeline element to wrap the canvases drawn by this plugin
+     *
+     * @private
+     */
     createWrapper() {
         const wsParams = this.wavesurfer.params;
         this.container.innerHTML = '';
@@ -324,18 +343,41 @@ export default class TimelinePlugin {
         }
     }
 
+    /**
+     * Set the canvas fill style
+     *
+     * @param {DOMString|CanvasGradient|CanvasPattern} fillStyle
+     * @private
+     */
     setFillStyles(fillStyle) {
         this.canvases.forEach(canvas => {
             canvas.getContext('2d').fillStyle = fillStyle;
         });
     }
 
+    /**
+     * Set the canvas font
+     *
+     * @param {DOMString} font
+     * @private
+     */
     setFonts(font) {
         this.canvases.forEach(canvas => {
             canvas.getContext('2d').font = font;
         });
     }
 
+    /**
+     * Draw a rectangle on the canvases
+     *
+     * (it figures out the offset for each canvas)
+     *
+     * @param {number} x
+     * @param {number} y
+     * @param {number} width
+     * @param {number} height
+     * @private
+     */
     fillRect(x, y, width, height) {
         this.canvases.forEach((canvas, i) => {
             const leftOffset = i * this.maxCanvasWidth;
@@ -360,6 +402,14 @@ export default class TimelinePlugin {
         });
     }
 
+    /**
+     * Fill a given text on the canvases
+     *
+     * @param {string} text
+     * @param {number} x
+     * @param {number} y
+     * @private
+     */
     fillText(text, x, y) {
         let textWidth;
         let xOffset = 0;

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -179,6 +179,7 @@ export default class TimelinePlugin {
 
     createWrapper() {
         const wsParams = this.wavesurfer.params;
+        this.container.innerHTML = '';
         this.wrapper = this.container.appendChild(
             document.createElement('timeline')
         );

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -11,6 +11,9 @@
  * the main notches
  * @property {string} secondaryFontColor='#000' The colour of the labels next to
  * the secondary notches
+ * @property {number} labelPadding=5 The padding between the label and the notch
+ * @property {?number} zoomDebounce A debounce timeout to increase rendering
+ * performance for large files
  * @property {string} fontFamily='Arial'
  * @property {number} fontSize=10 Font size of labels in pixels
  * @property {function} formatTimeCallback=→00:00
@@ -62,6 +65,37 @@ export default class TimelinePlugin {
         };
     }
 
+    // event handlers
+    /** @private */
+    _onScroll = () => {
+        if (this.wrapper && this.drawer.wrapper) {
+            this.wrapper.scrollLeft = this.drawer.wrapper.scrollLeft;
+        }
+    };
+    /** @private */
+    _onRedraw = () => this.render();
+    /** @private */
+    _onReady = () => {
+        const ws = this.wavesurfer;
+        this.drawer = ws.drawer;
+        this.pixelRatio = ws.drawer.params.pixelRatio;
+        this.maxCanvasWidth = ws.drawer.maxCanvasWidth || ws.drawer.width;
+        this.maxCanvasElementWidth =
+            ws.drawer.maxCanvasElementWidth ||
+            Math.round(this.maxCanvasWidth / this.pixelRatio);
+
+        ws.drawer.wrapper.addEventListener('scroll', this._onScroll);
+        ws.on('redraw', this._onRedraw);
+        ws.on('zoom', this._onZoom);
+        this.render();
+    };
+    /** @private */
+    _onWrapperClick = e => {
+        e.preventDefault();
+        const relX = 'offsetX' in e ? e.offsetX : e.layerX;
+        this.fireEvent('click', relX / this.wrapper.scrollWidth || 0);
+    };
+
     /**
      * Creates an instance of TimelinePlugin.
      *
@@ -71,6 +105,7 @@ export default class TimelinePlugin {
      * @param {object} ws Wavesurfer instance
      */
     constructor(params, ws) {
+        /** @private */
         this.container =
             'string' == typeof params.container
                 ? document.querySelector(params.container)
@@ -79,19 +114,24 @@ export default class TimelinePlugin {
         if (!this.container) {
             throw new Error('No container for wavesurfer timeline');
         }
+        /** @private */
         this.wavesurfer = ws;
+        /** @private */
         this.util = ws.util;
+        /** @private */
         this.params = this.util.extend(
             {},
             {
                 height: 20,
                 notchPercentHeight: 90,
+                labelPadding: 5,
                 primaryColor: '#000',
                 secondaryColor: '#c0c0c0',
                 primaryFontColor: '#000',
                 secondaryFontColor: '#000',
                 fontFamily: 'Arial',
                 fontSize: 10,
+                zoomDebounce: false,
                 formatTimeCallback(seconds) {
                     if (seconds / 60 > 1) {
                         // calculate minutes and seconds from seconds count
@@ -137,29 +177,33 @@ export default class TimelinePlugin {
             params
         );
 
+        /** @private */
         this.canvases = [];
-
-        this._onZoom = () => ws.util.debounce(() => this.render(), 100);
-        this._onScroll = () => {
-            if (this.wrapper && this.drawer.wrapper) {
-                this.wrapper.scrollLeft = this.drawer.wrapper.scrollLeft;
-            }
-        };
-        this._onRedraw = () => this.render();
-        this._onReady = () => {
-            this.drawer = ws.drawer;
-            this.pixelRatio = ws.drawer.params.pixelRatio;
-            this.maxCanvasWidth = ws.drawer.maxCanvasWidth || ws.drawer.width;
-            this.maxCanvasElementWidth =
-                ws.drawer.maxCanvasElementWidth ||
-                Math.round(this.maxCanvasWidth / this.pixelRatio);
-
-            this.createWrapper();
-            this.render();
-            ws.drawer.wrapper.addEventListener('scroll', this._onScroll);
-            ws.on('redraw', this._onRedraw);
-            ws.on('zoom', this._onZoom);
-        };
+        /** @private */
+        this.wrapper = null;
+        /** @private */
+        this.drawer = null;
+        /** @private */
+        this.pixelRatio = null;
+        /** @private */
+        this.maxCanvasWidth = null;
+        /** @private */
+        this.maxCanvasElementWidth = null;
+        /**
+         * This event handler has to be in the constructor function because it
+         * relies on the debounce function which is only available after
+         * instantiation
+         *
+         * Use a debounced function if zoomDebounce is defined
+         *
+         * @private
+         */
+        this._onZoom = this.params.zoomDebounce
+            ? this.wavesurfer.util.debounce(
+                  () => this.render(),
+                  this.params.zoomDebounce
+              )
+            : () => this.render();
     }
 
     /**
@@ -179,13 +223,14 @@ export default class TimelinePlugin {
     destroy() {
         this.unAll();
         this.wavesurfer.un('redraw', this._onRedraw);
-        this.wavesurfer.un('zoom', this._onZoom);
+        this.wavesurfer.un('zoom', this._onRedraw);
         this.wavesurfer.un('ready', this._onReady);
         this.wavesurfer.drawer.wrapper.removeEventListener(
             'scroll',
             this._onScroll
         );
         if (this.wrapper && this.wrapper.parentNode) {
+            this.wrapper.removeEventListener('click', this._onWrapperClick);
             this.wrapper.parentNode.removeChild(this.wrapper);
             this.wrapper = null;
         }
@@ -218,31 +263,31 @@ export default class TimelinePlugin {
             });
         }
 
-        this._onClick = e => {
-            e.preventDefault();
-            const relX = 'offsetX' in e ? e.offsetX : e.layerX;
-            this.fireEvent('click', relX / this.wrapper.scrollWidth || 0);
-        };
-        this.wrapper.addEventListener('click', this._onClick);
+        this.wrapper.addEventListener('click', this._onWrapperClick);
     }
 
-    removeOldCanvases() {
-        while (this.canvases.length > 0) {
-            const canvas = this.canvases.pop();
-            canvas.parentElement.removeChild(canvas);
+    /**
+     * Render the timeline (also updates the already rendered timeline)
+     *
+     * @private
+     */
+    render() {
+        if (!this.wrapper) {
+            this.createWrapper();
         }
+        this.updateCanvases();
+        this.updateCanvasesPositioning();
+        this.renderCanvases();
     }
 
-    createCanvases() {
-        this.removeOldCanvases();
-
-        const totalWidth = Math.round(this.drawer.wrapper.scrollWidth);
-        const requiredCanvases = Math.ceil(
-            totalWidth / this.maxCanvasElementWidth
-        );
-        let i;
-
-        for (i = 0; i < requiredCanvases; i++) {
+    /**
+     * Make sure the correct of timeline canvas elements exist and are cached in
+     * this.canvases
+     *
+     * @private
+     */
+    updateCanvases() {
+        const addCanvas = () => {
             const canvas = this.wrapper.appendChild(
                 document.createElement('canvas')
             );
@@ -251,47 +296,76 @@ export default class TimelinePlugin {
                 position: 'absolute',
                 zIndex: 4
             });
+        };
+        const removeCanvas = () => {
+            const canvas = this.canvases.pop();
+            canvas.parentElement.removeChild(canvas);
+        };
+
+        const totalWidth = Math.round(this.drawer.wrapper.scrollWidth);
+        const requiredCanvases = Math.ceil(
+            totalWidth / this.maxCanvasElementWidth
+        );
+        while (this.canvases.length < requiredCanvases) {
+            addCanvas();
+        }
+
+        while (this.canvases.length > requiredCanvases) {
+            removeCanvas();
         }
     }
 
-    render() {
-        this.createCanvases();
-        this.updateCanvasStyle();
-        this.drawTimeCanvases();
-    }
-
-    updateCanvasStyle() {
-        const requiredCanvases = this.canvases.length;
-        let i;
-        for (i = 0; i < requiredCanvases; i++) {
-            const canvas = this.canvases[i];
-            let canvasWidth = this.maxCanvasElementWidth;
-
-            if (i === requiredCanvases - 1) {
-                canvasWidth =
-                    this.drawer.wrapper.scrollWidth -
-                    this.maxCanvasElementWidth * (requiredCanvases - 1);
-            }
-
+    /**
+     * Update the dimensions and positioning style for all the timeline canvases
+     *
+     * @private
+     */
+    updateCanvasesPositioning() {
+        // cache length for perf
+        const canvasesLength = this.canvases.length;
+        this.canvases.forEach((canvas, i) => {
+            // canvas width is the max element width, or if it is the last the
+            // required width
+            const canvasWidth =
+                i === canvasesLength - 1
+                    ? this.drawer.wrapper.scrollWidth -
+                      this.maxCanvasElementWidth * (canvasesLength - 1)
+                    : this.maxCanvasElementWidth;
+            // set dimensions and style
             canvas.width = canvasWidth * this.pixelRatio;
-            canvas.height = this.params.height * this.pixelRatio;
+            // on certain pixel ratios the canvas appears cut off at the bottom,
+            // therefore leave 1px extra
+            canvas.height = (this.params.height + 1) * this.pixelRatio;
             this.util.style(canvas, {
                 width: `${canvasWidth}px`,
                 height: `${this.params.height}px`,
                 left: `${i * this.maxCanvasElementWidth}px`
             });
-        }
+        });
     }
 
-    drawTimeCanvases() {
-        const backend = this.wavesurfer.backend;
-        const wsParams = this.wavesurfer.params;
+    /**
+     * Render the timeline labels and notches
+     *
+     * @private
+     */
+    renderCanvases() {
         const duration = this.wavesurfer.backend.getDuration();
+        if (duration <= 0) {
+            return;
+        }
+        const wsParams = this.wavesurfer.params;
+        const fontSize = this.params.fontSize * wsParams.pixelRatio;
         const totalSeconds = parseInt(duration, 10) + 1;
         const width =
             wsParams.fillParent && !wsParams.scrollParent
                 ? this.drawer.getWidth()
                 : this.drawer.wrapper.scrollWidth * wsParams.pixelRatio;
+        const height1 = this.params.height * this.pixelRatio;
+        const height2 =
+            this.params.height *
+            (this.params.notchPercentHeight / 100) *
+            this.pixelRatio;
         const pixelsPerSecond = width / duration;
 
         const formatTime = this.params.formatTimeCallback;
@@ -309,38 +383,63 @@ export default class TimelinePlugin {
 
         let curPixel = 0;
         let curSeconds = 0;
-
-        if (duration <= 0) {
-            return;
-        }
-
-        const height1 = this.params.height - 4;
-        const height2 =
-            this.params.height * (this.params.notchPercentHeight / 100) - 4;
-        const fontSize = this.params.fontSize * wsParams.pixelRatio;
         let i;
-
+        // build an array of position data with index, second and pixel data,
+        // this is then used multiple times below
+        const positioning = [];
         for (i = 0; i < totalSeconds / timeInterval; i++) {
-            if (i % primaryLabelInterval == 0) {
-                this.setFillStyles(this.params.primaryColor);
-                this.fillRect(curPixel, 0, 1, height1);
-                this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
-                this.setFillStyles(this.params.primaryFontColor);
-                this.fillText(formatTime(curSeconds), curPixel + 5, height1);
-            } else if (i % secondaryLabelInterval == 0) {
-                this.setFillStyles(this.params.secondaryColor);
-                this.fillRect(curPixel, 0, 1, height1);
-                this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
-                this.setFillStyles(this.params.secondaryFontColor);
-                this.fillText(formatTime(curSeconds), curPixel + 5, height1);
-            } else {
-                this.setFillStyles(this.params.secondaryColor);
-                this.fillRect(curPixel, 0, 1, height2);
-            }
-
+            positioning.push([i, curSeconds, curPixel]);
             curSeconds += timeInterval;
             curPixel += pixelsPerSecond * timeInterval;
         }
+
+        // iterate over each position
+        const renderPositions = cb => {
+            positioning.forEach(pos => {
+                cb(pos[0], pos[1], pos[2]);
+            });
+        };
+
+        // render primary labels
+        this.setFillStyles(this.params.primaryColor);
+        this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
+        this.setFillStyles(this.params.primaryFontColor);
+        renderPositions((i, curSeconds, curPixel) => {
+            if (i % primaryLabelInterval === 0) {
+                this.fillRect(curPixel, 0, 1, height1);
+                this.fillText(
+                    formatTime(curSeconds),
+                    curPixel + this.params.labelPadding * this.pixelRatio,
+                    height1
+                );
+            }
+        });
+
+        // render secondary labels
+        this.setFillStyles(this.params.secondaryColor);
+        this.setFonts(`${fontSize}px ${this.params.fontFamily}`);
+        this.setFillStyles(this.params.secondaryFontColor);
+        renderPositions((i, curSeconds, curPixel) => {
+            if (i % secondaryLabelInterval === 0) {
+                this.fillRect(curPixel, 0, 1, height1);
+                this.fillText(
+                    formatTime(curSeconds),
+                    curPixel + this.params.labelPadding * this.pixelRatio,
+                    height1
+                );
+            }
+        });
+
+        // render the actual notches (when no labels are used)
+        this.setFillStyles(this.params.secondaryColor);
+        renderPositions((i, curSeconds, curPixel) => {
+            if (
+                i % secondaryLabelInterval !== 0 &&
+                i % primaryLabelInterval !== 0
+            ) {
+                this.fillRect(curPixel, 0, 1, height2);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
### Short description of changes:
- Clean timeline container so consecutive file loads don't produce empty canvases
- Refactor timeline plugin to be more like the multi canvas renderer
- Performance optimisations (as described [here](https://www.html5rocks.com/en/tutorials/canvas/performance/)) for rerenders (when zooming)
- Added `labelPadding` parameter to configure the space between notches and labels
- Added `zoomDebounce` parameter to (optionally) specify a debounce timeout when zooming. (Useful for very large files
- Added jsdoc comments


### Breaking in the external API:
/

### Breaking changes in the internal API:
/

### Todos/Notes:
- Performance gains should be more noticeable when #1220 is merged (currently there is one unnecessary timeline redraw happening when zooming)
- Contains #1233 to be able to build

### Related Issues and other PRs:
- Should fix the issues in #1226 
- Should fix #967 for v2