### PR TITLE
Bugfixed the  iteration on the array

### DIFF
--- a/src/util/ajax.js
+++ b/src/util/ajax.js
@@ -17,9 +17,9 @@ export default function ajax(options) {
     if (options.xhr) {
         if (options.xhr.requestHeaders) {
             // add custom request headers
-            for (let header in options.xhr.requestHeaders) {
+            options.xhr.requestHeaders.forEach(header => {
                 xhr.setRequestHeader(header.key, header.value);
-            }
+            });
         }
         if (options.xhr.withCredentials) {
             // use credentials


### PR DESCRIPTION
Seems like there has been a mistake on how to iterate the request headers, where that has been used `for ... in` on an array. 

Now it uses the `array.forEach()` instead. 
