### PR TITLE
return Promise from wavesurfer.exportPCM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ wavesurfer.js changelog
 3.3.0 (unreleased)
 ------------------
 
+- `wavesurfer.exportPCM` now accepts an optional `end` argument and returns
+  a Promise (#1728)
 - Add `wavesurfer.setPlayEnd(position)` to set a point in seconds for
   playback to stop at (#1795)
 - Add `barMinHeight` option (#1693)

--- a/spec/wavesurfer.spec.js
+++ b/spec/wavesurfer.spec.js
@@ -322,7 +322,6 @@ describe('WaveSurfer/playback:', function() {
 
     /** @test {WaveSurfer#exportPCM} */
     it('return Promise with PCM data formatted using JSON.stringify', function(done) {
-        manualDestroy = true;
         wavesurfer.exportPCM().then(pcmData => {
             expect(pcmData).toBeNonEmptyString();
 

--- a/spec/wavesurfer.spec.js
+++ b/spec/wavesurfer.spec.js
@@ -321,9 +321,13 @@ describe('WaveSurfer/playback:', function() {
     });
 
     /** @test {WaveSurfer#exportPCM} */
-    it('return PCM data formatted using JSON.stringify', function() {
-        var pcmData = wavesurfer.exportPCM();
-        expect(pcmData).toBeNonEmptyString();
+    it('return Promise with PCM data formatted using JSON.stringify', function(done) {
+        manualDestroy = true;
+        wavesurfer.exportPCM().then(pcmData => {
+            expect(pcmData).toBeNonEmptyString();
+
+            done();
+        });
     });
 
     /** @test {WaveSurfer#getFilters} */

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1530,15 +1530,15 @@ export default class WaveSurfer extends util.Observer {
      * @param {?boolean} noWindow Set to true to disable opening a new
      * window with the JSON
      * @param {number} start Start index
-     * @todo Update exportPCM to work with new getPeaks signature
+     * @param {number} end End index
      * @return {string} JSON of peaks
      */
-    exportPCM(length, accuracy, noWindow, start) {
+    exportPCM(length, accuracy, noWindow, start, end) {
         length = length || 1024;
         start = start || 0;
         accuracy = accuracy || 10000;
         noWindow = noWindow || false;
-        const peaks = this.backend.getPeaks(length, start);
+        const peaks = this.backend.getPeaks(length, start, end);
         const arr = [].map.call(
             peaks,
             val => Math.round(val * accuracy) / accuracy

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1525,13 +1525,13 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Exports PCM data into a JSON array and opens in a new window.
      *
-     * @param {number} length=1024 The scale in which to export the peaks. (Integer)
-     * @param {number} accuracy=10000 (Integer)
+     * @param {number} length=1024 The scale in which to export the peaks
+     * @param {number} accuracy=10000
      * @param {?boolean} noWindow Set to true to disable opening a new
      * window with the JSON
      * @param {number} start Start index
      * @param {number} end End index
-     * @return {string} JSON of peaks
+     * @return {Promise} Promise that resolves with array of peaks
      */
     exportPCM(length, accuracy, noWindow, start, end) {
         length = length || 1024;
@@ -1543,14 +1543,17 @@ export default class WaveSurfer extends util.Observer {
             peaks,
             val => Math.round(val * accuracy) / accuracy
         );
-        const json = JSON.stringify(arr);
-        if (!noWindow) {
-            window.open(
-                'data:application/json;charset=utf-8,' +
-                    encodeURIComponent(json)
-            );
-        }
-        return json;
+        return new Promise((resolve, reject) => {
+            const json = JSON.stringify(arr);
+
+            if (!noWindow) {
+                window.open(
+                    'data:application/json;charset=utf-8,' +
+                        encodeURIComponent(json)
+                );
+            }
+            resolve(json);
+        });
     }
 
     /**


### PR DESCRIPTION
Sometimes it can take a while before `JSON.stringify`, used in `exportPCM`, finishes, so return a Promise that resolves with data.

Also added missing `end` parameter to `exportPCM`.

I'm aware this is not backwards-compatible but not sure how else to fix/improve this issue.

fixes #1728 