### PR TITLE
Support for XHR options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ wavesurfer.js changelog
 next (unreleased)
 -----------------
 
+- Added `xhr` option to configure util.ajax for authorization (#1310, #1038, #1100)
 - Fix `setCurrentTime` method (#1292)
 - Fix `getScrollX` method: Check bounds when `scrollParent: true` (#1312)
 - Minimap plugin: fix initial load, canvas click did not work (#1265)

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -13,6 +13,13 @@ export default function ajax(options) {
     let fired100 = false;
     xhr.open(options.method || 'GET', options.url, true);
     xhr.responseType = options.responseType || 'json';
+
+    if (options.requestHeaders) {
+        for (let header in options.requestHeaders) {
+            xhr.setRequestHeader(header.key, header.value);
+        }
+    }
+
     xhr.addEventListener('progress', e => {
         instance.fireEvent('progress', e);
         if (e.lengthComputable && e.loaded == e.total) {

--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -14,9 +14,16 @@ export default function ajax(options) {
     xhr.open(options.method || 'GET', options.url, true);
     xhr.responseType = options.responseType || 'json';
 
-    if (options.requestHeaders) {
-        for (let header in options.requestHeaders) {
-            xhr.setRequestHeader(header.key, header.value);
+    if (options.xhr) {
+        if (options.xhr.requestHeaders) {
+            // add custom request headers
+            for (let header in options.xhr.requestHeaders) {
+                xhr.setRequestHeader(header.key, header.value);
+            }
+        }
+        if (options.xhr.withCredentials) {
+            // use credentials
+            xhr.withCredentials = true;
         }
     }
 

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -89,6 +89,7 @@ import PeakCache from './peakcache';
  * the channels of the audio
  * @property {string} waveColor='#999' The fill color of the waveform after the
  * cursor.
+ * @property {object} xhr={} XHR options.
  */
 
 /**
@@ -207,7 +208,8 @@ export default class WaveSurfer extends util.Observer {
         scrollParent: false,
         skipLength: 2,
         splitChannels: false,
-        waveColor: '#999'
+        waveColor: '#999',
+        xhr: {}
     };
 
     /** @private */
@@ -1136,8 +1138,8 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Loads audio and re-renders the waveform.
      *
-     * @param {string|HTMLMediaElement|object} url The url of the audio file, the
-     * audio element with the audio or an object descripting the AJAX request
+     * @param {string|HTMLMediaElement} url The url of the audio file or the
+     * audio element with the audio
      * @param {?number[]|number[][]} peaks Wavesurfer does not have to decode
      * the audio to render the waveform if this is specified
      * @param {?string} preload (Use with backend `MediaElement`)
@@ -1169,10 +1171,7 @@ export default class WaveSurfer extends util.Observer {
                 'Peaks are not provided': !peaks,
                 'Backend is not of type MediaElement':
                     this.params.backend !== 'MediaElement',
-                'Url is not of type string or object':
-                    typeof url !== 'string' || typeof url !== 'object',
-                'Url object does not contain a "url" property':
-                    typeof url === 'object' && typeof url.url !== 'string'
+                'Url is not of type string': typeof url !== 'string'
             };
             const activeReasons = Object.keys(preloadIgnoreReasons).filter(
                 reason => preloadIgnoreReasons[reason]
@@ -1235,7 +1234,7 @@ export default class WaveSurfer extends util.Observer {
     loadMediaElement(urlOrElt, peaks, preload, duration) {
         let url = urlOrElt;
 
-        if (typeof urlOrElt === 'string' || typeof urlOrElt === 'object') {
+        if (typeof urlOrElt === 'string') {
             this.backend.load(url, this.mediaContainer, peaks, preload);
         } else {
             const elt = urlOrElt;
@@ -1304,20 +1303,16 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Load an array buffer by ajax and pass to a callback
      *
-     * @param {string|object} obj a string or an object for the AJAX request
+     * @param {string} url
      * @param {function} callback
      * @private
      */
-    getArrayBuffer(obj, callback) {
-        const defaultOptions = { responseType: 'arraybuffer' };
-        let options;
-        if (typeof obj === 'object') {
-            options = Object.assign({}, defaultOptions, obj);
-        } else {
-            options = Object.assign({}, defaultOptions, { url: obj });
-        }
-
-        const ajax = util.ajax(options);
+    getArrayBuffer(url, callback) {
+        const ajax = util.ajax({
+            url: url,
+            responseType: 'arraybuffer',
+            xhr: this.params.xhr
+        });
 
         this.currentAjax = ajax;
 

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1170,7 +1170,9 @@ export default class WaveSurfer extends util.Observer {
                 'Backend is not of type MediaElement':
                     this.params.backend !== 'MediaElement',
                 'Url is not of type string or object':
-                    typeof url !== 'string' || typeof url !== 'object'
+                    typeof url !== 'string' || typeof url !== 'object',
+                'Url object does not contain a "url" property':
+                    typeof url === 'object' && typeof url.url !== 'string'
             };
             const activeReasons = Object.keys(preloadIgnoreReasons).filter(
                 reason => preloadIgnoreReasons[reason]

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1136,8 +1136,8 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Loads audio and re-renders the waveform.
      *
-     * @param {string|HTMLMediaElement} url The url of the audio file or the
-     * audio element with the audio
+     * @param {string|HTMLMediaElement|object} url The url of the audio file, the
+     * audio element with the audio or an object descripting the AJAX request
      * @param {?number[]|number[][]} peaks Wavesurfer does not have to decode
      * the audio to render the waveform if this is specified
      * @param {?string} preload (Use with backend `MediaElement`)
@@ -1169,7 +1169,8 @@ export default class WaveSurfer extends util.Observer {
                 'Peaks are not provided': !peaks,
                 'Backend is not of type MediaElement':
                     this.params.backend !== 'MediaElement',
-                'Url is not of type string': typeof url !== 'string'
+                'Url is not of type string or object':
+                    typeof url !== 'string' || typeof url !== 'object'
             };
             const activeReasons = Object.keys(preloadIgnoreReasons).filter(
                 reason => preloadIgnoreReasons[reason]
@@ -1232,7 +1233,7 @@ export default class WaveSurfer extends util.Observer {
     loadMediaElement(urlOrElt, peaks, preload, duration) {
         let url = urlOrElt;
 
-        if (typeof urlOrElt === 'string') {
+        if (typeof urlOrElt === 'string' || typeof urlOrElt === 'object') {
             this.backend.load(url, this.mediaContainer, peaks, preload);
         } else {
             const elt = urlOrElt;
@@ -1301,15 +1302,20 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Load an array buffer by ajax and pass to a callback
      *
-     * @param {string} url
+     * @param {string|object} obj a string or an object for the AJAX request
      * @param {function} callback
      * @private
      */
-    getArrayBuffer(url, callback) {
-        const ajax = util.ajax({
-            url: url,
-            responseType: 'arraybuffer'
-        });
+    getArrayBuffer(obj, callback) {
+        const defaultOptions = { responseType: 'arraybuffer' };
+        let options;
+        if (typeof obj === 'object') {
+            options = Object.assign({}, defaultOptions, obj);
+        } else {
+            options = Object.assign({}, defaultOptions, { url: obj });
+        }
+
+        const ajax = util.ajax(options);
 
         this.currentAjax = ajax;
 


### PR DESCRIPTION
This pull request expands the `load(url)` method to support object initialisation. This means you will be able to add headers and other request specific properties to the load function.

Example:

```js
this.wavesurfer.load({
    url: '/url/to/file.wav',
    requestHeaders: [
        { 
            key: "Authorization": 
            value: "my-token"
        }
    ]
});
```

Other options within `ws.util.ajax` will also be overridable.

### Short description of changes:

- I've added the support for adding request headers on the the XHR request.
- I've handling the support for having the `url` variable both as a string and as a object.
- I've added a preload check whether the object as a minimum contains a `url` property.

### Breaking in the external API:
Should not be any.

### Breaking changes in the internal API:
Should not be any.

### Todos/Notes:
We could argue that `url` is not a suitable name for the variable anymore, since it can now be a string, object and an element. 

### Related Issues and other PRs:
Authorization headers enhancement #1038
#1100 
