### PR TITLE
Fix comparison of seconds and getDuration in setCurrentTime

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -247,7 +247,7 @@ var WaveSurfer = {
      * @param {Number} seconds A positive number in seconds. E.g. 10 means 10 seconds, 60 means 1 minute
      */
     setCurrentTime: function (seconds) {
-        if(this.getDuration() >= seconds) {
+        if(seconds >= this.getDuration()) {
             this.seekTo(1);
         } else {
             this.seekTo(seconds/this.getDuration());


### PR DESCRIPTION
# Hey, thank you for contributing to wavesurfer.js!

To review/merge open PRs it is very helpful to know as much as possible about the changes which are being introduced. Reviewing PRs is very time consuming, please be patient, it can take some time to do properly.

**Title:** Please make sure the name of your PR is as descriptive as possible (Describe the feature that is introduced or the bug that is being fixed).

## Please make sure you provide the information below:

### Short description of changes:
Only skip to end of audio if seconds passed to setCurrentTime is longer than the duration, not shorter. This is fixed on master but not on the es5 branch.


### Breaking in the external API:


### Breaking changes in the internal API:


### Todos/Notes:


### Related Issues and other PRs:
