### PR TITLE
minimap plugin: fix left/width calculations for regions on retina/4k screens

### DIFF
--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -219,10 +219,10 @@ export default class MinimapPlugin {
         Object.keys(this.regions).forEach(id => {
             const region = this.regions[id];
             const width =
-                this.drawer.width *
+                this.getWidth() *
                 ((region.end - region.start) / this.wavesurfer.getDuration());
             const left =
-                this.drawer.width *
+                this.getWidth() *
                 (region.start / this.wavesurfer.getDuration());
             const regionElement = this.util.style(
                 document.createElement('region'),
@@ -375,5 +375,9 @@ export default class MinimapPlugin {
             this.wavesurfer.drawer.wrapper.scrollLeft =
                 this.overviewPosition * this.ratio;
         }
+    }
+
+    getWidth() {
+        return this.wavesurfer.drawer.width / this.wavesurfer.params.pixelRatio;
     }
 }

--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -378,6 +378,6 @@ export default class MinimapPlugin {
     }
 
     getWidth() {
-        return this.wavesurfer.drawer.width / this.wavesurfer.params.pixelRatio;
+        return this.drawer.width / this.params.pixelRatio;
     }
 }


### PR DESCRIPTION
### Short description of changes:
When drawing regions in the minimap plugin, the position calculated is incorrect on 4k or retina screens

### Breaking in the external API:
None

### Breaking changes in the internal API:
None

### Related Issues and other PRs:
https://github.com/katspaugh/wavesurfer.js/issues/354