### PR TITLE
Feature: Duration parameter for the load function

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "2.0.0-beta01",
+  "version": "2.0.0-beta03",
   "homepage": "http://wavesurfer-js.org",
   "authors": [
     "katspaugh <katspaugh@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "2.0.0-beta02",
+  "version": "2.0.0-beta03",
   "description": "Interactive navigable audio visualization using Web Audio and Canvas",
   "main": "dist/wavesurfer.min.js",
   "directories": {

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -168,6 +168,9 @@ export default class MediaElement extends WebAudio {
      * @return {number}
      */
     getDuration() {
+        if (this.explicitDuration) {
+            return this.explicitDuration;
+        }
         let duration = (this.buffer || this.media).duration;
         if (duration >= Infinity) {
             // streaming audio

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -362,14 +362,13 @@ export default class TimelinePlugin {
     fillText(text, x, y) {
         let textWidth;
         let xOffset = 0;
-        let i;
 
         this.canvases.forEach(canvas => {
             const context = canvas.getContext('2d');
             const canvasWidth = context.canvas.width;
 
             if (xOffset > x + textWidth) {
-                break;
+                return;
             }
 
             if (xOffset + canvasWidth > x) {
@@ -378,6 +377,6 @@ export default class TimelinePlugin {
             }
 
             xOffset += canvasWidth;
-        }
+        });
     }
 }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1026,8 +1026,10 @@ export default class WaveSurfer extends util.Observer {
      * the audio to render the waveform if this is specified
      * @param {?string} preload (Use with backend `MediaElement`)
      * `'none'|'metadata'|'auto'` Preload attribute for the media element
-     * @param {?number} duration The duration of the audio. This is required to
-     * render the peaks data correctly without having to decode the audio
+     * @param {?number} duration The duration of the audio. This is used to
+     * render the peaks data in the correct size for the audio duration (as
+     * befits the current minPxPerSec and zoom value) without having to decode
+     * the audio.
      * @example
      * // using ajax or media element to load (depending on backend)
      * wavesurfer.load('http://example.com/demo.wav');
@@ -1057,8 +1059,7 @@ export default class WaveSurfer extends util.Observer {
      * @private
      * @param {string} url
      * @param {?number[]|number[][]} peaks
-     * @param {?number} duration The duration of the audio. This is required to
-     * render the peaks data correctly without having to decode the audio
+     * @param {?number} duration
      */
     loadBuffer(url, peaks, duration) {
         const load = action => {
@@ -1087,8 +1088,7 @@ export default class WaveSurfer extends util.Observer {
      * dependency
      * @param {?boolean} preload Set to true if the preload attribute of the
      * audio element should be enabled
-     * @param {?number} duration The duration of the audio. This is required to
-     * render the peaks data correctly without having to decode the audio
+     * @param {?number} duration
      */
     loadMediaElement(urlOrElt, peaks, preload, duration) {
         let url = urlOrElt;

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1022,10 +1022,12 @@ export default class WaveSurfer extends util.Observer {
      * Loads audio and re-renders the waveform.
      *
      * @param {string} url The url of the audio file
-     * @param {?number[]|number[][]} peaks Wavesurfer does not have to decode the audio to
-     * render the waveform if this is specified
+     * @param {?number[]|number[][]} peaks Wavesurfer does not have to decode
+     * the audio to render the waveform if this is specified
      * @param {?string} preload (Use with backend `MediaElement`)
      * `'none'|'metadata'|'auto'` Preload attribute for the media element
+     * @param {?number} duration The duration of the audio. This is required to
+     * render the peaks data correctly without having to decode the audio
      * @example
      * // using ajax or media element to load (depending on backend)
      * wavesurfer.load('http://example.com/demo.wav');
@@ -1037,15 +1039,15 @@ export default class WaveSurfer extends util.Observer {
      *   true,
      * );
      */
-    load(url, peaks, preload) {
+    load(url, peaks, preload, duration) {
         this.empty();
         this.isMuted = false;
 
         switch (this.params.backend) {
             case 'WebAudio':
-                return this.loadBuffer(url, peaks);
+                return this.loadBuffer(url, peaks, duration);
             case 'MediaElement':
-                return this.loadMediaElement(url, peaks, preload);
+                return this.loadMediaElement(url, peaks, preload, duration);
         }
     }
 
@@ -1055,8 +1057,10 @@ export default class WaveSurfer extends util.Observer {
      * @private
      * @param {string} url
      * @param {?number[]|number[][]} peaks
+     * @param {?number} duration The duration of the audio. This is required to
+     * render the peaks data correctly without having to decode the audio
      */
-    loadBuffer(url, peaks) {
+    loadBuffer(url, peaks, duration) {
         const load = action => {
             if (action) {
                 this.tmpEvents.push(this.once('ready', action));
@@ -1065,7 +1069,7 @@ export default class WaveSurfer extends util.Observer {
         };
 
         if (peaks) {
-            this.backend.setPeaks(peaks);
+            this.backend.setPeaks(peaks, duration);
             this.drawBuffer();
             this.tmpEvents.push(this.once('interaction', load));
         } else {
@@ -1083,8 +1087,10 @@ export default class WaveSurfer extends util.Observer {
      * dependency
      * @param {?boolean} preload Set to true if the preload attribute of the
      * audio element should be enabled
+     * @param {?number} duration The duration of the audio. This is required to
+     * render the peaks data correctly without having to decode the audio
      */
-    loadMediaElement(urlOrElt, peaks, preload) {
+    loadMediaElement(urlOrElt, peaks, preload, duration) {
         let url = urlOrElt;
 
         if (typeof urlOrElt === 'string') {
@@ -1111,7 +1117,7 @@ export default class WaveSurfer extends util.Observer {
         // provided with forceDecode flag, attempt to download the
         // audio file and decode it with Web Audio.
         if (peaks) {
-            this.backend.setPeaks(peaks);
+            this.backend.setPeaks(peaks, duration);
         }
 
         if (

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -142,6 +142,8 @@ export default class WebAudio extends util.Observer {
         this.splitPeaks = [];
         /** @private */
         this.state = null;
+        /** @private */
+        this.explicitDuration = null;
     }
 
     /**
@@ -308,9 +310,11 @@ export default class WebAudio extends util.Observer {
     /**
      * Set pre-decoded peaks
      *
-     * @param {Array} peaks
+     * @param {number[]|number[][]} peaks
+     * @param {?number} duration
      */
-    setPeaks(peaks) {
+    setPeaks(peaks, duration) {
+        this.explicitDuration = duration;
         this.peaks = peaks;
     }
 
@@ -512,6 +516,9 @@ export default class WebAudio extends util.Observer {
      */
     getDuration() {
         if (!this.buffer) {
+            if (this.explicitDuration) {
+                return this.explicitDuration;
+            }
             return 0;
         }
         return this.buffer.duration;


### PR DESCRIPTION
### Short description of changes:
Adds an optional duration parameter to `wavesurfer.load` which can be used to explicitly set the duration of the audio (for both backends). This is useful to render the correct wave size in cases where the audio is not decoded:

WebAudio backend with peaks provided currently can't know the duration of the audio and thus always renders it at 100% width initially and then jumps to the correct size on first interaction (when audio is decoded) –
 this can be fixed by using the duration parameter (See one use case in #1210)

### Breaking in the external API:
/

### Breaking changes in the internal API:
/

### Todos/Notes:
- Subsequent calls of `load` overwrite the previous duration
- Once the audio is decoded (a buffer is available in `WebAudio.buffer`) its real length is used

### Related Issues and other PRs:
- Improved duration parameter feature initially proposed in #1210 
- Is required to implement lazy-loading of audio element (see #1237 )
- Contains #1233 in order to be able to build