### PR TITLE
Fix #1292: setCurrentTime condition fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 wavesurfer.js changelog
 =======================
 
+next (unreleased)
+-----------------
+
+- Fix `setCurrentTime` method (#1292)
+- Minimap plugin: fix initial load, canvas click did not work (#1265)
+
 2.0.3 (22.01.2018)
 ------------------
 

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -633,7 +633,7 @@ export default class WaveSurfer extends util.Observer {
      * seconds, 60 means 1 minute
      */
     setCurrentTime(seconds) {
-        if (this.getDuration() >= seconds) {
+        if (seconds >= this.getDuration()) {
             this.seekTo(1);
         } else {
             this.seekTo(seconds / this.getDuration());


### PR DESCRIPTION
### Short description of changes:
Check that seconds is greater than or equal to duration and not the other way around.
Just fixed a reversed condition. `this.getDuration() >= seconds` should [generally always] be true and was causing legitimate sets to skip to the end.

### Related Issues and other PRs:
fixes #1292
#1046