### PR TITLE
add wavesurfer.getActivePlugins()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ wavesurfer.js changelog
 2.2.2 (unreleased)
 ------------------
 
+- Add `wavesurfer.getActivePlugins()`: return map of plugins
+  that are currently initialised
 - Cursor plugin: add `formatTimeCallback` option
 
 2.2.1 (18.03.2019)

--- a/spec/plugin-api.spec.js
+++ b/spec/plugin-api.spec.js
@@ -150,4 +150,18 @@ describe('WaveSurfer/plugin API:', () => {
         expect(wavesurfer.dummy.ws).toEqual(wavesurfer);
         expect(wavesurfer.dummy.isInitialised).toBeTrue();
     });
+
+    /** @test {WaveSurfer#getActivePlugins} */
+    it('getActivePlugins returns map of plugin names that are currently initialised', () => {
+        dummyPlugin = mockPlugin('dummy');
+        __createWaveform({
+            plugins: [dummyPlugin]
+        });
+        expect(wavesurfer.getActivePlugins()).toEqual({
+            dummy: true
+        });
+        expect(wavesurfer.getActivePlugins()).toEqual(
+            wavesurfer.initialisedPluginList
+        );
+    });
 });

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -449,6 +449,16 @@ export default class WaveSurfer extends util.Observer {
     }
 
     /**
+     * Get a map of plugin names that are currently initialised
+     *
+     * @example wavesurfer.getPlugins();
+     * @return {Object} Object with plugin names
+     */
+    getActivePlugins() {
+        return this.initialisedPluginList;
+    }
+
+    /**
      * Add a plugin object to wavesurfer
      *
      * @param {PluginDefinition} plugin A plugin definition
@@ -1230,10 +1240,11 @@ export default class WaveSurfer extends util.Observer {
      * wavesurfer.load('http://example.com/demo.wav');
      *
      * // setting preload attribute with media element backend and supplying
-     * peaks wavesurfer.load(
+     * // peaks
+     * wavesurfer.load(
      *   'http://example.com/demo.wav',
      *   [0.0218, 0.0183, 0.0165, 0.0198, 0.2137, 0.2888],
-     *   true,
+     *   true
      * );
      */
     load(url, peaks, preload, duration) {


### PR DESCRIPTION
returns a map of pluginsthat are currently initialised.