### PR TITLE
Regions Plugins - prevent Click when creating / updating region

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -11,6 +11,7 @@ class Region {
         this.wavesurfer = ws;
         this.wrapper = ws.drawer.wrapper;
         this.style = ws.util.style;
+        this.util = ws.util;
 
         this.id = params.id == null ? ws.util.getId() : params.id;
         this.start = Number(params.start) || 0;
@@ -296,6 +297,7 @@ class Region {
                 let drag;
                 let maxScroll;
                 let resize;
+                let updated = false;
                 let scrollDirection;
                 let wrapperRect;
 
@@ -369,7 +371,11 @@ class Region {
                         drag = false;
                         scrollDirection = null;
                         resize = false;
+                    }
 
+                    if (updated) {
+                        updated = false;
+                        this.util.preventClick();
                         this.fireEvent('update-end', e);
                         this.wavesurfer.fireEvent('region-update-end', this, e);
                     }
@@ -394,11 +400,13 @@ class Region {
 
                         // Drag
                         if (this.drag && drag) {
+                            updated = updated || !!delta;
                             this.onDrag(delta);
                         }
 
                         // Resize
                         if (this.resize && resize) {
+                            updated = updated || !!delta;
                             this.onResize(delta, resize);
                         }
 
@@ -748,6 +756,7 @@ export default class RegionsPlugin {
             scrollDirection = null;
 
             if (region) {
+                this.util.preventClick();
                 region.fireEvent('update-end', e);
                 this.wavesurfer.fireEvent('region-update-end', region, e);
             }
@@ -756,7 +765,12 @@ export default class RegionsPlugin {
         };
         this.wrapper.addEventListener('mouseup', eventUp);
         this.wrapper.addEventListener('touchend', eventUp);
+
+        document.body.addEventListener('mouseup', eventUp);
+        document.body.addEventListener('touchend', eventUp);
         this.on('disable-drag-selection', () => {
+            document.body.removeEventListener('mouseup', eventUp);
+            document.body.removeEventListener('touchend', eventUp);
             this.wrapper.removeEventListener('touchend', eventUp);
             this.wrapper.removeEventListener('mouseup', eventUp);
         });

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -10,8 +10,8 @@ class Region {
     constructor(params, ws) {
         this.wavesurfer = ws;
         this.wrapper = ws.drawer.wrapper;
-        this.style = ws.util.style;
         this.util = ws.util;
+        this.style = this.util.style;
 
         this.id = params.id == null ? ws.util.getId() : params.id;
         this.start = Number(params.start) || 0;

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -8,3 +8,4 @@ export { default as style } from './style';
 export { default as requestAnimationFrame } from './request-animation-frame';
 export { default as frame } from './frame';
 export { default as debounce } from 'debounce';
+export { default as preventClick } from './prevent-click';

--- a/src/util/prevent-click.js
+++ b/src/util/prevent-click.js
@@ -1,0 +1,8 @@
+function preventClickHandler(e) {
+    e.stopPropagation();
+    document.body.removeEventListener('click', preventClickHandler, true);
+}
+
+export default function preventClick(values) {
+    document.body.addEventListener('click', preventClickHandler, true);
+}


### PR DESCRIPTION
When creating / updating regions, cursor seeks to mouseup position.
Such behaviour should be prevented, and must be part of application logic (e.g. by listening to `region-updated` or `region-created`, seekTo start of region might be useful).
Thus, interactions with regions plugin must be ignored by drawer.

# Fixes
* Prevent once following click event after updating or creating a region with a preventClick util function
* Added mouse up listener on body when creating region to stop resize if cursor leaves waveform
* Do not fire region update-end event if nothing changed

# Notes:
The only way to prevent click events to "bubble" after a `mouseup` is to capture following click event from body (or a parent to the listener), and stop its propagation.

So i added a preventClick util to expose it to future plugins. It should work when called from any mouseDown/mouseMove/mouseUp events

Reference/Idea: https://stackoverflow.com/questions/33364540/prevent-click-event-from-mousedown

# Related Issues:
https://github.com/katspaugh/wavesurfer.js/issues/1064 - Bad region dragging behaviour with cursor
https://github.com/katspaugh/wavesurfer.js/issues/572 - seekTo and seek event fires when creating a region

# Testing
Only tested on Chrome 63
