### PR TITLE
regions plugin: add option to select specific channel to draw on

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -48,6 +48,17 @@ class Region {
         this.scrollSpeed = params.scrollSpeed || 1;
         this.scrollThreshold = params.scrollThreshold || 10;
 
+        // select channel ID to set region
+        let channelIdx =
+            params.channelIdx == null ? -1 : parseInt(params.channelIdx);
+        this.regionHeight = '100%';
+        this.marginTop = '0px';
+        let channelCount = this.wavesurfer.backend.ac.destination.channelCount;
+        if (channelIdx >= 0 && channelIdx < channelCount) {
+            this.regionHeight = Math.floor((1 / channelCount) * 100) + '%';
+            this.marginTop = this.wavesurfer.getHeight() * channelIdx + 'px';
+        }
+
         this.bindInOut();
         this.render();
         this.wavesurfer.on('zoom', this._onRedraw);
@@ -152,8 +163,8 @@ class Region {
         this.style(regionEl, {
             position: 'absolute',
             zIndex: 2,
-            height: '100%',
-            top: '0px'
+            height: this.regionHeight,
+            top: this.marginTop
         });
 
         /* Allows the user to set the handlecolor dynamically, both handle colors must be set */
@@ -176,10 +187,10 @@ class Region {
             const css = {
                 cursor: 'col-resize',
                 position: 'absolute',
-                top: '0px',
+                top: this.marginTop,
                 width: '1%',
                 maxWidth: '4px',
-                height: '100%'
+                height: this.regionHeight
             };
             this.style(handleLeft, css);
             this.style(handleLeft, {

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -609,6 +609,7 @@ class Region {
  * @property {boolean} drag=true Allow/disallow dragging the region.
  * @property {boolean} resize=true Allow/disallow resizing the region.
  * @property {string} [color='rgba(0, 0, 0, 0.1)'] HTML color code.
+ * @property {?number} channelIdx Select channel to draw the region on (if there are multiple channel waveforms).
  */
 
 /**


### PR DESCRIPTION
**Now there can be specified `channelIdx` param to draw region on specific channel**

### Short description of changes:
```
plugins: [
            WaveSurfer.regions.create({
                regions: [
                    {
                        start: 1,
                        end: 5,
                        loop: false,
                        color: 'hsla(400, 100%, 30%, 0.5)'
                    },
                    {
                        start: 7,
                        end: 9,
                        loop: false,
                        color: 'hsla(200, 50%, 70%, 0.4)',
                        channelIdx: 1
                    }
                ]
            })
        ]
```
Height of region is controlled by 2 parameters, `regionHeight` and `marginTop`:
```
this.regionHeight = '100%';
this.marginTop = '0px';
let channelCount = this.wavesurfer.backend.ac.destination.channelCount;
if (channelIdx >= 0 && channelIdx < channelCount) {
    this.regionHeight = Math.floor((1 / channelCount) * 100) + '%';
    this.marginTop = this.wavesurfer.getHeight() * channelIdx + 'px';
}
```
Default behavior(if parameter is omitted) draws whole height.
### Screenshot
![image](https://user-images.githubusercontent.com/2136545/70803508-6e60bc00-1dde-11ea-9f9c-ce97e2b6ae05.png)
