### PR TITLE
Typo ?

### DIFF
--- a/example/audio-element/index.html
+++ b/example/audio-element/index.html
@@ -76,7 +76,7 @@
                     you can pass them into the <code>load</code>
                     function. This is optional–if you don't provide
                     any peaks,
-                    <strong>waserver.js</strong> will first draw a
+                    <strong>wavesurfer.js</strong> will first draw a
                     thin line instead of a waveform, then attempt to
                     download the audio file via Ajax and decode it
                     with Web Audio if available.


### PR DESCRIPTION
```waserver.js``` should be ```wavesurfer.js``` , no ?

