### PR TITLE
Keep scrollX in bounds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ next (unreleased)
 
 - Fix `setCurrentTime` method (#1292)
 - Minimap plugin: fix initial load, canvas click did not work (#1265)
+- Fix `getScrollX` method: Check bounds when `scrollParent: true` (#1312)
 
 2.0.3 (22.01.2018)
 ------------------

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -220,7 +220,7 @@ export default class Drawer extends util.Observer {
      * @return {number}
      */
     getScrollX() {
-        return Math.round(this.wrapper.scrollLeft * this.params.pixelRatio);
+        return Math.min(this.getWidth(), Math.max(0, Math.round(this.wrapper.scrollLeft * this.params.pixelRatio)));
     }
 
     /**

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -220,8 +220,11 @@ export default class Drawer extends util.Observer {
      * @return {number}
      */
     getScrollX() {
+        var maxScroll = this.params.scrollParent
+            ? this.wrapper.scrollWidth - this.getWidth()
+            : this.getWidth();
         return Math.min(
-            this.getWidth(),
+            maxScroll,
             Math.max(
                 0,
                 Math.round(this.wrapper.scrollLeft * this.params.pixelRatio)

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -220,20 +220,23 @@ export default class Drawer extends util.Observer {
      * @return {number}
      */
     getScrollX() {
-        var maxScroll = this.params.scrollParent
-            ? ~~(
-                  this.wrapper.scrollWidth * this.params.pixelRatio -
-                  this.getWidth()
-              )
-            : this.getWidth();
+        const pixelRatio = this.params.pixelRatio;
+        let x = Math.round(this.wrapper.scrollLeft * pixelRatio);
 
-        return Math.min(
-            maxScroll,
-            Math.max(
-                0,
-                Math.round(this.wrapper.scrollLeft * this.params.pixelRatio)
-            )
-        );
+        // In cases of elastic scroll (safari with mouse wheel) you can
+        // scroll beyond the limits of the container
+        // Calculate and floor the scrollable extent to make sure an out
+        // of bounds value is not returned
+        // https://github.com/katspaugh/wavesurfer.js/issues/1312
+        if (this.params.scrollParent) {
+            const maxScroll = ~~(
+                this.wrapper.scrollWidth * pixelRatio -
+                this.getWidth()
+            );
+            x = Math.min(maxScroll, Math.max(0, x));
+        }
+
+        return x;
     }
 
     /**

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -227,7 +227,7 @@ export default class Drawer extends util.Observer {
         // scroll beyond the limits of the container
         // Calculate and floor the scrollable extent to make sure an out
         // of bounds value is not returned
-        // https://github.com/katspaugh/wavesurfer.js/issues/1312
+        // Ticket #1312
         if (this.params.scrollParent) {
             const maxScroll = ~~(
                 this.wrapper.scrollWidth * pixelRatio -

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -220,7 +220,13 @@ export default class Drawer extends util.Observer {
      * @return {number}
      */
     getScrollX() {
-        return Math.min(this.getWidth(), Math.max(0, Math.round(this.wrapper.scrollLeft * this.params.pixelRatio)));
+        return Math.min(
+            this.getWidth(),
+            Math.max(
+                0,
+                Math.round(this.wrapper.scrollLeft * this.params.pixelRatio)
+            )
+        );
     }
 
     /**

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -221,8 +221,12 @@ export default class Drawer extends util.Observer {
      */
     getScrollX() {
         var maxScroll = this.params.scrollParent
-            ? this.wrapper.scrollWidth - this.getWidth()
+            ? ~~(
+                  this.wrapper.scrollWidth * this.params.pixelRatio -
+                  this.getWidth()
+              )
             : this.getWidth();
+
         return Math.min(
             maxScroll,
             Math.max(


### PR DESCRIPTION
### Short description of changes:
Keep scrollX from going beyond the container or below 0.

### Notes:
The only disadvantage I see to this check happening here, is if someone is counting on special behavior when using elastic scroll beyond the container extents. In which case `drawBuffer` needs to be checking that `start`/`end` stay in bounds.

### Related Issues and other PRs:
fixes #1312