### PR TITLE
Suggestion for always wavesurfer work on LTR independant of inheritance

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -295,7 +295,7 @@ export default class WaveSurfer extends util.Observer {
         }
 
         /** set dir always ltr, only way 'today' to work independant of inheritance */
-        this.container.dir='ltr';
+        this.container.dir = 'ltr';
 
         if (this.params.maxCanvasWidth <= 1) {
             throw new Error('maxCanvasWidth must be greater than 1');

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -294,6 +294,9 @@ export default class WaveSurfer extends util.Observer {
             throw new Error('Media Container element not found');
         }
 
+        /** set dir always ltr, only way 'today' to work independant of inheritance */
+        this.container.dir='ltr';
+
         if (this.params.maxCanvasWidth <= 1) {
             throw new Error('maxCanvasWidth must be greater than 1');
         } else if (this.params.maxCanvasWidth % 2 == 1) {


### PR DESCRIPTION
see #1319 : with this change, wavesurfer.js always work and stay Left to Rigth (like audio) with correct functionnality if it's use in HTML form with dir ='RTL' since a global RTL implementation #1296 ?

