### PR TITLE
fix showtime jsdoc type, fix typo in comment

### DIFF
--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -132,7 +132,7 @@ export default class CursorPlugin {
         /**
          * displays the time next to the cursor
          *
-         * @type {Boolean}
+         * @type {?HTMLElement}
          */
         this.showTime = null;
         /**
@@ -307,7 +307,7 @@ export default class CursorPlugin {
             [
                 Math.floor((time % 3600) / 60), // minutes
                 ('00' + Math.floor(time % 60)).slice(-2), // seconds
-                ('000' + Math.floor((time % 1) * 1000)).slice(-3) // miliseconds
+                ('000' + Math.floor((time % 1) * 1000)).slice(-3) // milliseconds
             ].join(':')
         );
     }


### PR DESCRIPTION
### Short description of changes:
- change type of this.showtime in cursor plugin from Boolean to HtmlElement
- fix typo in comment, add missing l in mili
