### PR TITLE
plugins: add duration parameter handling to timeline plugin

### DIFF
--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -141,6 +141,7 @@ export default class TimelinePlugin {
                 secondaryFontColor: '#000',
                 fontFamily: 'Arial',
                 fontSize: 10,
+                duration: null,
                 zoomDebounce: false,
                 formatTimeCallback: this.defaultFormatTimeCallback,
                 timeInterval: this.defaultTimeInterval,
@@ -323,9 +324,10 @@ export default class TimelinePlugin {
      * @private
      */
     renderCanvases() {
-        const duration = this.wavesurfer.backend.getDuration()
-            ? this.wavesurfer.backend.getDuration()
-            : this.wavesurfer.timeline.params.duration;
+        const duration =
+            this.wavesurfer.timeline.params.duration ||
+            this.wavesurfer.backend.getDuration();
+
         if (duration <= 0) {
             return;
         }

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -321,7 +321,9 @@ export default class TimelinePlugin {
      * @private
      */
     renderCanvases() {
-        const duration = this.wavesurfer.backend.getDuration();
+        const duration = this.wavesurfer.backend.getDuration()
+            ? this.wavesurfer.backend.getDuration()
+            : this.wavesurfer.timeline.params.duration;
         if (duration <= 0) {
             return;
         }

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -18,7 +18,8 @@
  * performance for large files
  * @property {string} fontFamily='Arial'
  * @property {number} fontSize=10 Font size of labels in pixels
- * @property {number} duration Length of the track in seconds
+ * @property {?number} duration Length of the track in seconds. Overrides
+ * getDuration() for setting length of timeline
  * @property {function} formatTimeCallback (sec, pxPerSec) -> label
  * @property {function} timeInterval (pxPerSec) -> seconds between notches
  * @property {function} primaryLabelInterval (pxPerSec) -> cadence between

--- a/src/plugin/timeline.js
+++ b/src/plugin/timeline.js
@@ -18,6 +18,7 @@
  * performance for large files
  * @property {string} fontFamily='Arial'
  * @property {number} fontSize=10 Font size of labels in pixels
+ * @property {number} duration Length of the track in seconds
  * @property {function} formatTimeCallback (sec, pxPerSec) -> label
  * @property {function} timeInterval (pxPerSec) -> seconds between notches
  * @property {function} primaryLabelInterval (pxPerSec) -> cadence between


### PR DESCRIPTION
Short description of changes:
Add handling for duration parameter to Wavesurfer Timeline plugin. The code I added to the renderCanvases function favors the duration parameter over this.wavesurfer.backend.getDuration()

Related Issues and other PRs:
fixes #1460