### PR TITLE
regions plugin: disable drag selection before enabling it

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -746,6 +746,8 @@ export default class RegionsPlugin {
     }
 
     enableDragSelection(params) {
+        this.disableDragSelection();
+
         const slop = params.slop || 2;
         const container = this.wavesurfer.drawer.container;
         const scroll =


### PR DESCRIPTION
**Prevent from attaching multiple event handlers to drag selection action, in a scenario where drag selection is enabled multiple times in a row.**

### Short description of changes:

The simplest solution was applied: disabling drag selection before enabling it. I've tested a few other possible solutions, but this was the shortest and the best. One of the other possible solutions was setting a flag indicating that drag selection is already enabled and returning from the `enableDragSelection` immediately, but this unfortunately also prevents from updating drag parameters by simply calling `enableDragSelection` again with new parameters.

### Todos/Notes:

The main cause why this issue even happened is because of using "arrow functions" for event listeners. When `addEventListener` is used with **the same** event handler, the previous handler is discarded, but when using "arrow functions", the handler is different at 
each `enableDragSelection` invocation, so instead of being replaced, it was added.

### Related Issues and other PRs:

fixes #1698 