### PR TITLE
style right and left handles of region plugin independently

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -144,13 +144,15 @@ class Region {
             const css = {
                 cursor: 'col-resize',
                 position: 'absolute',
-                left: '0px',
                 top: '0px',
                 width: '1%',
                 maxWidth: '4px',
                 height: '100%'
             };
             this.style(handleLeft, css);
+            this.style(handleLeft, {
+                left: '0px'
+            });
             this.style(handleRight, css);
             this.style(handleRight, {
                 right: '0px'


### PR DESCRIPTION
# Short description of changes:

In 804334d63e36f88b5340aa8faac2d0db5adf5acf, the css style of the right region resize handle was changed to `right: 0`, but the element in question already had a `left: 0` style.  This means that the drag handles for the region were basically in the same place. 