### PR TITLE
regions plugin: add maxRegions option to limit max nr of created regions

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -643,6 +643,7 @@ export default class RegionsPlugin {
         this.params = params;
         this.wavesurfer = ws;
         this.util = ws.util;
+        this.maxRegions = params.maxRegions;
         this.util.getRegionSnapToGridValue = value => {
             return this.getRegionSnapToGridValue(value, params);
         };
@@ -836,7 +837,11 @@ export default class RegionsPlugin {
                 return;
             }
 
+
             if (!region) {
+                if (this.maxRegions && Object.keys(this.list).length >= this.maxRegions)
+                    return;
+
                 region = this.add(params || {});
             }
 

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -551,6 +551,7 @@ class Region {
  * @property {?number} snapToGridInterval Snap the regions to a grid of the specified multiples in seconds
  * @property {?number} snapToGridOffset Shift the snap-to-grid by the specified seconds. May also be negative.
  * @property {?boolean} deferInit Set to true to manually call
+ * @property {number[]} maxRegions Maximum number of regions that may be created by the user at one time.
  * `initPlugin('regions')`
  */
 
@@ -837,9 +838,12 @@ export default class RegionsPlugin {
                 return;
             }
 
-
+            // auto-create a region during mouse drag, unless region-count would exceed "maxRegions"
             if (!region) {
-                if (this.maxRegions && Object.keys(this.list).length >= this.maxRegions)
+                if (
+                    this.maxRegions &&
+                    Object.keys(this.list).length >= this.maxRegions
+                )
                     return;
 
                 region = this.add(params || {});

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -699,12 +699,25 @@ export default class RegionsPlugin {
     }
 
     /**
+     * check to see if adding a new region would exceed maxRegions
+     * @return {boolean} whether we should proceed and create a region
+     * @private
+     */
+    wouldExceedMaxRegions() {
+        return (
+            this.maxRegions && Object.keys(this.list).length >= this.maxRegions
+        );
+    }
+
+    /**
      * Add a region
      *
      * @param {object} params Region parameters
      * @return {Region} The created region
      */
     add(params) {
+        if (this.wouldExceedMaxRegions()) return null;
+
         const region = new this.wavesurfer.Region(params, this.wavesurfer);
 
         this.list[region.id] = region;
@@ -840,13 +853,8 @@ export default class RegionsPlugin {
 
             // auto-create a region during mouse drag, unless region-count would exceed "maxRegions"
             if (!region) {
-                if (
-                    this.maxRegions &&
-                    Object.keys(this.list).length >= this.maxRegions
-                )
-                    return;
-
                 region = this.add(params || {});
+                if (!region) return;
             }
 
             const end = this.wavesurfer.drawer.handleEvent(e);


### PR DESCRIPTION
I've been heavily using the regions plugin in a project i'm playing with.  One feature I definitely needed (for my UI's sanity) was to limit the number of regions a user could create (to 1, in my case).