### PR TITLE
refactor: add drawer.canvasentry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ wavesurfer.js changelog
 - Add `wavesurfer.getActivePlugins()`: return map of plugins
   that are currently initialised
 - Update progress when seeking with HTML media controls (#1535)
+- Refactor `MultiCanvas` and add `CanvasEntry` class (#1617)
 - Fix `wavesurfer.isReady`: make it a public boolean, the
   broken `isReady` method is removed (#1597)
 - Add support for `Blob` output type in `wavesurfer.exportImage` (#1610)

--- a/build-config/fragments/common.js
+++ b/build-config/fragments/common.js
@@ -26,16 +26,6 @@ module.exports = {
         rules: [
             {
                 test: /\.js$/,
-                enforce: 'pre',
-                exclude: /node_modules/,
-                use: [
-                    {
-                        loader: 'eslint-loader'
-                    }
-                ]
-            },
-            {
-                test: /\.js$/,
                 exclude: /node_modules/,
                 use: [
                     {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "esdoc-standard-plugin": "^1.0.0",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.1.0",
-    "eslint-loader": "^2.1.2",
     "eslint-plugin-prettier": "^3.0.1",
     "htmlhint": "^0.11.0",
     "in-publish": "^2.0.0",

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -229,20 +229,20 @@ export default class CanvasEntry {
             return;
         }
 
-        let length = peaks.length / 2;
-        let first = Math.round(length * this.start);
+        const length = peaks.length / 2;
+        const first = Math.round(length * this.start);
 
         // use one more peak value to make sure we join peaks at ends -- unless,
         // of course, this is the last canvas
-        let last = Math.round(length * this.end) + 1;
+        const last = Math.round(length * this.end) + 1;
 
-        let canvasStart = first;
-        let canvasEnd = last;
-        let scale = this.progress.width / (canvasEnd - canvasStart - 1);
+        const canvasStart = first;
+        const canvasEnd = last;
+        const scale = this.progress.width / (canvasEnd - canvasStart - 1);
 
         // optimization
-        let halfOffset = halfH + offsetY;
-        let absmaxHalf = absmax / halfH;
+        const halfOffset = halfH + offsetY;
+        const absmaxHalf = absmax / halfH;
 
         ctx.beginPath();
         ctx.moveTo((canvasStart - first) * scale, halfOffset);
@@ -261,8 +261,8 @@ export default class CanvasEntry {
 
         // draw the bottom edge going backwards, to make a single
         // closed hull to fill
-        let j;
-        for (j = canvasEnd - 1; j >= canvasStart; j--) {
+        let j = canvasEnd - 1;
+        for (j; j >= canvasStart; j--) {
             peak = peaks[2 * j + 1] || 0;
             h = Math.round(peak / absmaxHalf);
             ctx.lineTo((j - first) * scale + this.halfPixel, halfOffset - h);
@@ -292,7 +292,8 @@ export default class CanvasEntry {
     /**
      * Return image data of the wave `canvas` element
      *
-     * When using a `type` of `'blob'`, this will return a `Promise`.
+     * When using a `type` of `'blob'`, this will return a `Promise` that
+     * resolves with a `Blob` instance.
      *
      * @param {string} format='image/png' An optional value of a format type.
      * @param {number} quality=0.92 An optional value between 0 and 1.

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -1,0 +1,284 @@
+/**
+ * @since 2.3.0
+ */
+
+import style from './util/style';
+import getId from './util/get-id';
+
+export default class CanvasEntry {
+    constructor() {
+        /**
+         * The wave node
+         *
+         * @type {HTMLElement}
+         * @private
+         */
+        this.wave = null;
+        /**
+         * The wave canvas rendering context
+         *
+         * @type {CanvasRenderingContext2D}
+         * @private
+         */
+        this.waveCtx = null;
+        /**
+         * The (optional) progress wave node
+         *
+         * @type {HTMLElement}
+         * @private
+         */
+        this.progress = null;
+        /**
+         * The progress wave canvas rendering context
+         *
+         * @type {CanvasRenderingContext2D}
+         * @private
+         */
+        this.progressCtx = null;
+        /**
+         * Start of the area the canvas should render, between 0 and 1
+         *
+         * @type {number}
+         * @private
+         */
+        this.start = 0;
+        /**
+         * End of the area the canvas should render, between 0 and 1
+         *
+         * @type {number}
+         * @private
+         */
+        this.end = 1;
+        /**
+         * Unique identifier for this entry.
+         *
+         * @type {string}
+         * @private
+         */
+        this.id = getId();
+    }
+
+    /**
+     * Create the wave canvas and 2D rendering context
+     */
+    createWave(element) {
+        this.wave = element;
+        this.waveCtx = this.wave.getContext('2d');
+    }
+
+    /**
+     * Create the progress canvas and 2D rendering context
+     */
+    createProgress(element) {
+        this.progress = element;
+        this.progressCtx = this.progress.getContext('2d');
+    }
+
+    /**
+     * Update the dimensions
+     *
+     * @param {number} elementWidth
+     * @param {number} totalWidth
+     * @param {number} width The new width of the element
+     * @param {number} height The new height of the element
+     */
+    updateDimensions(elementWidth, totalWidth, width, height) {
+        // Where the canvas starts and ends in the waveform, represented as a
+        // decimal between 0 and 1.
+        this.start = this.wave.offsetLeft / totalWidth || 0;
+        this.end = this.start + elementWidth / totalWidth;
+
+        // set wave canvas dimensions
+        this.wave.width = width;
+        this.wave.height = height;
+        style(this.wave, { width: elementWidth + 'px' });
+
+        if (this.hasProgressCanvas) {
+            // set progress canvas dimensions
+            this.progress.width = width;
+            this.progress.height = height;
+            style(this.progress, {
+                width: elementWidth + 'px'
+            });
+        }
+    }
+
+    /**
+     * Clear the wave and progress rendering contexts
+     */
+    clearWave() {
+        // wave
+        this.waveCtx.clearRect(
+            0,
+            0,
+            this.waveCtx.canvas.width,
+            this.waveCtx.canvas.height
+        );
+
+        // progress
+        if (this.hasProgressCanvas) {
+            this.progressCtx.clearRect(
+                0,
+                0,
+                this.progressCtx.canvas.width,
+                this.progressCtx.canvas.height
+            );
+        }
+    }
+
+    /**
+     * Set the fill styles for wave and progress
+     *
+     * @param {string} waveColor Fill color for the wave canvas
+     * @param {?string} progressColor Fill color for the progress canvas
+     */
+    setFillStyles(waveColor, progressColor) {
+        this.waveCtx.fillStyle = waveColor;
+
+        if (this.hasProgressCanvas) {
+            this.progressCtx.fillStyle = progressColor;
+        }
+    }
+
+    /**
+     * Draw a rectangle for wave and progress
+     *
+     * @param {number} x X start position
+     * @param {number} y Y start position
+     * @param {number} width Width of the rectangle
+     * @param {number} height Height of the rectangle
+     */
+    fillRects(x, y, width, height) {
+        this.fillRectToContext(this.waveCtx);
+        this.fillRectToContext(this.progressCtx);
+    }
+
+    /**
+     * Draw the actual rectangle on a canvas
+     *
+     * @private
+     * @param {CanvasRenderingContext2D} ctx Rendering context of target canvas
+     * @param {number} x X start position
+     * @param {number} y Y start position
+     * @param {number} width Width of the rectangle
+     * @param {number} height Height of the rectangle
+     */
+    fillRectToContext(ctx, x, y, width, height) {
+        if (!ctx) {
+            return;
+        }
+        ctx.fillRect(x, y, width, height);
+    }
+
+    /**
+     * Render the actual wave and progress lines
+     *
+     * @param {number[]} peaks Array with peaks data
+     * @param {number} absmax Maximum peak value (absolute)
+     * @param {number} halfH Half the height of the waveform
+     * @param {number} offsetY Offset to the top
+     * @param {number} start The x-offset of the beginning of the area that
+     * should be rendered
+     * @param {number} end The x-offset of the end of the area that
+     * should be rendered
+     */
+    drawLines(peaks, absmax, halfH, offsetY, start, end) {
+        this.drawLineToContext(
+            this.waveCtx,
+            peaks,
+            absmax,
+            halfH,
+            offsetY,
+            start,
+            end
+        );
+        this.drawLineToContext(
+            this.progressCtx,
+            peaks,
+            absmax,
+            halfH,
+            offsetY,
+            start,
+            end
+        );
+    }
+
+    /**
+     * Render the actual waveform line on a canvas
+     *
+     * @private
+     * @param {CanvasRenderingContext2D} ctx Rendering context of target canvas
+     * @param {number[]} peaks Array with peaks data
+     * @param {number} absmax Maximum peak value (absolute)
+     * @param {number} halfH Half the height of the waveform
+     * @param {number} offsetY Offset to the top
+     * @param {number} start The x-offset of the beginning of the area that
+     * should be rendered
+     * @param {number} end The x-offset of the end of the area that
+     * should be rendered
+     */
+    drawLineToContext(ctx, peaks, absmax, halfH, offsetY, start, end) {
+        if (!ctx) {
+            return;
+        }
+
+        let length = peaks.length / 2;
+        let first = Math.round(length * this.start);
+
+        // Use one more peak value to make sure we join peaks at ends -- unless,
+        // of course, this is the last canvas.
+        let last = Math.round(length * this.end) + 1;
+
+        let canvasStart = first;
+        let canvasEnd = last;
+
+        let scale = this.progress.width / (canvasEnd - canvasStart - 1);
+        // optimization
+        let halfOffset = halfH + offsetY;
+        let absmaxHalf = absmax / halfH;
+
+        ctx.beginPath();
+        ctx.moveTo((canvasStart - first) * scale, halfOffset);
+
+        ctx.lineTo(
+            (canvasStart - first) * scale,
+            halfOffset - Math.round((peaks[2 * canvasStart] || 0) / absmaxHalf)
+        );
+
+        let i, peak, h;
+        for (i = canvasStart; i < canvasEnd; i++) {
+            peak = peaks[2 * i] || 0;
+            h = Math.round(peak / absmaxHalf);
+            ctx.lineTo((i - first) * scale + this.halfPixel, halfOffset - h);
+        }
+
+        // Draw the bottom edge going backwards, to make a single
+        // closed hull to fill.
+        let j;
+        for (j = canvasEnd - 1; j >= canvasStart; j--) {
+            peak = peaks[2 * j + 1] || 0;
+            h = Math.round(peak / absmaxHalf);
+            ctx.lineTo((j - first) * scale + this.halfPixel, halfOffset - h);
+        }
+
+        ctx.lineTo(
+            (canvasStart - first) * scale,
+            halfOffset -
+                Math.round((peaks[2 * canvasStart + 1] || 0) / absmaxHalf)
+        );
+
+        ctx.closePath();
+        ctx.fill();
+    }
+
+    /**
+     * Destroys this entry
+     */
+    destroy() {
+        this.waveCtx = null;
+        this.wave = null;
+
+        this.progressCtx = null;
+        this.progress = null;
+    }
+}

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -6,11 +6,11 @@ import style from './util/style';
 import getId from './util/get-id';
 
 /**
- * The CanvasEntry class represents an element consisting of a wave `canvas`
+ * The `CanvasEntry` class represents an element consisting of a wave `canvas`
  * and an (optional) progress wave `canvas`.
  *
- * The MultiCanvas renderer uses one or more CanvasEntry instances to render
- * a waveform, depending on the zoom level.
+ * The `MultiCanvas` renderer uses one or more `CanvasEntry` instances to
+ * render a waveform, depending on the zoom level.
  */
 export default class CanvasEntry {
     constructor() {
@@ -90,8 +90,8 @@ export default class CanvasEntry {
      * @param {number} height The new height of the element
      */
     updateDimensions(elementWidth, totalWidth, width, height) {
-        // Where the canvas starts and ends in the waveform, represented as a
-        // decimal between 0 and 1.
+        // where the canvas starts and ends in the waveform, represented as a
+        // decimal between 0 and 1
         this.start = this.wave.offsetLeft / totalWidth || 0;
         this.end = this.start + elementWidth / totalWidth;
 
@@ -232,8 +232,8 @@ export default class CanvasEntry {
         let length = peaks.length / 2;
         let first = Math.round(length * this.start);
 
-        // Use one more peak value to make sure we join peaks at ends -- unless,
-        // of course, this is the last canvas.
+        // use one more peak value to make sure we join peaks at ends -- unless,
+        // of course, this is the last canvas
         let last = Math.round(length * this.end) + 1;
 
         let canvasStart = first;
@@ -297,11 +297,9 @@ export default class CanvasEntry {
      * @param {string} format='image/png' An optional value of a format type.
      * @param {number} quality=0.92 An optional value between 0 and 1.
      * @param {string} type='dataURL' Either 'dataURL' or 'blob'.
-     * @return {string|string[]|Promise} When using the default `'dataURL'`
-     * `type` this returns a single data URL or an array of data URLs,
-     * one for each canvas. When using the `'blob'` `type` this returns a
-     * `Promise` that resolves with an array of `Blob` instances, one for each
-     * canvas.
+     * @return {string|Promise} When using the default `'dataURL'` `type` this
+     * returns a data URL. When using the `'blob'` `type` this returns a
+     * `Promise` that resolves with a `Blob` instance.
      */
     getImage(format, quality, type) {
         if (type === 'blob') {

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -6,8 +6,8 @@ import style from './util/style';
 import getId from './util/get-id';
 
 /**
- * The CanvasEntry class represents an element consisting of a wave canvas and a
- * (optional) progress wave canvas.
+ * The CanvasEntry class represents an element consisting of a wave `canvas`
+ * and an (optional) progress wave `canvas`.
  *
  * The MultiCanvas renderer uses one or more CanvasEntry instances to render
  * a waveform, depending on the zoom level.
@@ -17,29 +17,25 @@ export default class CanvasEntry {
         /**
          * The wave node
          *
-         * @type {HTMLElement}
-         * @private
+         * @type {HTMLCanvasElement}
          */
         this.wave = null;
         /**
          * The wave canvas rendering context
          *
          * @type {CanvasRenderingContext2D}
-         * @private
          */
         this.waveCtx = null;
         /**
          * The (optional) progress wave node
          *
-         * @type {HTMLElement}
-         * @private
+         * @type {HTMLCanvasElement}
          */
         this.progress = null;
         /**
-         * The progress wave canvas rendering context
+         * The (optional) progress wave canvas rendering context
          *
          * @type {CanvasRenderingContext2D}
-         * @private
          */
         this.progressCtx = null;
         /**
@@ -60,23 +56,27 @@ export default class CanvasEntry {
          * Unique identifier for this entry.
          *
          * @type {string}
-         * @private
          */
         this.id = getId();
     }
 
     /**
-     * Create the wave canvas and 2D rendering context
+     * Store the wave canvas element and create the 2D rendering context
+     *
+     * @param {HTMLCanvasElement} element The wave `canvas` element.
      */
-    createWave(element) {
+    initWave(element) {
         this.wave = element;
         this.waveCtx = this.wave.getContext('2d');
     }
 
     /**
-     * Create the progress canvas and 2D rendering context
+     * Store the progress wave canvas element and create the 2D rendering
+     * context
+     *
+     * @param {HTMLCanvasElement} element The progress wave `canvas` element.
      */
-    createProgress(element) {
+    initProgress(element) {
         this.progress = element;
         this.progressCtx = this.progress.getContext('2d');
     }
@@ -161,7 +161,7 @@ export default class CanvasEntry {
     }
 
     /**
-     * Draw the actual rectangle on a canvas
+     * Draw the actual rectangle on a `canvas` element
      *
      * @private
      * @param {CanvasRenderingContext2D} ctx Rendering context of target canvas
@@ -211,7 +211,7 @@ export default class CanvasEntry {
     }
 
     /**
-     * Render the actual waveform line on a canvas
+     * Render the actual waveform line on a `canvas` element
      *
      * @private
      * @param {CanvasRenderingContext2D} ctx Rendering context of target canvas
@@ -238,8 +238,8 @@ export default class CanvasEntry {
 
         let canvasStart = first;
         let canvasEnd = last;
-
         let scale = this.progress.width / (canvasEnd - canvasStart - 1);
+
         // optimization
         let halfOffset = halfH + offsetY;
         let absmaxHalf = absmax / halfH;
@@ -259,8 +259,8 @@ export default class CanvasEntry {
             ctx.lineTo((i - first) * scale + this.halfPixel, halfOffset - h);
         }
 
-        // Draw the bottom edge going backwards, to make a single
-        // closed hull to fill.
+        // draw the bottom edge going backwards, to make a single
+        // closed hull to fill
         let j;
         for (j = canvasEnd - 1; j >= canvasStart; j--) {
             peak = peaks[2 * j + 1] || 0;
@@ -290,7 +290,7 @@ export default class CanvasEntry {
     }
 
     /**
-     * Return image data of the wave canvas
+     * Return image data of the wave `canvas` element
      *
      * When using a `type` of `'blob'`, this will return a `Promise`.
      *

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -5,6 +5,13 @@
 import style from './util/style';
 import getId from './util/get-id';
 
+/**
+ * The CanvasEntry class represents an element consisting of a wave canvas and a
+ * (optional) progress wave canvas.
+ *
+ * The MultiCanvas renderer uses one or more CanvasEntry instances to render
+ * a waveform, depending on the zoom level.
+ */
 export default class CanvasEntry {
     constructor() {
         /**

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -281,4 +281,28 @@ export default class CanvasEntry {
         this.progressCtx = null;
         this.progress = null;
     }
+
+    /**
+     * Return image data of the wave canvas
+     *
+     * When using a `type` of `'blob'`, this will return a `Promise`.
+     *
+     * @param {string} format='image/png' An optional value of a format type.
+     * @param {number} quality=0.92 An optional value between 0 and 1.
+     * @param {string} type='dataURL' Either 'dataURL' or 'blob'.
+     * @return {string|string[]|Promise} When using the default `'dataURL'`
+     * `type` this returns a single data URL or an array of data URLs,
+     * one for each canvas. When using the `'blob'` `type` this returns a
+     * `Promise` that resolves with an array of `Blob` instances, one for each
+     * canvas.
+     */
+    getImage(format, quality, type) {
+        if (type === 'blob') {
+            return new Promise(resolve => {
+                this.wave.toBlob(resolve, format, quality);
+            });
+        } else if (type === 'dataURL') {
+            return this.wave.toDataURL(format, quality);
+        }
+    }
 }

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -481,14 +481,12 @@ export default class MultiCanvas extends Drawer {
         if (type === 'blob') {
             return Promise.all(
                 this.canvases.map(entry => {
-                    return new Promise(resolve => {
-                        entry.wave.toBlob(resolve, format, quality);
-                    });
+                    return entry.getImage(format, quality, type);
                 })
             );
         } else if (type === 'dataURL') {
             let images = this.canvases.map(entry =>
-                entry.wave.toDataURL(format, quality)
+                entry.getImage(format, quality, type)
             );
             return images.length > 1 ? images : images[0];
         }

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -5,6 +5,9 @@ import CanvasEntry from './drawer.canvasentry';
 /**
  * MultiCanvas renderer for wavesurfer. Is currently the default and sole
  * builtin renderer.
+ *
+ * A `MultiCanvas` consists of one or more `CanvasEntry` instances, depending
+ * on the zoom level.
  */
 export default class MultiCanvas extends Drawer {
     /**

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -16,11 +16,13 @@ export default class MultiCanvas extends Drawer {
      */
     constructor(container, params) {
         super(container, params);
+
         /**
          * @type {number}
          * @private
          */
         this.maxCanvasWidth = params.maxCanvasWidth;
+
         /**
          * @private
          * @type {number}
@@ -28,33 +30,49 @@ export default class MultiCanvas extends Drawer {
         this.maxCanvasElementWidth = Math.round(
             params.maxCanvasWidth / params.pixelRatio
         );
+
         /**
          * Whether or not the progress wave is rendered. If the `waveColor`
          * and `progressColor` are the same color it is not.
+         *
          * @type {boolean}
          */
         this.hasProgressCanvas = params.waveColor != params.progressColor;
+
         /**
          * @private
          * @type {number}
          */
         this.halfPixel = 0.5 / params.pixelRatio;
+
         /**
          * List of `CanvasEntry` instances.
+         *
          * @private
          * @type {Array}
          */
         this.canvases = [];
+
         /**
          * @private
          * @type {HTMLElement}
          */
         this.progressWave = null;
+
         /**
+         * Class used to generate entries.
+         *
          * @private
          * @type {function}
          */
         this.EntryClass = CanvasEntry;
+
+        /**
+         * Overlap added to prevent vertical white stripes.
+         *
+         * @type {number}
+         */
+        this.overlap = 2 * Math.ceil(params.pixelRatio / 2);
     }
 
     /**
@@ -106,12 +124,8 @@ export default class MultiCanvas extends Drawer {
      */
     updateSize() {
         const totalWidth = Math.round(this.width / this.params.pixelRatio);
-
-        // add some overlap to prevent vertical white stripes
-        const OVERLAP = 2 * Math.ceil(this.params.pixelRatio / 2);
-
         const requiredCanvases = Math.ceil(
-            totalWidth / (this.maxCanvasElementWidth + OVERLAP)
+            totalWidth / (this.maxCanvasElementWidth + this.overlap)
         );
 
         // add required canvases
@@ -124,7 +138,7 @@ export default class MultiCanvas extends Drawer {
             this.removeCanvas();
         }
 
-        let canvasWidth = this.maxCanvasWidth + OVERLAP;
+        let canvasWidth = this.maxCanvasWidth + this.overlap;
         let lastCanvas = this.canvases.length - 1;
         this.canvases.forEach((entry, i) => {
             if (i == lastCanvas) {

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -145,7 +145,7 @@ export default class MultiCanvas extends Drawer {
         const leftOffset = this.maxCanvasElementWidth * this.canvases.length;
 
         // wave
-        entry.createWave(
+        entry.initWave(
             this.wrapper.appendChild(
                 this.style(document.createElement('canvas'), {
                     position: 'absolute',
@@ -161,7 +161,7 @@ export default class MultiCanvas extends Drawer {
 
         // progress
         if (this.hasProgressCanvas) {
-            entry.createProgress(
+            entry.initProgress(
                 this.progressWave.appendChild(
                     this.style(document.createElement('canvas'), {
                         position: 'absolute',

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -139,7 +139,7 @@ export default class MultiCanvas extends Drawer {
         }
 
         let canvasWidth = this.maxCanvasWidth + this.overlap;
-        let lastCanvas = this.canvases.length - 1;
+        const lastCanvas = this.canvases.length - 1;
         this.canvases.forEach((entry, i) => {
             if (i == lastCanvas) {
                 canvasWidth = this.width - this.maxCanvasWidth * lastCanvas;
@@ -284,9 +284,9 @@ export default class MultiCanvas extends Drawer {
                 const scale = length / this.width;
                 const first = start;
                 const last = end;
-                let i;
+                let i = first;
 
-                for (i = first; i < last; i += step) {
+                for (i; i < last; i += step) {
                     const peak =
                         peaks[Math.floor(i * scale * peakIndexScale)] || 0;
                     const h = Math.round((peak / absmax) * halfH);
@@ -323,8 +323,8 @@ export default class MultiCanvas extends Drawer {
                 if (!hasMinVals) {
                     const reflectedPeaks = [];
                     const len = peaks.length;
-                    let i;
-                    for (i = 0; i < len; i++) {
+                    let i = 0;
+                    for (i; i < len; i++) {
                         reflectedPeaks[2 * i] = peaks[i];
                         reflectedPeaks[2 * i + 1] = -peaks[i];
                     }
@@ -382,8 +382,8 @@ export default class MultiCanvas extends Drawer {
             Math.ceil((x + width) / this.maxCanvasWidth) + 1,
             this.canvases.length
         );
-        let i;
-        for (i = startCanvas; i < endCanvas; i++) {
+        let i = startCanvas;
+        for (i; i < endCanvas; i++) {
             const entry = this.canvases[i];
             const leftOffset = i * this.maxCanvasWidth;
 


### PR DESCRIPTION
This PR adds a `CanvasEntry` class used by the `MultiCanvas` renderer. Previously the renderer used simple objects to store the canvas and rendering context in, this PR creates a dedicated class for these canvases. This way it should be easier to eventually implement `OffscreenCanvas` support (#1600).

Also disabled eslint in webpack, because it's really annoying to fix lint errors while you're working on wavesurfer.js. eslint will run when you try to commit the changes, a much better moment to fix lint errors.