### PR TITLE
Fix: MediaElement backend: Update progress on pause events (#1267)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 wavesurfer.js changelog
 =======================
 
+next (unreleased)
+-----------------
+
+- MediaElement backend: Update progress on pause events (#1267) 
+
 2.0.1 (18.12.2017)
 ------------------
 

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -23,7 +23,8 @@ export default class MediaElement extends WebAudio {
             paused: true,
             playbackRate: 1,
             play() {},
-            pause() {}
+            pause() {},
+            volume: 0
         };
 
         /** @private */
@@ -34,6 +35,8 @@ export default class MediaElement extends WebAudio {
         this.peaks = null;
         /** @private */
         this.playbackRate = 1;
+        /** @private */
+        this.volume = 1;
         /** @private */
         this.buffer = null;
         /** @private */
@@ -159,6 +162,7 @@ export default class MediaElement extends WebAudio {
         this.onPlayEnd = null;
         this.buffer = null;
         this.setPlaybackRate(this.playbackRate);
+        this.setVolume(this.volume);
     }
 
     /**
@@ -303,7 +307,7 @@ export default class MediaElement extends WebAudio {
      * @return {number} value A floating point value between 0 and 1.
      */
     getVolume() {
-        return this.media.volume;
+        return this.volume || this.media.volume;
     }
 
     /**
@@ -312,7 +316,8 @@ export default class MediaElement extends WebAudio {
      * @param {number} value A floating point value between 0 and 1.
      */
     setVolume(value) {
-        this.media.volume = value;
+        this.volume = value;
+        this.media.volume = this.volume;
     }
 
     /**

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -68,6 +68,11 @@ export default class MediaElement extends WebAudio {
         };
 
         this.on('play', onAudioProcess);
+
+        // Update the progress one more time to prevent it from being stuck in case of lower framerates
+        this.on('pause', () => {
+            this.fireEvent('audioprocess', this.getCurrentTime());
+        });
     }
 
     /**

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1142,7 +1142,6 @@ export default class WaveSurfer extends util.Observer {
      */
     load(url, peaks, preload, duration) {
         this.empty();
-        this.isMuted = false;
 
         if (preload) {
             // check whether the preload attribute will be usable and if not log


### PR DESCRIPTION
The progress might not get updated if the playback finishes while another tab is active, this happens because in modern browsers the framerate is reduced to save energy.

Fix it by updating the progress one more time using the pause event instead of relying on a high framerate.

This shouldn't break anything and is just a bugfix.