### PR TITLE
regions plugin: display regions before file load

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -665,6 +665,7 @@ export default class RegionsPlugin {
 
     destroy() {
         this.wavesurfer.un('ready', this._onReady);
+        this.wavesurfer.un('backend-created', this._onBackendCreated);
         this.disableDragSelection();
         this.clear();
     }

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -177,34 +177,34 @@ class Region {
 
     /* Update element's position, width, color. */
     updateRender() {
-        // Duration varies during loading process, so don't overwrite important data
+        // duration varies during loading process, so don't overwrite important data
         const dur = this.wavesurfer.getDuration();
         const width = this.getWidth();
 
-        var start_limited = this.start;
-        var end_limited = this.end;
-        if (start_limited < 0) {
-            start_limited = 0;
-            end_limited = end_limited - start_limited;
+        var startLimited = this.start;
+        var endLimited = this.end;
+        if (startLimited < 0) {
+            startLimited = 0;
+            endLimited = endLimited - startLimited;
         }
-        if (end_limited > dur) {
-            end_limited = dur;
-            start_limited = dur - (end_limited - start_limited);
+        if (endLimited > dur) {
+            endLimited = dur;
+            startLimited = dur - (endLimited - startLimited);
         }
 
         if (this.minLength != null) {
-            end_limited = Math.max(start_limited + this.minLength, end_limited);
+            endLimited = Math.max(startLimited + this.minLength, endLimited);
         }
 
         if (this.maxLength != null) {
-            end_limited = Math.min(start_limited + this.maxLength, end_limited);
+            endLimited = Math.min(startLimited + this.maxLength, endLimited);
         }
 
         if (this.element != null) {
             // Calculate the left and width values of the region such that
             // no gaps appear between regions.
-            const left = Math.round((start_limited / dur) * width);
-            const regionWidth = Math.round((end_limited / dur) * width) - left;
+            const left = Math.round((startLimited / dur) * width);
+            const regionWidth = Math.round((endLimited / dur) * width) - left;
 
             this.style(this.element, {
                 left: left + 'px',

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -177,31 +177,34 @@ class Region {
 
     /* Update element's position, width, color. */
     updateRender() {
+        // Duration varies during loading process, so don't overwrite important data
         const dur = this.wavesurfer.getDuration();
         const width = this.getWidth();
 
-        if (this.start < 0) {
-            this.start = 0;
-            this.end = this.end - this.start;
+        var start_limited = this.start;
+        var end_limited = this.end;
+        if (start_limited < 0) {
+            start_limited = 0;
+            end_limited = end_limited - start_limited;
         }
-        if (this.end > dur) {
-            this.end = dur;
-            this.start = dur - (this.end - this.start);
+        if (end_limited > dur) {
+            end_limited = dur;
+            start_limited = dur - (end_limited - start_limited);
         }
 
         if (this.minLength != null) {
-            this.end = Math.max(this.start + this.minLength, this.end);
+            end_limited = Math.max(start_limited + this.minLength, end_limited);
         }
 
         if (this.maxLength != null) {
-            this.end = Math.min(this.start + this.maxLength, this.end);
+            end_limited = Math.min(start_limited + this.maxLength, end_limited);
         }
 
         if (this.element != null) {
             // Calculate the left and width values of the region such that
             // no gaps appear between regions.
-            const left = Math.round((this.start / dur) * width);
-            const regionWidth = Math.round((this.end / dur) * width) - left;
+            const left = Math.round((start_limited / dur) * width);
+            const regionWidth = Math.round((end_limited / dur) * width) - left;
 
             this.style(this.element, {
                 left: left + 'px',
@@ -644,6 +647,9 @@ export default class RegionsPlugin {
             if (this.params.dragSelection) {
                 this.enableDragSelection(this.params);
             }
+            Object.keys(this.list).forEach(id => {
+                this.list[id].updateRender();
+            });
         };
     }
 

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -629,15 +629,18 @@ export default class RegionsPlugin {
         });
         this.wavesurfer.Region = Region;
 
-        // Id-based hash of regions.
-        this.list = {};
-        this._onReady = () => {
+        this._onBackendCreated = () => {
             this.wrapper = this.wavesurfer.drawer.wrapper;
             if (this.params.regions) {
                 this.params.regions.forEach(region => {
                     this.add(region);
                 });
             }
+        };
+
+        // Id-based hash of regions.
+        this.list = {};
+        this._onReady = () => {
             if (this.params.dragSelection) {
                 this.enableDragSelection(this.params);
             }
@@ -647,9 +650,11 @@ export default class RegionsPlugin {
     init() {
         // Check if ws is ready
         if (this.wavesurfer.isReady) {
+            this._onBackendCreated();
             this._onReady();
         }
         this.wavesurfer.on('ready', this._onReady);
+        this.wavesurfer.on('backend-created', this._onBackendCreated);
     }
 
     destroy() {

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -39,6 +39,8 @@ import PeakCache from './peakcache';
  * @property {string} cursorColor='#333' The fill color of the cursor indicating
  * the playhead position.
  * @property {number} cursorWidth=1 Measured in pixels.
+ * @property {number} duration=null Optional audio length so pre-rendered peaks
+ * can be display immediately for example.
  * @property {boolean} fillParent=true Whether to fill the entire container or
  * draw only according to `minPxPerSec`.
  * @property {boolean} forceDecode=false Force decoding of audio using web audio
@@ -187,7 +189,7 @@ export default class WaveSurfer extends util.Observer {
         cursorColor: '#333',
         cursorWidth: 1,
         dragSelection: true,
-        explicitDuration: null,
+        duration: null,
         fillParent: true,
         forceDecode: false,
         height: 128,

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -187,6 +187,7 @@ export default class WaveSurfer extends util.Observer {
         cursorColor: '#333',
         cursorWidth: 1,
         dragSelection: true,
+        explicitDuration: null,
         fillParent: true,
         forceDecode: false,
         height: 128,

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -392,6 +392,9 @@ export default class WebAudio extends util.Observer {
         if (this.peaks) {
             return this.peaks;
         }
+        if (!this.buffer) {
+            return [];
+        }
 
         first = first || 0;
         last = last || length - 1;

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -143,7 +143,7 @@ export default class WebAudio extends util.Observer {
         /** @private */
         this.state = null;
         /** @private */
-        this.explicitDuration = null;
+        this.explicitDuration = params.explicitDuration;
     }
 
     /**
@@ -347,7 +347,9 @@ export default class WebAudio extends util.Observer {
      * @param {?number} duration
      */
     setPeaks(peaks, duration) {
-        this.explicitDuration = duration;
+        if (duration != null) {
+            this.explicitDuration = duration;
+        }
         this.peaks = peaks;
     }
 
@@ -551,10 +553,10 @@ export default class WebAudio extends util.Observer {
      * @return {number}
      */
     getDuration() {
+        if (this.explicitDuration) {
+            return this.explicitDuration;
+        }
         if (!this.buffer) {
-            if (this.explicitDuration) {
-                return this.explicitDuration;
-            }
             return 0;
         }
         return this.buffer.duration;

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -143,7 +143,7 @@ export default class WebAudio extends util.Observer {
         /** @private */
         this.state = null;
         /** @private */
-        this.explicitDuration = params.explicitDuration;
+        this.explicitDuration = params.duration;
     }
 
     /**


### PR DESCRIPTION
Pre-generated peaks waits for the audio length, either from loaded audio or from explicitDuration. This PR adds explicitDuration as an argument for the WebAudio constructor. This allows it to be defined up front.

I've also updated the regions plugin initialization to make use of this information so the "backend-created" event is used to add regions, rather than the "ready" event which only fires when a song has finished loading.
