### PR TITLE
regions plugin: allow setting the handleColor inside addRegion

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -29,7 +29,14 @@ class Region {
         this.isDragging = false;
         this.loop = Boolean(params.loop);
         this.color = params.color || 'rgba(0, 0, 0, 0.1)';
-        this.handleColor = params.handleColor || 'rgba(0, 0, 0, 1)';
+        this.handleStyle = params.handleStyle || {
+            left: {
+                backgroundColor: 'rgba(0, 0, 0, 1)'
+            },
+            right: {
+                backgroundColor: 'rgba(0, 0, 0, 1)'
+            }
+        };
         this.data = params.data || {};
         this.attributes = params.attributes || {};
 
@@ -62,8 +69,8 @@ class Region {
         if (null != params.color) {
             this.color = params.color;
         }
-        if (null != params.handleColor) {
-            this.handleColor = params.handleColor;
+        if (null != params.handleStyle) {
+            this.handleStyle = params.handleStyle;
         }
         if (null != params.data) {
             this.data = params.data;
@@ -149,9 +156,18 @@ class Region {
             top: '0px'
         });
         
-        /* Allows the user to set the handlecolor dynamically */
-        handleLeft.style.backgroundColor = this.handleColor;
-        handleRight.style.backgroundColor = this.handleColor;
+        /* Allows the user to set the handlecolor dynamically, both handle colors must be set */
+        if(!this.handleStyle.left) {
+            handleLeft.style.backgroundColor = 'rgba(0, 0, 0, 1)';
+        } else {
+            handleLeft.style.backgroundColor = this.handleStyle.left.backgroundColor;
+        }
+
+        if(!this.handleStyle.right) {
+            handleRight.style.backgroundColor = 'rgba(0, 0, 0, 1)';
+        } else {
+            handleRight.style.backgroundColor = this.handleStyle.right.backgroundColor;
+        }
 
         /* Resize handles */
         if (this.resize) {

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -29,6 +29,7 @@ class Region {
         this.isDragging = false;
         this.loop = Boolean(params.loop);
         this.color = params.color || 'rgba(0, 0, 0, 0.1)';
+        this.handleColor = params.handleColor || 'rgba(0, 0, 0, 1)';
         this.data = params.data || {};
         this.attributes = params.attributes || {};
 
@@ -60,6 +61,9 @@ class Region {
         }
         if (null != params.color) {
             this.color = params.color;
+        }
+        if (null != params.handleColor) {
+            this.handleColor = params.handleColor;
         }
         if (null != params.data) {
             this.data = params.data;
@@ -120,6 +124,13 @@ class Region {
     /* Render a region as a DOM element. */
     render() {
         const regionEl = document.createElement('region');
+        const handleLeft = regionEl.appendChild(
+            document.createElement('handle')
+        );
+        const handleRight = regionEl.appendChild(
+            document.createElement('handle')
+        );
+        
         regionEl.className = 'wavesurfer-region';
         regionEl.title = this.formatTime(this.start, this.end);
         regionEl.setAttribute('data-id', this.id);
@@ -137,15 +148,13 @@ class Region {
             height: '100%',
             top: '0px'
         });
+        
+        /* Allows the user to set the handlecolor dynamically */
+        handleLeft.style.backgroundColor = this.handleColor;
+        handleRight.style.backgroundColor = this.handleColor;
 
         /* Resize handles */
         if (this.resize) {
-            const handleLeft = regionEl.appendChild(
-                document.createElement('handle')
-            );
-            const handleRight = regionEl.appendChild(
-                document.createElement('handle')
-            );
             handleLeft.className = 'wavesurfer-handle wavesurfer-handle-start';
             handleRight.className = 'wavesurfer-handle wavesurfer-handle-end';
             const css = {

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -137,7 +137,7 @@ class Region {
         const handleRight = regionEl.appendChild(
             document.createElement('handle')
         );
-        
+
         regionEl.className = 'wavesurfer-region';
         regionEl.title = this.formatTime(this.start, this.end);
         regionEl.setAttribute('data-id', this.id);
@@ -155,15 +155,15 @@ class Region {
             height: '100%',
             top: '0px'
         });
-        
+
         /* Allows the user to set the handlecolor dynamically, both handle colors must be set */
-        if(!this.handleStyle.left) {
+        if (!this.handleStyle.left) {
             handleLeft.style.backgroundColor = 'rgba(0, 0, 0, 1)';
         } else {
             handleLeft.style.backgroundColor = this.handleStyle.left.backgroundColor;
         }
 
-        if(!this.handleStyle.right) {
+        if (!this.handleStyle.right) {
             handleRight.style.backgroundColor = 'rgba(0, 0, 0, 1)';
         } else {
             handleRight.style.backgroundColor = this.handleStyle.right.backgroundColor;


### PR DESCRIPTION
### Short description of changes:
Currently we can set the handleColor for a region inside CSS, while this is great, it does not allow the user to set the handleColor dynamically. 

### Breaking changes in the internal API:
- I currently moved out the creation of `handleLeft` and `handleRight` to the render function instead of inside the resize conditional, just so that we don't have to create them again, I am not sure whether or not this has a performance impact.

**Notes**
- Added a new handleColor attribute to the Region constructor
- The regular CSS solution still works as you would expect