### PR TITLE
regions plugin: improve handle style support

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -30,12 +30,8 @@ class Region {
         this.loop = Boolean(params.loop);
         this.color = params.color || 'rgba(0, 0, 0, 0.1)';
         this.handleStyle = params.handleStyle || {
-            left: {
-                backgroundColor: 'rgba(0, 0, 0, 1)'
-            },
-            right: {
-                backgroundColor: 'rgba(0, 0, 0, 1)'
-            }
+            left: {},
+            right: {}
         };
         this.data = params.data || {};
         this.attributes = params.attributes || {};
@@ -142,12 +138,6 @@ class Region {
     /* Render a region as a DOM element. */
     render() {
         const regionEl = document.createElement('region');
-        const handleLeft = regionEl.appendChild(
-            document.createElement('handle')
-        );
-        const handleRight = regionEl.appendChild(
-            document.createElement('handle')
-        );
 
         regionEl.className = 'wavesurfer-region';
         regionEl.title = this.formatTime(this.start, this.end);
@@ -167,21 +157,15 @@ class Region {
             top: this.marginTop
         });
 
-        /* Allows the user to set the handlecolor dynamically, both handle colors must be set */
-        if (!this.handleStyle.left) {
-            handleLeft.style.backgroundColor = 'rgba(0, 0, 0, 1)';
-        } else {
-            handleLeft.style.backgroundColor = this.handleStyle.left.backgroundColor;
-        }
-
-        if (!this.handleStyle.right) {
-            handleRight.style.backgroundColor = 'rgba(0, 0, 0, 1)';
-        } else {
-            handleRight.style.backgroundColor = this.handleStyle.right.backgroundColor;
-        }
-
         /* Resize handles */
         if (this.resize) {
+            const handleLeft = regionEl.appendChild(
+                document.createElement('handle')
+            );
+            const handleRight = regionEl.appendChild(
+                document.createElement('handle')
+            );
+
             handleLeft.className = 'wavesurfer-handle wavesurfer-handle-start';
             handleRight.className = 'wavesurfer-handle wavesurfer-handle-end';
             const css = {
@@ -190,16 +174,29 @@ class Region {
                 top: this.marginTop,
                 width: '1%',
                 maxWidth: '4px',
-                height: this.regionHeight
+                height: this.regionHeight,
+                backgroundColor: 'rgba(0, 0, 0, 1)'
             };
-            this.style(handleLeft, css);
-            this.style(handleLeft, {
-                left: '0px'
-            });
-            this.style(handleRight, css);
-            this.style(handleRight, {
-                right: '0px'
-            });
+            const handleLeftCss =
+                this.handleStyle.left !== 'none'
+                    ? Object.assign({ left: '0px' }, css, this.handleStyle.left)
+                    : null;
+            const handleRightCss =
+                this.handleStyle.right !== 'none'
+                    ? Object.assign(
+                          { right: '0px' },
+                          css,
+                          this.handleStyle.right
+                      )
+                    : null;
+
+            if (handleLeftCss) {
+                this.style(handleLeft, handleLeftCss);
+            }
+
+            if (handleRightCss) {
+                this.style(handleRight, handleRightCss);
+            }
         }
 
         this.element = this.wrapper.appendChild(regionEl);

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -29,6 +29,8 @@ class Region {
         this.isDragging = false;
         this.loop = Boolean(params.loop);
         this.color = params.color || 'rgba(0, 0, 0, 0.1)';
+        // The left and right handleStyle properties can be set to 'none' for
+        // no styling or can be assigned an object containing CSS properties.
         this.handleStyle = params.handleStyle || {
             left: {},
             right: {}
@@ -168,6 +170,8 @@ class Region {
 
             handleLeft.className = 'wavesurfer-handle wavesurfer-handle-start';
             handleRight.className = 'wavesurfer-handle wavesurfer-handle-end';
+
+            // Default CSS properties for both handles.
             const css = {
                 cursor: 'col-resize',
                 position: 'absolute',
@@ -177,6 +181,8 @@ class Region {
                 height: this.regionHeight,
                 backgroundColor: 'rgba(0, 0, 0, 1)'
             };
+
+            // Merge CSS properties per handle.
             const handleLeftCss =
                 this.handleStyle.left !== 'none'
                     ? Object.assign({ left: '0px' }, css, this.handleStyle.left)


### PR DESCRIPTION
### Short description of changes:

This PR improves the stylability of the region handles. Previously (since version 3.3.0) it was only possible to set a background-color. This feature was made possible by #1798. Other styling properties could not be set on the region handles.

This PR makes it possible to:

1. Set any styling property on a handle. As discussed [here](https://github.com/katspaugh/wavesurfer.js/issues/1838#issue-544401172).
2. Disable all JS-styling of a handle. This way styling can be done in CSS. As discussed [in point 1 here](https://github.com/katspaugh/wavesurfer.js/issues/1838#issuecomment-570312988).

### Breaking in the external API:

None, as far as I can see. It should be compatible with v3.3.0 / PR #1798, but please check my comment [there](https://github.com/katspaugh/wavesurfer.js/pull/1798#issuecomment-570084267).

### Breaking changes in the internal API:

None, as far as I can see. It should be compatible with v3.3.0 / PR #1798, but please check my comment [there](https://github.com/katspaugh/wavesurfer.js/pull/1798#issuecomment-570084267).

### Todos/Notes:

Issue #1838 contains more suggestions for further improvements.

### Related Issues and other PRs:

- Issue #1838.