### PR TITLE
regions plugin: add start argument to play and playLoop methods

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -98,15 +98,16 @@ class Region {
     }
 
     /* Play the audio region. */
-    play() {
-        this.wavesurfer.play(this.start, this.end);
+    play(start) {
+        const s = start || this.start;
+        this.wavesurfer.play(s, this.end);
         this.fireEvent('play');
         this.wavesurfer.fireEvent('region-play', this);
     }
 
     /* Play the region in loop. */
-    playLoop() {
-        this.play();
+    playLoop(start) {
+        this.play(start);
         this.once('out', () => this.playLoop());
     }
 

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -97,7 +97,10 @@ class Region {
         }
     }
 
-    /* Play the audio region. */
+    /**
+     * Play the audio region.
+     * @param {number} start Optional offset to start playing at
+     */
     play(start) {
         const s = start || this.start;
         this.wavesurfer.play(s, this.end);
@@ -105,7 +108,10 @@ class Region {
         this.wavesurfer.fireEvent('region-play', this);
     }
 
-    /* Play the region in loop. */
+    /**
+     * Play the audio region in a loop.
+     * @param {number} start Optional offset to start playing at
+     * */
     playLoop(start) {
         this.play(start);
         this.once('out', () => this.playLoop());


### PR DESCRIPTION
I've had the need of late to start playing a loop defined in the region plugin in the middle of the loop.

(fyi if you're interested, https://mixmastermiles.com/)