### PR TITLE
Change the time format for seconds from ceil to floor 

### DIFF
--- a/example/angular-material/wavesurfer.directive.js
+++ b/example/angular-material/wavesurfer.directive.js
@@ -101,7 +101,7 @@
             }
 
             var minutes = Math.floor(input / 60);
-            var seconds = Math.ceil(input) % 60;
+            var seconds = Math.floor(input) % 60;
 
             return (
                 (minutes < 10 ? '0' : '') +


### PR DESCRIPTION
### Short description of changes:
In the Angular Player example, when the time was suppose to hit a new minute and display 01:00 or 02:00 it would display 00:00 for one second before displaying 01:01 or 02:01. By changing the format function it now displays each minute properly and the length is the actual file length.  


