### PR TITLE
add autoCenter option

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -203,8 +203,13 @@ export default class Drawer extends util.Observer {
 
         // if the cursor is currently visible...
         if (!immediate && -half <= offset && offset < half) {
-            // we'll limit the "re-center" rate.
-            const rate = 5;
+            // set rate at which waveform is centered
+            let rate = this.params.autoCenteringRate;
+
+            // make rate dependable on on width of viewwidth and length of waveform
+            rate /= half;
+            rate *= maxScroll;
+
             offset = Math.max(-rate, Math.min(rate, offset));
             target = scrollLeft + offset;
         }
@@ -314,7 +319,10 @@ export default class Drawer extends util.Observer {
 
             if (this.params.scrollParent && this.params.autoCenter) {
                 const newPos = ~~(this.wrapper.scrollWidth * progress);
-                this.recenterOnPosition(newPos);
+                this.recenterOnPosition(
+                    newPos,
+                    this.params.autoCenterImmediately
+                );
             }
 
             this.updateProgress(pos);

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -206,7 +206,7 @@ export default class Drawer extends util.Observer {
             // set rate at which waveform is centered
             let rate = this.params.autoCenteringRate;
 
-            // make rate dependable on on width of viewwidth and length of waveform
+            // make rate depend on on width of viewwidth and length of waveform
             rate /= half;
             rate *= maxScroll;
 

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -204,7 +204,7 @@ export default class Drawer extends util.Observer {
         // if the cursor is currently visible...
         if (!immediate && -half <= offset && offset < half) {
             // set rate at which waveform is centered
-            let rate = this.params.autoCenteringRate;
+            let rate = this.params.autoCenterRate;
 
             // make rate depend on on width of viewwidth and length of waveform
             rate /= half;

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -206,7 +206,7 @@ export default class Drawer extends util.Observer {
             // set rate at which waveform is centered
             let rate = this.params.autoCenterRate;
 
-            // make rate depend on on width of viewwidth and length of waveform
+            // make rate depend on width of view and length of waveform
             rate /= half;
             rate *= maxScroll;
 

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -208,7 +208,7 @@ export default class WaveSurfer extends util.Observer {
         audioScriptProcessor: null,
         audioRate: 1,
         autoCenter: true,
-        autoCenteringRate: 5,
+        autoCenterRate: 5,
         autoCenterImmediately: false,
         backend: 'WebAudio',
         backgroundColor: null,

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -26,6 +26,10 @@ import PeakCache from './peakcache';
  * initialized ScriptProcessorNode or leave blank.
  * @property {boolean} autoCenter=true If a scrollbar is present, center the
  * waveform around the progress
+ * @property {number} autoCenteringRate=5 If autoCenter is active, rate at which the
+ * waveform is centered
+ * @property {boolean} autoCenterImmediately=false If autoCenter is active, immediately
+ * center waveform around progress
  * @property {string} backend='WebAudio' `'WebAudio'|'MediaElement'` In most cases
  * you don't have to set this manually. MediaElement is a fallback for
  * unsupported browsers.
@@ -204,6 +208,8 @@ export default class WaveSurfer extends util.Observer {
         audioScriptProcessor: null,
         audioRate: 1,
         autoCenter: true,
+        autoCenteringRate: 5,
+        autoCenterImmediately: false,
         backend: 'WebAudio',
         backgroundColor: null,
         barHeight: 1,

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -25,11 +25,11 @@ import PeakCache from './peakcache';
  * @property {ScriptProcessorNode} audioScriptProcessor=null Use your own previously
  * initialized ScriptProcessorNode or leave blank.
  * @property {boolean} autoCenter=true If a scrollbar is present, center the
- * waveform around the progress
- * @property {number} autoCenteringRate=5 If autoCenter is active, rate at which the
+ * waveform on current progress
+ * @property {number} autoCenterRate=5 If autoCenter is active, rate at which the
  * waveform is centered
  * @property {boolean} autoCenterImmediately=false If autoCenter is active, immediately
- * center waveform around progress
+ * center waveform on current progress
  * @property {string} backend='WebAudio' `'WebAudio'|'MediaElement'` In most cases
  * you don't have to set this manually. MediaElement is a fallback for
  * unsupported browsers.


### PR DESCRIPTION
### Short description of changes:
Added parameters in options to change the rate of centering if active and added option to immediately center instead of gradual centering.

### Todos/Notes:
- Rate at which the waveform is centered is now dependent from viewWidth, length of waveform and the factor specified in the options
- For very long files, the scrolling event is still triggered too infrequently so the cursor slowly stutters forward while centering. Any idea for triggering the event more frequently in this case?

### Related Issues and other PRs:
Fixes #1699