### PR TITLE
fix destroy in MediaElement backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,15 +13,17 @@ wavesurfer.js changelog
     a long duration. You can also supply peaks data, so the entire audio file
     does not have to be decoded.
     For example:
-    ` wavesurfer.load(url | HTMLMediaElement, peaks, preload, duration);
-      wavesurfer.play();
-      wavesurfer.setFilter(customFilter);
-    `
+    ```
+    wavesurfer.load(url | HTMLMediaElement, peaks, preload, duration);
+    wavesurfer.play();
+    wavesurfer.setFilter(customFilter);
+    ```
 - Add `barRadius` option to create waveforms with rounded bars (#953)
 - Throw error when the url parameter supplied to `wavesurfer.load()`
   is empty (#1773, #1775)
 - Specify non-minified wavesurfer.js in `main` entry of `package.json` (#1759)
 - Add `dblclick` event listener to wavesurfer wrapper (#1764)
+- Fix `destroy()` in `MediaElement` backend
 - Cursor plugin: flip position of time text to left of the cursor where needed
   to improve readability (#1776)
 - Regions plugin: change region end handler position (#1762)

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1398,9 +1398,12 @@ export default class WaveSurfer extends util.Observer {
 
         this.tmpEvents.push(
             this.backend.once('canplay', () => {
-                this.drawBuffer();
-                this.isReady = true;
-                this.fireEvent('ready');
+                // ignore when backend was already destroyed
+                if (!this.backend.destroyed) {
+                    this.drawBuffer();
+                    this.isReady = true;
+                    this.fireEvent('ready');
+                }
             }),
             this.backend.once('error', err => this.fireEvent('error', err))
         );


### PR DESCRIPTION
one of my projects that uses wavesurfer.js runs some unit tests that create/destroy a MediaElement backend within a few 100 ms. This situation throws some errors that this PR aims to fix.