### PR TITLE
spectrogram plugin: fix variable name in click handler

### DIFF
--- a/src/plugin/spectrogram.js
+++ b/src/plugin/spectrogram.js
@@ -428,9 +428,8 @@ export default class SpectrogramPlugin {
 
     _wrapperClickHandler(event) {
         event.preventDefault();
-
         const relX = 'offsetX' in event ? event.offsetX : event.layerX;
-        this.fireEvent('click', relX / this.scrollWidth || 0);
+        this.fireEvent('click', relX / this.width || 0);
     }
 
     createCanvas() {


### PR DESCRIPTION
I noticed that when handling click events performed in the spectrogram, the click position/progress was always evaluating to 0. After some investigation, I realized that the property `this.scrollWidth` did not exist in the context it was being used (spectrogram.js, line 433), and I believe the correct property name is actually `this.width`, since after that modification the position value was aparently evaluating correctly.