### PR TITLE
Added npm prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint-and-format-staged": "lint-staged",
     "doc": "esdoc",
     "test": "karma start karma.conf.js",
-    "prepublishOnly": "not-in-install && npm run build || in-install"
+    "prepublishOnly": "not-in-install && npm run build || in-install",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Short description of changes:
Added a new npm script "prepare" in the package.json, which simply redirects to the build-script. The prepare script is described by npm as follows:

> Run both BEFORE the package is packed and published, on local npm install without any arguments, and when installing git dependencies (See below).
https://docs.npmjs.com/misc/scripts

This is sometimes required, if the dependency is not installed over npm directly but over github.

### Breaking in the external API:
None

### Breaking changes in the internal API:
None

### Todos/Notes:
None

### Related Issues and other PRs:
None