### PR TITLE
Include credentials when fetching audio urls.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -109,6 +109,7 @@ WaveSurfer.util = {
             ajax.fireEvent('error', e);
         });
 
+        xhr.withCredentials = options.sendCredentials || false;
         xhr.send();
         ajax.xhr = xhr;
         return ajax;

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -36,6 +36,7 @@ var WaveSurfer = {
         normalize     : false,
         renderer      : 'MultiCanvas',
         scrollParent  : false,
+        sendCredentials: false,
         skipLength    : 2,
         splitChannels : false,
         waveColor     : '#999',
@@ -518,7 +519,8 @@ var WaveSurfer = {
 
         var ajax = WaveSurfer.util.ajax({
             url: url,
-            responseType: 'arraybuffer'
+            responseType: 'arraybuffer',
+            sendCredentials: this.params.sendCredentials,
         });
 
         this.currentAjax = ajax;


### PR DESCRIPTION
### Short description of changes:
Add options to set withCredentials to true on outgoing requests. This allows accessing audio resources hosted on a different domain.

### Breaking in the external API:
None

### Breaking changes in the internal API:
None

### Todos/Notes:


### Related Issues and other PRs:

  