### PR TITLE
allow changing the stop-point of wavesurfer during playback

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -317,6 +317,8 @@ export default class MediaElement extends WebAudio {
      * @param {number} end Where to end
      */
     setPlayEnd(end) {
+        this.clearPlayEnd();
+
         this._onPlayEnd = time => {
             if (time >= end) {
                 this.pause();

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -314,7 +314,6 @@ export default class MediaElement extends WebAudio {
     /**
      * Set the play end
      *
-     * @private
      * @param {number} end Where to end
      */
     setPlayEnd(end) {

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -768,6 +768,15 @@ export default class WaveSurfer extends util.Observer {
     }
 
     /**
+     * Set a point in seconds for playback to stop at.
+     *
+     * @param {number} position Position (in seconds) to stop at
+     */
+    setPlayEnd(position) {
+        this.backend.setPlayEnd(position);
+    }
+
+    /**
      * Stops and pauses playback
      *
      * @example wavesurfer.pause();

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -771,6 +771,7 @@ export default class WaveSurfer extends util.Observer {
      * Set a point in seconds for playback to stop at.
      *
      * @param {number} position Position (in seconds) to stop at
+     * @version 3.3.0
      */
     setPlayEnd(position) {
         this.backend.setPlayEnd(position);

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -111,7 +111,7 @@ export default class WebAudio extends util.Observer {
         this.lastPlay = this.ac.currentTime;
         /** @private */
         this.startPosition = 0;
-        /** @private  */
+        /** @private */
         this.scheduledPause = null;
         /** @private */
         this.states = {
@@ -656,7 +656,7 @@ export default class WebAudio extends util.Observer {
 
         this.scheduledPause = end;
 
-        this.source.start(0, start, end - start);
+        this.source.start(0, start);
 
         if (this.ac.state == 'suspended') {
             this.ac.resume && this.ac.resume();
@@ -714,5 +714,14 @@ export default class WebAudio extends util.Observer {
             this.playbackRate = value;
             this.play();
         }
+    }
+
+    /**
+     * Set a point in seconds for playback to stop at.
+     *
+     * @param {number} end Position to end at
+     */
+    setPlayEnd(end) {
+        this.scheduledPause = end;
     }
 }

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -720,6 +720,7 @@ export default class WebAudio extends util.Observer {
      * Set a point in seconds for playback to stop at.
      *
      * @param {number} end Position to end at
+     * @version 3.3.0
      */
     setPlayEnd(end) {
         this.scheduledPause = end;


### PR DESCRIPTION
When someone is playing back a loop or region, this allows for moving the loop end-point while playback is happening.

If you like I can also code that behavior into regions.js.  currently I'm moving the loop end point in external code.