### PR TITLE
regions plugin: don't assign to module object

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -650,11 +650,13 @@ export default class RegionsPlugin {
     constructor(params, ws) {
         this.params = params;
         this.wavesurfer = ws;
-        this.util = ws.util;
-        this.maxRegions = params.maxRegions;
-        this.util.getRegionSnapToGridValue = value => {
-            return this.getRegionSnapToGridValue(value, params);
+        this.util = {
+            ...ws.util,
+            getRegionSnapToGridValue: value => {
+                return this.getRegionSnapToGridValue(value, params);
+            }
         };
+        this.maxRegions = params.maxRegions;
 
         // turn the plugin instance into an observer
         const observerPrototypeKeys = Object.getOwnPropertyNames(


### PR DESCRIPTION
As it's invalid (I noticed when bundling with rollup).

Reproduce in a browser with something like the following:
```html
<script type=module>
import * as util from './util.js';
util.a = 1;
</script>
```