### PR TITLE
add missing arguments to fillRectToContext

### DIFF
--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -155,10 +155,10 @@ export default class CanvasEntry {
      * @param {number} height Height of the rectangle
      */
     fillRects(x, y, width, height) {
-        this.fillRectToContext(this.waveCtx);
+        this.fillRectToContext(this.waveCtx, x, y, width, height);
 
         if (this.hasProgressCanvas) {
-            this.fillRectToContext(this.progressCtx);
+            this.fillRectToContext(this.progressCtx, x, y, width, height);
         }
     }
 


### PR DESCRIPTION
### Short description of changes:
fix for barWidth option not working after canvasEntry refactor, arguments were missing in the call to fillRectToContext

fixes #1628 
