### PR TITLE
a workaround to fix "playLoop will not play a region on clips with duration <15s" #1626

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -230,7 +230,7 @@ class Region {
     bindInOut() {
         this.firedIn = false;
         this.firedOut = false;
-        const approx = (a, b) =>  (Math.abs(a -b) < 1e-1);
+        const approx = (a, b) =>  (Math.abs(a -b) < 1e-2);
         const onProcess = time => {
             if (
                 !this.firedOut &&

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -230,7 +230,8 @@ class Region {
     bindInOut() {
         this.firedIn = false;
         this.firedOut = false;
-        const approx = (a, b) =>  (Math.abs(a -b) < 1e-2);
+        const threshold = 5e-2;
+        const approx = (a, b) => Math.abs(a - b) < threshold;
         const onProcess = time => {
             if (
                 !this.firedOut &&

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -230,13 +230,13 @@ class Region {
     bindInOut() {
         this.firedIn = false;
         this.firedOut = false;
-
+        const approx = (a, b) =>  (Math.abs(a -b) < 1e-1);
         const onProcess = time => {
             if (
                 !this.firedOut &&
                 this.firedIn &&
                 (this.start >= Math.round(time * 100) / 100 ||
-                    this.end <= Math.round(time * 100) / 100)
+                    approx(this.end, time))
             ) {
                 this.firedOut = true;
                 this.firedIn = false;


### PR DESCRIPTION
When judge the end of region playing, use approximate value.
Lines of code,  should no other effects.

fixes #1626
