### PR TITLE
plugins: fix microphone plugin on MS Edge 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,12 @@ wavesurfer.js changelog
 2.0.7 (unreleased)
 ------------------
 
+- Fix microphone plugin on MS Edge browser (#627)
 - Add wavesurfer.js logo, created by @entonbiba (#1409)
 - Library version number is now available as `WaveSurfer.VERSION` (#1430)
 - Fix `setSinkId` that used deprecated API (#1428)
 - Set `isReady` attribute to false when emptying wavesufer (#1396, #1403)
+- Fix cursor plugin `destroy` (#1435)
 
 2.0.6 (14.06.2018)
 ------------------

--- a/src/plugin/microphone.js
+++ b/src/plugin/microphone.js
@@ -219,8 +219,10 @@ export default class MicrophonePlugin {
             // - Firefox 44 (https://www.fxsitecompat.com/en-US/docs/2015/mediastream-stop-has-been-deprecated/)
             // - Chrome 45 (https://developers.google.com/web/updates/2015/07/mediastream-deprecations)
             if (
-                (this.browser.browser === 'chrome' && this.browser.version >= 45) ||
-                (this.browser.browser === 'firefox' && this.browser.version >= 44) ||
+                (this.browser.browser === 'chrome' &&
+                    this.browser.version >= 45) ||
+                (this.browser.browser === 'firefox' &&
+                    this.browser.version >= 44) ||
                 this.browser.browser === 'edge'
             ) {
                 if (this.stream.getTracks) {

--- a/src/plugin/microphone.js
+++ b/src/plugin/microphone.js
@@ -240,12 +240,14 @@ export default class MicrophonePlugin {
      */
     connect() {
         if (this.stream !== undefined) {
-            // Create a local buffer for data to be copied to the Wavesurfer buffer
-            this.localAudioBuffer = this.micContext.createBuffer(
-                this.numberOfInputChannels,
-                this.bufferSize,
-                this.micContext.sampleRate
-            );
+            // Create a local buffer for data to be copied to the Wavesurfer buffer for Edge
+            if (this.browser === 'edge') {
+                this.localAudioBuffer = this.micContext.createBuffer(
+                    this.numberOfInputChannels,
+                    this.bufferSize,
+                    this.micContext.sampleRate
+                );
+            }
 
             // Create an AudioNode from the stream.
             this.mediaStreamSource = this.micContext.createMediaStreamSource(

--- a/src/plugin/microphone.js
+++ b/src/plugin/microphone.js
@@ -62,6 +62,7 @@ export default class MicrophonePlugin {
 
         this.active = false;
         this.paused = false;
+        this.browser = this.detectBrowser().browser;
         this.reloadBufferFunction = e => this.reloadBuffer(e);
 
         // cross-browser getUserMedia
@@ -286,25 +287,30 @@ export default class MicrophonePlugin {
      */
     reloadBuffer(event) {
         if (!this.paused) {
-            // copy audio data to a local audio buffer,
-            // from https://github.com/audiojs/audio-buffer-utils
-            let channel, l;
-            for (
-                channel = 0,
-                    l = Math.min(
-                        this.localAudioBuffer.numberOfChannels,
-                        event.inputBuffer.numberOfChannels
-                    );
-                channel < l;
-                channel++
-            ) {
-                this.localAudioBuffer
-                    .getChannelData(channel)
-                    .set(event.inputBuffer.getChannelData(channel));
-            }
-
             this.wavesurfer.empty();
-            this.wavesurfer.loadDecodedBuffer(this.localAudioBuffer);
+
+            if (this.browser === 'edge') {
+                // copy audio data to a local audio buffer,
+                // from https://github.com/audiojs/audio-buffer-utils
+                let channel, l;
+                for (
+                    channel = 0,
+                        l = Math.min(
+                            this.localAudioBuffer.numberOfChannels,
+                            event.inputBuffer.numberOfChannels
+                        );
+                    channel < l;
+                    channel++
+                ) {
+                    this.localAudioBuffer
+                        .getChannelData(channel)
+                        .set(event.inputBuffer.getChannelData(channel));
+                }
+
+                this.wavesurfer.loadDecodedBuffer(this.localAudioBuffer);
+            } else {
+                this.wavesurfer.loadDecodedBuffer(event.inputBuffer);
+            }
         }
     }
 

--- a/src/plugin/microphone.js
+++ b/src/plugin/microphone.js
@@ -221,7 +221,7 @@ export default class MicrophonePlugin {
             if (
                 (this.browser.browser === 'chrome' && this.browser.version >= 45) ||
                 (this.browser.browser === 'firefox' && this.browser.version >= 44) ||
-                 this.browser.browser === 'edge'
+                this.browser.browser === 'edge'
             ) {
                 if (this.stream.getTracks) {
                     // note that this should not be a call

--- a/src/plugin/microphone.js
+++ b/src/plugin/microphone.js
@@ -286,9 +286,11 @@ export default class MicrophonePlugin {
      */
     reloadBuffer(event) {
         if (!this.paused) {
-            // copy audio data to a local audio buffer
+            // copy audio data to a local audio buffer,
+            // from https://github.com/audiojs/audio-buffer-utils
+            let channel, l;
             for (
-                var channel = 0,
+                channel = 0,
                     l = Math.min(
                         this.localAudioBuffer.numberOfChannels,
                         event.inputBuffer.numberOfChannels

--- a/src/plugin/microphone.js
+++ b/src/plugin/microphone.js
@@ -239,7 +239,7 @@ export default class MicrophonePlugin {
      */
     connect() {
         if (this.stream !== undefined) {
-            // Create a local buffer for data
+            // Create a local buffer for data to be copied to the Wavesurfer buffer
             this.localAudioBuffer = this.micContext.createBuffer(
                 this.numberOfInputChannels,
                 this.bufferSize,
@@ -286,10 +286,7 @@ export default class MicrophonePlugin {
      */
     reloadBuffer(event) {
         if (!this.paused) {
-            this.wavesurfer.empty();
-
-            // copy audio buffer from onaudioprocess to a local buffer,
-            // function from audio-buffer-utils library
+            // copy audio data to a local audio buffer
             for (
                 var channel = 0,
                     l = Math.min(
@@ -304,6 +301,7 @@ export default class MicrophonePlugin {
                     .set(event.inputBuffer.getChannelData(channel));
             }
 
+            this.wavesurfer.empty();
             this.wavesurfer.loadDecodedBuffer(this.localAudioBuffer);
         }
     }

--- a/src/plugin/microphone.js
+++ b/src/plugin/microphone.js
@@ -62,7 +62,7 @@ export default class MicrophonePlugin {
 
         this.active = false;
         this.paused = false;
-        this.browser = this.detectBrowser().browser;
+        this.browser = this.detectBrowser();
         this.reloadBufferFunction = e => this.reloadBuffer(e);
 
         // cross-browser getUserMedia
@@ -215,14 +215,13 @@ export default class MicrophonePlugin {
 
         // stop stream from device
         if (this.stream) {
-            const result = this.detectBrowser();
             // MediaStream.stop is deprecated since:
             // - Firefox 44 (https://www.fxsitecompat.com/en-US/docs/2015/mediastream-stop-has-been-deprecated/)
             // - Chrome 45 (https://developers.google.com/web/updates/2015/07/mediastream-deprecations)
             if (
-                (result.browser === 'chrome' && result.version >= 45) ||
-                (result.browser === 'firefox' && result.version >= 44) ||
-                result.browser === 'edge'
+                (this.browser.browser === 'chrome' && this.browser.version >= 45) ||
+                (this.browser.browser === 'firefox' && this.browser.version >= 44) ||
+                 this.browser.browser === 'edge'
             ) {
                 if (this.stream.getTracks) {
                     // note that this should not be a call
@@ -241,7 +240,7 @@ export default class MicrophonePlugin {
     connect() {
         if (this.stream !== undefined) {
             // Create a local buffer for data to be copied to the Wavesurfer buffer for Edge
-            if (this.browser === 'edge') {
+            if (this.browser.browser === 'edge') {
                 this.localAudioBuffer = this.micContext.createBuffer(
                     this.numberOfInputChannels,
                     this.bufferSize,
@@ -291,7 +290,7 @@ export default class MicrophonePlugin {
         if (!this.paused) {
             this.wavesurfer.empty();
 
-            if (this.browser === 'edge') {
+            if (this.browser.browser === 'edge') {
                 // copy audio data to a local audio buffer,
                 // from https://github.com/audiojs/audio-buffer-utils
                 let channel, l;


### PR DESCRIPTION
This PR just makes the microphone plugin work on Edge: the audio data received from onaudioprocess is first copied to a local AudioBuffer which is passed on instead of the event.inputBuffer. Note that there is a lot of blinking whenever a new buffer is received.

There are no breaking changes.

fixes #627 