### PR TITLE
Cursor Plugin: Flip time text to left of cursor on right edge for readability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,13 @@ wavesurfer.js changelog
 3.2.0 (unreleased)
 ------------------
 
-- New `barRadius` option to create waveforms with rounded bars (#953)
+- Add `barRadius` option to create waveforms with rounded bars (#953)
 - Throw error when the url parameter supplied to `wavesurfer.load()`
   is empty (#1773, #1775)
 - Specify non-minified wavesurfer.js in `main` entry of `package.json` (#1759)
 - Add `dblclick` event listener to wavesurfer wrapper (#1764)
+- Cursor plugin: flip position of time text to left of the cursor where needed
+  to improve readability (#1776)
 - Regions plugin: change region end handler position (#1762)
 
 3.1.0 (26.09.2019)

--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -241,6 +241,7 @@ export default class CursorPlugin {
      *
      * @param {number} xpos The x offset of the cursor in pixels
      * @param {number} ypos The y offset of the cursor in pixels
+     * @param {boolean} flip Flag to flip duration text from right to left
      */
     updateCursorPosition(xpos, ypos, flip = false) {
         this.style(this.cursor, {
@@ -324,7 +325,7 @@ export default class CursorPlugin {
     /**
      * Get outer width of given element.
      *
-     * @param {e} DOM Element
+     * @param {DOM} e DOM Element
      * @returns {number} outer width
      */
     outerWidth(e) {

--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -90,13 +90,14 @@ export default class CursorPlugin {
         const bbox = this.wavesurfer.container.getBoundingClientRect();
         let y = 0;
         let x = e.clientX - bbox.left;
+        let flip = bbox.right < e.clientX + this.outerWidth(this.displayTime);
 
         if (this.params.showTime && this.params.followCursorY) {
             // follow y-position of the mouse
             y = e.clientY - (bbox.top + bbox.height / 2);
         }
 
-        this.updateCursorPosition(x, y);
+        this.updateCursorPosition(x, y, flip);
     };
 
     /**
@@ -200,12 +201,15 @@ export default class CursorPlugin {
                         {
                             display: 'inline',
                             pointerEvents: 'none',
-                            margin: 'auto'
+                            margin: 'auto',
+                            visibility: 'hidden' //initial value will be hidden just for measuring purpose
                         },
                         this.params.customShowTimeStyle
                     )
                 )
             );
+            //initial value to measure display width
+            this.displayTime.innerHTML = '0:00:000';
         }
 
         this.wrapper.addEventListener('mousemove', this._onMousemove);
@@ -238,7 +242,7 @@ export default class CursorPlugin {
      * @param {number} xpos The x offset of the cursor in pixels
      * @param {number} ypos The y offset of the cursor in pixels
      */
-    updateCursorPosition(xpos, ypos) {
+    updateCursorPosition(xpos, ypos, flip = false) {
         this.style(this.cursor, {
             left: `${xpos}px`
         });
@@ -255,9 +259,14 @@ export default class CursorPlugin {
             const timeValue =
                 Math.max(0, (xpos / elementWidth) * duration) + scrollTime;
             const formatValue = this.formatTime(timeValue);
+            if (flip) {
+                const textOffset = this.outerWidth(this.displayTime);
+                xpos -= textOffset;
+            }
             this.style(this.showTime, {
                 left: `${xpos}px`,
-                top: `${ypos}px`
+                top: `${ypos}px`,
+                visibility: 'visible'
             });
             this.displayTime.innerHTML = `${formatValue}`;
         }
@@ -310,5 +319,21 @@ export default class CursorPlugin {
                 ('000' + Math.floor((time % 1) * 1000)).slice(-3) // milliseconds
             ].join(':')
         );
+    }
+
+    /**
+     * Get outer width of given element.
+     *
+     * @param {e} DOM Element
+     * @returns {number} outer width
+     */
+    outerWidth(e) {
+        if (!e) return 0;
+
+        var width = e.offsetWidth;
+        var style = getComputedStyle(e);
+
+        width += parseInt(style.marginLeft + style.marginRight);
+        return width;
     }
 }

--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -202,14 +202,14 @@ export default class CursorPlugin {
                             display: 'inline',
                             pointerEvents: 'none',
                             margin: 'auto',
-                            visibility: 'hidden' //initial value will be hidden just for measuring purpose
+                            visibility: 'hidden' // initial value will be hidden just for measuring purpose
                         },
                         this.params.customShowTimeStyle
                     )
                 )
             );
-            //initial value to measure display width
-            this.displayTime.innerHTML = '0:00:000';
+            // initial value to measure display width
+            this.displayTime.innerHTML = this.formatTime(0);
         }
 
         this.wrapper.addEventListener('mousemove', this._onMousemove);
@@ -325,14 +325,14 @@ export default class CursorPlugin {
     /**
      * Get outer width of given element.
      *
-     * @param {DOM} e DOM Element
+     * @param {DOM} element DOM Element
      * @returns {number} outer width
      */
-    outerWidth(e) {
-        if (!e) return 0;
+    outerWidth(element) {
+        if (!element) return 0;
 
-        var width = e.offsetWidth;
-        var style = getComputedStyle(e);
+        let width = element.offsetWidth;
+        let style = getComputedStyle(element);
 
         width += parseInt(style.marginLeft + style.marginRight);
         return width;


### PR DESCRIPTION
Hey there!

I did a small change on cursor plugin, which improves the readability of duration text next to the cursor. When user point the very right edge, the duration will be placed on left side of the cursor for better UX. See the gif; 

**Before:**
![duration_without_flip](https://user-images.githubusercontent.com/2774845/66938206-18230700-f041-11e9-810c-e0ee38d94043.gif)

**After:**
![duration_flip](https://user-images.githubusercontent.com/2774845/66938005-b367ac80-f040-11e9-9b45-e02ac63caefb.gif)
