### PR TITLE
regions plugin: change position of region end handler

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -153,7 +153,7 @@ class Region {
             this.style(handleLeft, css);
             this.style(handleRight, css);
             this.style(handleRight, {
-                left: '100%'
+                right: '0px'
             });
         }
 


### PR DESCRIPTION
### Short description of changes:
Currently start handler is located inside the region while end handler is outside of the region boundary.
PR solves the issue by relocating the end handler to be a part of whole region block

### Breaking in the external API:
No breaking changes

### Breaking changes in the internal API:
No breaking changes

### Todos/Notes:
-

### Related Issues and other PRs:
-