### PR TITLE
Update isReady attribute

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1449,6 +1449,7 @@ export default class WaveSurfer extends util.Observer {
             this.stop();
             this.backend.disconnectSource();
         }
+        this.isReady = false;
         this.cancelAjax();
         this.clearTmpEvents();
         this.drawer.progress(0);


### PR DESCRIPTION
### Short description of changes:
The isReady attribute is set to false at the creation of a wavesurfer. Then, It is set to true when a song is loaded but it is never set to false when emptying the wavesufer. As a result, after the first song is loaded, isReady return true even if the wavesurfer is empty.
