### PR TITLE
cursor plugin: hide the cursor elements before first mouseover if hideOnBlur is set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ wavesurfer.js changelog
   - Add `formatTimeCallback` option
   - Add `followCursorY` option (#1605)
   - Remove deprecated `enableCursor` method (#1646)
+  - Hide the cursor elements before first mouseover if `hideOnBlur` is set (#1663)
 - Spectrogram plugin:
   - Fix `ready` listener when loading multiple audio files (#1572)
   - Allow user to specify a colorMap (#1436)

--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -161,7 +161,7 @@ export default class CursorPlugin {
                         top: 0,
                         bottom: 0,
                         width: '0',
-                        display: 'flex',
+                        display: 'none',
                         borderRightStyle: this.params.style,
                         borderRightWidth: this.params.width,
                         borderRightColor: this.params.color,

--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -161,7 +161,7 @@ export default class CursorPlugin {
                         top: 0,
                         bottom: 0,
                         width: '0',
-                        display: 'none',
+                        display: 'flex',
                         borderRightStyle: this.params.style,
                         borderRightWidth: this.params.width,
                         borderRightColor: this.params.color,
@@ -184,7 +184,7 @@ export default class CursorPlugin {
                             top: 0,
                             bottom: 0,
                             width: 'auto',
-                            display: 'none',
+                            display: 'flex',
                             opacity: this.params.opacity,
                             pointerEvents: 'none',
                             height: '100%'
@@ -210,6 +210,8 @@ export default class CursorPlugin {
 
         this.wrapper.addEventListener('mousemove', this._onMousemove);
         if (this.params.hideOnBlur) {
+            // ensure elements are hidden initially
+            this.hideCursor();
             this.wrapper.addEventListener('mouseenter', this._onMouseenter);
             this.wrapper.addEventListener('mouseleave', this._onMouseleave);
         }

--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -184,7 +184,7 @@ export default class CursorPlugin {
                             top: 0,
                             bottom: 0,
                             width: 'auto',
-                            display: 'flex',
+                            display: 'none',
                             opacity: this.params.opacity,
                             pointerEvents: 'none',
                             height: '100%'

--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -78,9 +78,7 @@ export default class MinimapPlugin {
             const el = document.querySelector(params.container);
             if (!el) {
                 console.warn(
-                    `Wavesurfer minimap container ${
-                        params.container
-                    } was not found! The minimap will be automatically appended below the waveform.`
+                    `Wavesurfer minimap container ${params.container} was not found! The minimap will be automatically appended below the waveform.`
                 );
             }
             this.params.container = el;


### PR DESCRIPTION
Both the cursor and the time element are visible before the first hover, but then hide when cursor moves away if hideOnBlur is true. The most obvious manifestation of this bug is a small 4x4 square on the left upon load. (This may be because I'm loading peak data before the audio and it's not noticeable otherwise.)

This change ensures the elements are hidden and require a mouse enter event if hideOnBlur is true.