### PR TITLE
cursor plugin: fix time visibility

### DIFF
--- a/src/plugin/cursor.js
+++ b/src/plugin/cursor.js
@@ -266,7 +266,9 @@ export default class CursorPlugin {
             }
             this.style(this.showTime, {
                 left: `${xpos}px`,
-                top: `${ypos}px`,
+                top: `${ypos}px`
+            });
+            this.style(this.displayTime, {
                 visibility: 'visible'
             });
             this.displayTime.innerHTML = `${formatValue}`;


### PR DESCRIPTION
I have opened this pull request to solve the bug described in the issue #1802 
 
The element showing the time in the cursor plugin was always hidden after changes made in version 3.2, with this changes I fixed it.

fixes #1802 
