### PR TITLE
deprecate util.frame

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ wavesurfer.js changelog
   - Disable drag selection before enabling it (#1698)
   - Add `channelIdx` option to select specific channel to draw on (#1829)
 - Cursor plugin: fix time visibility (#1802)
+- Deprecate `util.frame` (i.e. rAF shim) (#1833)
 
 3.2.0 (24.10.2019)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ wavesurfer.js changelog
   - Disable drag selection before enabling it (#1698)
   - Add `channelIdx` option to select specific channel to draw on (#1829)
 - Cursor plugin: fix time visibility (#1802)
+- Deprecate `util.extend` (#1825)
 - Deprecate `util.frame` (i.e. rAF shim) (#1833)
 
 3.2.0 (24.10.2019)

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -458,7 +458,7 @@ export default class MultiCanvas extends Drawer {
      * @returns {void}
      */
     prepareDraw(peaks, channelIndex, start, end, fn) {
-        return util.frame(() => {
+        return window.requestAnimationFrame(() => {
             // Split channels and call this function with the channelIndex set
             if (peaks[0] instanceof Array) {
                 const channels = peaks;
@@ -499,7 +499,7 @@ export default class MultiCanvas extends Drawer {
                 halfH: halfH,
                 peaks: peaks
             });
-        })();
+        });
     }
 
     /**

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -110,7 +110,7 @@ export default class MediaElement extends WebAudio {
             this.fireEvent('audioprocess', this.getCurrentTime());
 
             // Call again in the next frame
-            util.frame(onAudioProcess)();
+            window.requestAnimationFrame(onAudioProcess);
         };
 
         this.on('play', onAudioProcess);

--- a/src/util/frame.js
+++ b/src/util/frame.js
@@ -1,5 +1,3 @@
-import reqAnimationFrame from './request-animation-frame';
-
 /**
  * Create a function which will be called at the next requestAnimationFrame
  * cycle
@@ -9,5 +7,8 @@ import reqAnimationFrame from './request-animation-frame';
  * @return {func} The function wrapped within a requestAnimationFrame
  */
 export default function frame(func) {
-    return (...args) => reqAnimationFrame(() => func(...args));
+    console.warn(
+        'util.frame is deprecated; use window.requestAnimationFrame instead'
+    );
+    return (...args) => window.requestAnimationFrame(() => func(...args));
 }

--- a/src/util/request-animation-frame.js
+++ b/src/util/request-animation-frame.js
@@ -11,5 +11,5 @@ export default (
     window.mozRequestAnimationFrame ||
     window.oRequestAnimationFrame ||
     window.msRequestAnimationFrame ||
-    ((callback, element) => setTimeout(callback, 1000 / 60))
+    (callback => setTimeout(callback, 1000 / 60))
 ).bind(window);


### PR DESCRIPTION
Funny that this is even in. The README says:

> wavesurfer.js works only in modern browsers supporting Web Audio.

Anything that supports Web Audio supports rAF.