### PR TITLE
Fix order of arguments for PluginClass.constructor

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -133,10 +133,10 @@ class PluginClass {
     /**
      * Construct the plugin
      *
-     * @param {Object} ws The wavesurfer instance
      * @param {Object} params={} The plugin params (specific to the plugin)
+     * @param {Object} ws The wavesurfer instance
      */
-    constructor(ws, params) {}
+    constructor(params, ws) {}
     /**
      * Initialise the plugin
      *


### PR DESCRIPTION
### Short description of changes:
#### Before
* The PluginClass (base class defined in src/wavesurfer.js) has `constructor(ws, params)`
* \*Plugin (concrete classes defined in src/plugin/*.js) have `constructor(params, ws)`
* The WaveSurfer object instantiates plugins with `new *Plugin(params, ws)`
#### After
* The PluginClass has `constructor(params, ws)`

### Breaking in the external API:
None

### Breaking changes in the internal API:
None

### Todos/Notes:
None

### Related Issues and other PRs:
None