### PR TITLE
Fix #811: Cursor plugin refactor for improved performance and functionality

### DIFF
--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -57,13 +57,21 @@ export default class CursorPlugin {
     constructor(params, ws) {
         this.wavesurfer = ws;
         this.style = ws.util.style;
+        this._mouseX = null;
         this._onDrawerCreated = () => {
             this.drawer = this.wavesurfer.drawer;
-            this.wrapper = this.wavesurfer.drawer.wrapper;
+            this.wrapper = this.wavesurfer.container;
 
-            this._onMousemove = e =>
-                this.updateCursorPosition(this.drawer.handleEvent(e));
+            this._onMousemove = e => {
+                const bbox = this.wrapper.getBoundingClientRect();
+                this._mouseX = e.clientX - bbox.left;
+                this.updateCursorPosition(this._mouseX);
+            };
             this.wrapper.addEventListener('mousemove', this._onMousemove);
+
+            this._onAudioProcess = () =>
+                this.updateCursorPosition(this._mouseX);
+            this.wavesurfer.on('audioprocess', this._onAudioProcess);
 
             this._onMouseenter = () => this.showCursor();
             this.wrapper.addEventListener('mouseenter', this._onMouseenter);
@@ -72,7 +80,7 @@ export default class CursorPlugin {
             this.wrapper.addEventListener('mouseleave', this._onMouseleave);
 
             this.cursor = this.wrapper.appendChild(
-                this.style(document.createElement('wave'), {
+                this.style(document.createElement('cursor'), {
                     position: 'absolute',
                     zIndex: 3,
                     left: 0,
@@ -117,11 +125,8 @@ export default class CursorPlugin {
         }
     }
 
-    updateCursorPosition(progress) {
-        const pos =
-            Math.round(this.drawer.width * progress) /
-                this.drawer.params.pixelRatio -
-            1;
+    updateCursorPosition(pos) {
+        console.log('POS: ', pos);
         this.style(this.cursor, {
             left: `${pos}px`
         });

--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -1,6 +1,15 @@
 /**
  * @typedef {Object} CursorPluginParams
  * @property {?boolean} deferInit Set to true to stop auto init in `addPlugin()`
+ * @property {boolean} hideOnBlur=true Hide the cursor when the mouse leaves the
+ * waveform
+ * @property {string} width='1px' The width of the cursor
+ * @property {string} color='black' The color of the cursor
+ * @property {string} opacity='0.25' The opacity of the cursor
+ * @property {string} style='solid' The border style of the cursor
+ * @property {number} zIndex=3 The z-index of the cursor element
+ * @property {object} customStyle An object with custom styles which are applied
+ * to the cursor element
  */
 
 /**
@@ -54,90 +63,121 @@ export default class CursorPlugin {
         };
     }
 
+    /**
+     * @type {CursorPluginParams}
+     */
+    defaultParams = {
+        hideOnBlur: true,
+        width: '1px',
+        color: 'black',
+        opacity: '0.25',
+        style: 'solid',
+        zIndex: 4,
+        customStyle: {}
+    };
+
+    /** @private */
+    _onMousemove = e => {
+        const bbox = this.wavesurfer.container.getBoundingClientRect();
+        this.updateCursorPosition(e.clientX - bbox.left);
+    };
+    /** @private */
+    _onMouseenter = () => this.showCursor();
+    /** @private */
+    _onMouseleave = () => this.hideCursor();
+
+    /**
+     * Construct the plugin class. You probably want to use CursorPlugin.create
+     * instead.
+     *
+     * @param {CursorPluginParams} params
+     * @param {object} ws
+     */
     constructor(params, ws) {
+        /** @private */
         this.wavesurfer = ws;
+        /** @private */
         this.style = ws.util.style;
-        this._mouseX = null;
-        this._onDrawerCreated = () => {
-            this.drawer = this.wavesurfer.drawer;
-            this.wrapper = this.wavesurfer.container;
-
-            this._onMousemove = e => {
-                const bbox = this.wrapper.getBoundingClientRect();
-                this._mouseX = e.clientX - bbox.left;
-                this.updateCursorPosition(this._mouseX);
-            };
-            this.wrapper.addEventListener('mousemove', this._onMousemove);
-
-            this._onAudioProcess = () =>
-                this.updateCursorPosition(this._mouseX);
-            this.wavesurfer.on('audioprocess', this._onAudioProcess);
-
-            this._onMouseenter = () => this.showCursor();
-            this.wrapper.addEventListener('mouseenter', this._onMouseenter);
-
-            this._onMouseleave = () => this.hideCursor();
-            this.wrapper.addEventListener('mouseleave', this._onMouseleave);
-
-            this.cursor = this.wrapper.appendChild(
-                this.style(document.createElement('cursor'), {
-                    position: 'absolute',
-                    zIndex: 3,
-                    left: 0,
-                    top: 0,
-                    bottom: 0,
-                    width: '0',
-                    display: 'block',
-                    borderRightStyle: 'solid',
-                    borderRightWidth: 1 + 'px',
-                    borderRightColor: 'black',
-                    opacity: '.25',
-                    pointerEvents: 'none'
-                })
-            );
-        };
+        /**
+         * The cursor html element
+         *
+         * @type {?HTMLElement}
+         */
+        this.cursor = null;
+        /** @private */
+        this.params = ws.util.extend({}, this.defaultParams, params);
     }
 
+    /**
+     * Initialise the plugin (used by the Plugin API)
+     */
     init() {
-        // drawer already existed, just call initialisation code
-        if (this.wavesurfer.drawer) {
-            this._onDrawerCreated();
-        }
+        const wrapper = this.wavesurfer.container;
+        this.cursor = wrapper.appendChild(
+            this.style(
+                document.createElement('cursor'),
+                this.wavesurfer.util.extend(
+                    {
+                        position: 'absolute',
+                        zIndex: this.params.zIndex,
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: '0',
+                        display: 'block',
+                        borderRightStyle: this.params.style,
+                        borderRightWidth: this.params.width,
+                        borderRightColor: this.params.color,
+                        opacity: this.params.opacity,
+                        pointerEvents: 'none'
+                    },
+                    this.params.customStyle
+                )
+            )
+        );
 
-        // the drawer was initialised, call the initialisation code
-        this.wavesurfer.on('drawer-created', this._onDrawerCreated);
+        wrapper.addEventListener('mousemove', this._onMousemove);
+        if (this.params.hideOnBlur) {
+            wrapper.addEventListener('mouseenter', this._onMouseenter);
+            wrapper.addEventListener('mouseleave', this._onMouseleave);
+        }
     }
 
+    /**
+     * Destroy the plugin (used by the Plugin API)
+     */
     destroy() {
-        this.wavesurfer.un('drawer-created', this._onDrawerCreated);
-
-        // if cursor was appended, remove it
-        if (this.cursor) {
-            this.cursor.parentNode.removeChild(this.cursor);
-        }
-
-        // if the drawer existed (the cached version referenced in the init code),
-        // remove the event listeners attached to it
-        if (this.drawer) {
-            this.wrapper.removeEventListener('mousemove', this._onMousemove);
+        this.cursor.parentNode.removeChild(this.cursor);
+        this.wrapper.removeEventListener('mousemove', this._onMousemove);
+        if (this.params.hideOnBlur) {
             this.wrapper.removeEventListener('mouseenter', this._onMouseenter);
             this.wrapper.removeEventListener('mouseleave', this._onMouseleave);
         }
     }
 
+    /**
+     * Update the cursor position
+     *
+     * @param {number} pos The x offset of the cursor in pixels
+     */
     updateCursorPosition(pos) {
-        console.log('POS: ', pos);
         this.style(this.cursor, {
             left: `${pos}px`
         });
     }
 
+    /**
+     * Show the cursor
+     */
     showCursor() {
         this.style(this.cursor, {
             display: 'block'
         });
     }
 
+    /**
+     * Hide the cursor
+     */
     hideCursor() {
         this.style(this.cursor, {
             display: 'none'

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -362,14 +362,13 @@ export default class TimelinePlugin {
     fillText(text, x, y) {
         let textWidth;
         let xOffset = 0;
-        let i;
 
         this.canvases.forEach(canvas => {
             const context = canvas.getContext('2d');
             const canvasWidth = context.canvas.width;
 
             if (xOffset > x + textWidth) {
-                break;
+                return;
             }
 
             if (xOffset + canvasWidth > x) {
@@ -378,6 +377,6 @@ export default class TimelinePlugin {
             }
 
             xOffset += canvasWidth;
-        }
+        });
     }
 }


### PR DESCRIPTION
### Short description of changes:
- The cursor element is no longer a child of the wave element, but of the wavesurfer container, this means it isn't moved about when the wave is scrolled (fix for #811 )
- Parameters for all styling options and a `hideOnBlur` option. (Also a `customStyle` parameter to be able to pass custom style without hassle)
- Jsdoc comments for everything

### Breaking in the external API:
- Parameter defaults are the values which are currently being used. This update might break implementations which rely on the exact position of the cursor element in the DOM.
- Cursor element is now over the scroll bar, this has no implication for its functionality though.

### Breaking changes in the internal API:
/

### Todos/Notes:
- Tests are missing as yet

### Related Issues and other PRs:
- Fixes #811 
- Contains #1233 in order to be able to build