### PR TITLE
timeline plugin: add parameters for start time value and format

### DIFF
--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -16,7 +16,9 @@
  * performance for large files
  * @property {string} fontFamily='Arial'
  * @property {number} fontSize=10 Font size of labels in pixels
- * @property {function} formatTimeCallback=→00:00
+ * @property {number} startSeconds=0 Start time in second for begining timeline rule
+ * @property {string} formatTime='MM:SS' default time format for timeline rule, can be change to'HH:MM:SS'
+ * @property {function} formatTimeCallback=→00:00 (or 00:00:00 depend of formatTime property)
  * @property {?boolean} deferInit Set to true to manually call
  * `initPlugin('timeline')`
  */
@@ -132,14 +134,26 @@ export default class TimelinePlugin {
                 fontFamily: 'Arial',
                 fontSize: 10,
                 zoomDebounce: false,
-                formatTimeCallback(seconds) {
+                startSeconds : 0,
+                formatTime : 'MM:SS',
+                formatTimeCallback(seconds, format) {
                     if (seconds / 60 > 1) {
                         // calculate minutes and seconds from seconds count
-                        const minutes = parseInt(seconds / 60, 10);
+                        minutes = parseInt(seconds / 60, 10);
                         seconds = parseInt(seconds % 60, 10);
                         // fill up seconds with zeroes
                         seconds = seconds < 10 ? '0' + seconds : seconds;
-                        return `${minutes}:${seconds}`;
+                        if (format === 'HH:MM:SS') {
+                            // calculate hours from minutes
+                            var hours = parseInt(minutes / 60, 10);
+                            minutes = parseInt(minutes % 60, 10);
+                            // fill up minutes and hours with zeroes
+                            minutes = minutes < 10 ? '0' + minutes : minutes;
+                            hours = hours < 10 ? '0' + hours : hours;
+                            return `${hours}:${minutes}:${seconds}`;
+                        } else {
+                            return `${minutes}:${seconds}`;
+                        }
                     }
                     return Math.round(seconds * 1000) / 1000;
                 },
@@ -382,7 +396,7 @@ export default class TimelinePlugin {
         );
 
         let curPixel = 0;
-        let curSeconds = 0;
+        let curSeconds = this.params.startSeconds;
         let i;
         // build an array of position data with index, second and pixel data,
         // this is then used multiple times below
@@ -408,7 +422,7 @@ export default class TimelinePlugin {
             if (i % primaryLabelInterval === 0) {
                 this.fillRect(curPixel, 0, 1, height1);
                 this.fillText(
-                    formatTime(curSeconds),
+                    formatTime(curSeconds, this.params.formatTime),
                     curPixel + this.params.labelPadding * this.pixelRatio,
                     height1
                 );
@@ -423,7 +437,7 @@ export default class TimelinePlugin {
             if (i % secondaryLabelInterval === 0) {
                 this.fillRect(curPixel, 0, 1, height1);
                 this.fillText(
-                    formatTime(curSeconds),
+                    formatTime(curSeconds, this.params.formatTime),
                     curPixel + this.params.labelPadding * this.pixelRatio,
                     height1
                 );

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -134,8 +134,8 @@ export default class TimelinePlugin {
                 fontFamily: 'Arial',
                 fontSize: 10,
                 zoomDebounce: false,
-                startSeconds : 0,
-                formatTime : 'MM:SS',
+                startSeconds: 0,
+                formatTime: 'MM:SS',
                 formatTimeCallback(seconds, format) {
                     if (seconds / 60 > 1) {
                         // calculate minutes and seconds from seconds count

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -137,7 +137,7 @@ export default class TimelinePlugin {
                 startSeconds: 0,
                 formatTime: 'MM:SS',
                 formatTimeCallback(seconds, format) {
-                    if (seconds / 60 > 1  || format === 'HH:MM:SS') {
+                    if (seconds / 60 > 1 || format === 'HH:MM:SS') {
                         // calculate minutes and seconds from seconds count
                         var minutes = parseInt(seconds / 60, 10);
                         seconds = parseInt(seconds % 60, 10);

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -16,9 +16,9 @@
  * performance for large files
  * @property {string} fontFamily='Arial'
  * @property {number} fontSize=10 Font size of labels in pixels
- * @property {number} startSeconds=0 Start time in second for begining timeline rule
- * @property {string} formatTime='MM:SS' default time format for timeline rule, can be change to'HH:MM:SS'
- * @property {function} formatTimeCallback=→00:00 (or 00:00:00 depend of formatTime property)
+ * @property {number} startSeconds=0 Start time in seconds for beginning timeline rule
+ * @property {string} formatTime='MM:SS' default time format for timeline rule, can be changed to 'HH:MM:SS'
+ * @property {function} formatTimeCallback=00:00 (or 00:00:00 depend of formatTime property)
  * @property {?boolean} deferInit Set to true to manually call
  * `initPlugin('timeline')`
  */

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -137,7 +137,7 @@ export default class TimelinePlugin {
                 startSeconds: 0,
                 formatTime: 'MM:SS',
                 formatTimeCallback(seconds, format) {
-                    if (seconds / 60 > 1) {
+                    if (seconds / 60 > 1  || format === 'HH:MM:SS') {
                         // calculate minutes and seconds from seconds count
                         var minutes = parseInt(seconds / 60, 10);
                         seconds = parseInt(seconds % 60, 10);

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -18,7 +18,7 @@
  * @property {number} fontSize=10 Font size of labels in pixels
  * @property {number} startSeconds=0 Start time in seconds for beginning timeline rule
  * @property {string} formatTime='MM:SS' default time format for timeline rule, can be changed to 'HH:MM:SS'
- * @property {function} formatTimeCallback=00:00 (or 00:00:00 depend of formatTime property)
+ * @property {function} formatTimeCallback=00:00 (or 00:00:00 depending on formatTime property)
  * @property {?boolean} deferInit Set to true to manually call
  * `initPlugin('timeline')`
  */

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -139,7 +139,7 @@ export default class TimelinePlugin {
                 formatTimeCallback(seconds, format) {
                     if (seconds / 60 > 1) {
                         // calculate minutes and seconds from seconds count
-                        minutes = parseInt(seconds / 60, 10);
+                        var minutes = parseInt(seconds / 60, 10);
                         seconds = parseInt(seconds % 60, 10);
                         // fill up seconds with zeroes
                         seconds = seconds < 10 ? '0' + seconds : seconds;


### PR DESCRIPTION
fixes #1380 

Make startSeconds like a parametre can be change initial value.
Add formatTime parameter to have possibility to change default format

No change on current using timeLine !

Can be call when create wavesurfer like this to change startSecond and/or cahnge formatTime :
 
`plugins: [TimelinePlugin.create({container: '#waveform-timeline', startSeconds: 3600, formatTime: 'HH:MM:SS'})]`



