### PR TITLE
Use fake AudioContext when not supported

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ wavesurfer.js changelog
 - Fix `wavesurfer.isReady`: make it a public boolean, the
   broken `isReady` method is removed (#1597)
 - Add support for `Blob` output type in `wavesurfer.exportImage` (#1610)
+- Fix fallback to Audio Element in browsers that don't support Web Audio (#1614)
 - Cursor plugin:
   - add `formatTimeCallback` option
   - add `followCursorY` option (#1605)

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -103,7 +103,9 @@ export default class WebAudio extends util.Observer {
         /** @private */
         this.params = params;
         /** @private */
-        this.ac = params.audioContext || this.getAudioContext();
+        this.ac =
+            params.audioContext ||
+            (this.supportsWebAudio() ? this.getAudioContext() : {});
         /**@private */
         this.lastPlay = this.ac.currentTime;
         /** @private */


### PR DESCRIPTION
As [requested here](https://github.com/katspaugh/wavesurfer.js/issues/1614#issuecomment-481666875).

fixes #1614