### PR TITLE
Dev flexibility

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-OUTPUT_DIR="dist"
+OUTPUT_DIR="../../wavesurfer"

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-OUTPUT_DIR="../../wavesurfer"
+OUTPUT_DIR="dist"

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+OUTPUT_DIR="dist"

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .chrome
 .build_cache
 .pydevproject
+.env
 
 package-lock.json
 .package.json.swp

--- a/build-config/fragments/htmlinit.js
+++ b/build-config/fragments/htmlinit.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 
+require('dotenv').config();
 const path = require('path');
 const banner = require('./banner');
 
@@ -10,7 +11,7 @@ module.exports = {
         'html-init': path.join(rootDir, 'src', 'html-init.js')
     },
     output: {
-        path: path.join(rootDir, 'dist'),
+        path: path.join(rootDir, process.env.OUTPUT_DIR),
         filename: 'wavesurfer-[name].js',
         library: ['WaveSurfer', '[name]']
     },

--- a/build-config/fragments/main.js
+++ b/build-config/fragments/main.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 
+require('dotenv').config();
 const path = require('path');
 const banner = require('./banner');
 
@@ -10,7 +11,7 @@ module.exports = {
         wavesurfer: path.join(rootDir, 'src', 'wavesurfer.js')
     },
     output: {
-        path: path.join(rootDir, 'dist'),
+        path: path.join(rootDir, process.env.OUTPUT_DIR),
         filename: '[name].js',
         library: 'WaveSurfer'
     },

--- a/build-config/fragments/plugins.js
+++ b/build-config/fragments/plugins.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+require('dotenv').config();
 const fs = require('fs');
 const path = require('path');
 const banner = require('./banner');
@@ -34,7 +35,7 @@ function buildPluginEntry(plugins) {
 module.exports = {
     entry: buildPluginEntry(PLUGINS),
     output: {
-        path: path.join(rootDir, 'dist', 'plugin'),
+        path: path.join(rootDir, process.env.OUTPUT_DIR, 'plugin'),
         filename: 'wavesurfer.[name].js',
         library: ['WaveSurfer', '[name]'],
         publicPath: 'localhost:8080/dist/plugin/'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:htmlinit": "webpack --config ./build-config/webpack.prod.htmlinit.js",
     "build:htmlinit:min": "webpack --config ./build-config/webpack.prod.htmlinit.min.js",
     "build:normal": "npm run build:main && npm run build:plugins && npm run build:htmlinit",
+    "build:main:plugins": "npm run build:main && npm run build:plugins",
     "build:minified": "npm run build:main:min && npm run build:plugins:min && npm run build:htmlinit:min",
     "format": "prettier 'src/**/*.js*' 'example/**/*.js*' 'spec/**/*.js*' 'website/**/*.js*' 'build-config/**/*.js' karma.conf.js --write",
     "lint": "npm run lint:js && npm run lint:html",
@@ -31,7 +32,13 @@
     "doc": "esdoc",
     "test": "karma start karma.conf.js",
     "prepublishOnly": "not-in-install && npm run build || in-install",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "watch": "watch 'npm run build' ./src",
+    "watch:main": "watch 'npm run build:main' ./src",
+    "watch:plugins": "watch 'npm run build:plugins' ./src",
+    "watch:htmlinit": "watch 'npm run build:htmlinit' ./src",
+    "watch:main:plugins": "watch 'npm run build:main:plugins' ./src",
+    "watch:normal": "watch 'npm run build:normal' ./src"
   },
   "repository": {
     "type": "git",
@@ -104,5 +111,9 @@
     "*.html": [
       "htmlhint"
     ]
+  },
+  "dependencies": {
+    "dotenv": "^7.0.0",
+    "watch": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "date-fns": "^1.30.1",
     "debounce": "^1.2.0",
+    "dotenv": "^7.0.0",
     "esdoc": "^1.1.0",
     "esdoc-accessor-plugin": "^1.0.0",
     "esdoc-brand-plugin": "^1.0.1",
@@ -96,6 +97,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^1.17.0",
     "terser-webpack-plugin": "^1.2.3",
+    "watch": "^1.0.2",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.1",
     "webpack-dev-server": "^3.3.1",
@@ -111,9 +113,5 @@
     "*.html": [
       "htmlhint"
     ]
-  },
-  "dependencies": {
-    "dotenv": "^7.0.0",
-    "watch": "^1.0.2"
   }
 }


### PR DESCRIPTION
### Short description of changes:
dotenv - Allow customizing build output directory, useful for larger applications that utilize this library
watch - Watch the src directory for changes, trigger the specific build command
build:main:plugins - Build library without htmlinit, for applications not using it

### Breaking in the external API:
N/A

### Breaking changes in the internal API:
N/A

### Todos/Notes:
N/A

### Related Issues and other PRs:
N/A