### PR TITLE
Apply prettier style to mediaelement.js

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -318,10 +318,11 @@ export default class MediaElement extends WebAudio {
         this.pause();
         this.unAll();
 
-        if (this.params.removeMediaElementOnDestroy &&
+        if (
+            this.params.removeMediaElementOnDestroy &&
             this.media &&
-            this.media.parentNode) {
-
+            this.media.parentNode
+        ) {
             this.media.parentNode.removeChild(this.media);
         }
 


### PR DESCRIPTION
My earlier PR #1163 introduced 2 prettier warnings. Linting errors
apparently do not make the build fail.