### PR TITLE
fix removeOnAudioProcess for Safari

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -253,7 +253,7 @@ export default class WebAudio extends util.Observer {
 
     /** @private */
     removeOnAudioProcess() {
-        this.scriptNode.onaudioprocess = null;
+        this.scriptNode.onaudioprocess = () => {};
     }
 
     /** @private */


### PR DESCRIPTION
### Short description of changes:

When using "WebAudio" in Safari the "audioprocess" event doesn't get fired anymore once you pause/play the current song or load a new one into your wavesurfer object preventing the following piece of code to be executed:
```
this.backend.on('audioprocess', time => {
    this.drawer.progress(this.backend.getPlayedPercents());
    this.fireEvent('audioprocess', time);
});
```
This commit fixes the bug, so it is not needed anymore to use "MediaElement" on Safari as a workaround (which has its own drawbacks).

This fix was also discovered and reported by @Joudee but apparently overlooked and not included in a PR.

### Breaking in the external API:

No

### Breaking changes in the internal API:

No

### Todos/Notes:

Afaik fixes the bug entirely with no additional work left to be done.

### Related Issues and other PRs:

fixes #1215 
fixes #1367 
fixes #1398