### PR TITLE
Fix minimap styling issues and add support for zooming

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,7 @@ process.traceDeprecation = true;
 
 require('babel-register');
 var webpackConfig = require('./build-config/webpack.prod.main.js');
+webpackConfig.devtool = 'none';
 var ci = process.env.TRAVIS || process.env.APPVEYOR;
 
 // Chrome CLI options

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,6 @@ process.traceDeprecation = true;
 
 require('babel-register');
 var webpackConfig = require('./build-config/webpack.prod.main.js');
-webpackConfig.devtool = 'none';
 var ci = process.env.TRAVIS || process.env.APPVEYOR;
 
 // Chrome CLI options

--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -168,7 +168,7 @@ export default class MinimapPlugin {
             }
         });
         this._onZoom = e => {
-          this.render();
+            this.render();
         };
         this.wavesurfer.on('zoom', this._onZoom);
     }
@@ -368,10 +368,14 @@ export default class MinimapPlugin {
     moveOverviewRegion(pixels) {
         if (pixels < 0) {
             this.overviewPosition = 0;
-        } else if (pixels + this.overviewWidth < this.drawer.container.offsetWidth) {
+        } else if (
+            pixels + this.overviewWidth <
+            this.drawer.container.offsetWidth
+        ) {
             this.overviewPosition = pixels;
         } else {
-            this.overviewPosition = this.drawer.container.offsetWidth - this.overviewWidth;
+            this.overviewPosition =
+                this.drawer.container.offsetWidth - this.overviewWidth;
         }
         this.overviewRegion.style.left = this.overviewPosition + 'px';
         if (this.draggingOverview) {

--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -167,6 +167,10 @@ export default class MinimapPlugin {
                 );
             }
         });
+        this._onZoom = e => {
+          this.render();
+        };
+        this.wavesurfer.on('zoom', this._onZoom);
     }
 
     init() {
@@ -187,6 +191,7 @@ export default class MinimapPlugin {
         this.wavesurfer.un('seek', this._onSeek);
         this.wavesurfer.un('scroll', this._onScroll);
         this.wavesurfer.un('audioprocess', this._onAudioprocess);
+        this.wavesurfer.un('zoom', this._onZoom);
         this.drawer.destroy();
         this.overviewRegion = null;
         this.unAll();
@@ -248,10 +253,8 @@ export default class MinimapPlugin {
             this.overviewRegion = this.util.style(
                 document.createElement('overview'),
                 {
-                    height:
-                        this.drawer.wrapper.offsetHeight -
-                        this.params.overviewBorderSize * 2 +
-                        'px',
+                    top: 0,
+                    bottom: 0,
                     width: '0px',
                     display: 'block',
                     position: 'absolute',
@@ -353,23 +356,22 @@ export default class MinimapPlugin {
             this.ratio = this.wavesurfer.drawer.width / this.drawer.width;
             this.waveShowedWidth = this.wavesurfer.drawer.width / this.ratio;
             this.waveWidth = this.wavesurfer.drawer.width;
-            this.overviewWidth = this.drawer.width / this.ratio;
+            this.overviewWidth = this.drawer.container.offsetWidth / this.ratio;
             this.overviewPosition = 0;
             this.moveOverviewRegion(
                 this.wavesurfer.drawer.wrapper.scrollLeft / this.ratio
             );
-            this.overviewRegion.style.width =
-                this.overviewWidth - this.params.overviewBorderSize * 2 + 'px';
+            this.overviewRegion.style.width = this.overviewWidth + 'px';
         }
     }
 
     moveOverviewRegion(pixels) {
         if (pixels < 0) {
             this.overviewPosition = 0;
-        } else if (pixels + this.overviewWidth < this.drawer.width) {
+        } else if (pixels + this.overviewWidth < this.drawer.container.offsetWidth) {
             this.overviewPosition = pixels;
         } else {
-            this.overviewPosition = this.drawer.width - this.overviewWidth;
+            this.overviewPosition = this.drawer.container.offsetWidth - this.overviewWidth;
         }
         this.overviewRegion.style.left = this.overviewPosition + 'px';
         if (this.draggingOverview) {


### PR DESCRIPTION
### Short description of changes:

Fixes some styling issues with the minimap plugin, the height and widths were not being calculated correctly. Also adds support while zooming in on the waveform to update the minimap.

![minimap](https://user-images.githubusercontent.com/3029989/45772071-ce38d900-bc14-11e8-86ac-5c95fadb8551.gif)

Ignore the weirdness near the end of the gif with the zoom jumping out, that's just my terribly buggy zoom code (outside of wavesurfer) 😆

### Breaking in the external API:

Nothing

### Breaking changes in the internal API:

Nothing

### Todos/Notes:

Nothing yet, maybe I'll find some more stuff to fix later on :) The library is awesome, really enjoying how easy it is to use overall.

### Related Issues and other PRs:

fixes #290
