### PR TITLE
document barMinHeight.  Also some css to stop prop names from wrapping.

### DIFF
--- a/docs/options.html
+++ b/docs/options.html
@@ -6,6 +6,12 @@ layout: default
 
   <p>This is the list of parameters you can pass to <code>var wavesurfer = WaveSurfer.create({ ... })</code> to create an instance of the player.</p>
 
+  <style>
+    code {
+      word-break: normal;
+    }
+  </style>
+
   <table class="table table-striped">
     <thead>
       <tr>
@@ -63,6 +69,12 @@ layout: default
         <td>number</td>
         <td><em>1</em></td>
         <td>Height of the waveform bars. Higher number than 1 will increase the waveform bar heights.</td>
+      </tr>
+      <tr>
+        <td><code>barHeight</code></td>
+        <td>number</td>
+        <td><em>null</em></td>
+        <td>Minimum height to draw a waveform bar.  Default behavior is to not draw a bar during silence.</td>
       </tr>
       <tr>
         <td><code>barRadius</code></td>


### PR DESCRIPTION
on my browser the properties name on the options pages wrap ugly like this: 

![image](https://user-images.githubusercontent.com/260084/69514721-2518fd00-0f01-11ea-88e2-d00fa91a4e57.png)

due to some odd bootstrap css around `<code>`.