### PR TITLE
define wavesurfer.isReady as public boolean

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 wavesurfer.js changelog
 =======================
 
-2.2.2 (unreleased)
+2.3.0 (unreleased)
 ------------------
 
 - Add `wavesurfer.getActivePlugins()`: return map of plugins

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ wavesurfer.js changelog
 
 - Add `wavesurfer.getActivePlugins()`: return map of plugins
   that are currently initialised
+- Fix `wavesurfer.isReady`: make it a public boolean, the
+  broken `isReady` method is removed (#1597)
 - Cursor plugin: add `formatTimeCallback` option
 
 2.2.1 (18.03.2019)

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -383,7 +383,13 @@ export default class WaveSurfer extends util.Observer {
         this.initialisedPluginList = {};
         /** @private */
         this.isDestroyed = false;
-        /** @private */
+
+        /**
+         * Get the current ready status.
+         *
+         * @example const isReady = wavesurfer.isReady;
+         * @return {boolean}
+         */
         this.isReady = false;
 
         // responsive debounced event listener. If this.params.responsive is not
@@ -948,16 +954,6 @@ export default class WaveSurfer extends util.Observer {
      */
     getMute() {
         return this.isMuted;
-    }
-
-    /**
-     * Get the current ready status.
-     *
-     * @example const isReady = wavesurfer.isReady();
-     * @return {boolean}
-     */
-    isReady() {
-        return this.isReady;
     }
 
     /**


### PR DESCRIPTION
make it a public boolean as it is, and was, being used:
```console
$ grep -Rn 'isReady' src/
src//plugin/regions.js:658:        if (this.wavesurfer.isReady) {
src//plugin/timeline.js:189:        if (this.wavesurfer.isReady) {
src//plugin/spectrogram.js:334:        if (this.wavesurfer.isReady) {
src//plugin/minimap.js:177:        if (this.wavesurfer.isReady) {
```
fixes #1597 