### PR TITLE
Regions plugin - Scroll when near edges of container

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,9 @@ next (unreleased)
 -----------------
 
 - Fix `setCurrentTime` method (#1292)
-- Minimap plugin: fix initial load, canvas click did not work (#1265)
 - Fix `getScrollX` method: Check bounds when `scrollParent: true` (#1312)
+- Minimap plugin: fix initial load, canvas click did not work (#1265)
+- Regions plugin: fix dragging a region utside of scrollbar (#430)
 
 2.0.3 (22.01.2018)
 ------------------


### PR DESCRIPTION
When dragging, if mouse or region edge is near the container's edges, scroll in that direction.

### Short description of changes:
Added checks, within region mouse move events, to scroll the container when within a certain threshold of the container's edges.

New region plugin options available:
`scroll` - defaults to true
`scrollSpeed` - defaults to 1
`scrollThreshold` - defaults to 10

### Related Issues and other PRs:
fixes #430 