### PR TITLE
Fix computing peaks when buffer is not set

### DIFF
--- a/spec/wavesurfer.spec.js
+++ b/spec/wavesurfer.spec.js
@@ -375,4 +375,17 @@ describe('WaveSurfer/errors:', function() {
             });
         }).toThrow(new Error('Renderer parameter is invalid'));
     });
+
+    /**
+     * @test {WaveSurfer}
+     */
+    it('should not throw when rendered and media is not loaded', function() {
+        expect(function() {
+            var wave = TestHelpers.createWaveform({
+                container: '#test'
+            });
+
+            wave[0].setWaveColor('#000000');
+        }).not.toThrow();
+    });
 });

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -391,14 +391,16 @@ export default class WebAudio extends util.Observer {
             return this.peaks;
         }
 
-        if (!this.buffer) {
-            return [];
-        }
-
         first = first || 0;
         last = last || length - 1;
 
         this.setLength(length);
+
+        if (!this.buffer) {
+            return this.params.splitChannels
+                ? this.splitPeaks
+                : this.mergedPeaks;
+        }
 
         /**
          * The following snippet fixes a buffering data issue on the Safari

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -391,6 +391,10 @@ export default class WebAudio extends util.Observer {
             return this.peaks;
         }
 
+        if (!this.buffer) {
+            return [];
+        }
+
         first = first || 0;
         last = last || length - 1;
 


### PR DESCRIPTION
### Short description of changes:
Return empty array from `getPeaks` when `this.buffer` is not set.


### Breaking in the external API:
none?

### Breaking changes in the internal API:
none?


### Related Issues and other PRs:
Fixes #1529 
Fixes #1507