### PR TITLE
regions plugin: add support for a context menu event on a region

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -618,6 +618,8 @@ class Region {
  * @property {boolean} resize=true Allow/disallow resizing the region.
  * @property {string} [color='rgba(0, 0, 0, 0.1)'] HTML color code.
  * @property {?number} channelIdx Select channel to draw the region on (if there are multiple channel waveforms).
+ * @property {?object} handleStyle A set of CSS properties used to style the left and right handle.
+ * @property {?boolean} preventContextMenu=false Determines whether the context menu is prevented from being opened.
  */
 
 /**

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -45,6 +45,11 @@ class Region {
         this.scroll = params.scroll !== false && ws.params.scrollParent;
         this.scrollSpeed = params.scrollSpeed || 1;
         this.scrollThreshold = params.scrollThreshold || 10;
+        // Determines whether the context menu is prevented from being opened.
+        this.preventContextMenu =
+            params.preventContextMenu === undefined
+                ? false
+                : Boolean(params.preventContextMenu);
 
         // select channel ID to set region
         let channelIdx =
@@ -318,6 +323,8 @@ class Region {
 
     /* Bind DOM events. */
     bindEvents() {
+        const preventContextMenu = this.preventContextMenu;
+
         this.element.addEventListener('mouseenter', e => {
             this.fireEvent('mouseenter', e);
             this.wavesurfer.fireEvent('region-mouseenter', this, e);
@@ -339,6 +346,14 @@ class Region {
             e.preventDefault();
             this.fireEvent('dblclick', e);
             this.wavesurfer.fireEvent('region-dblclick', this, e);
+        });
+
+        this.element.addEventListener('contextmenu', e => {
+            if (preventContextMenu) {
+                e.preventDefault();
+            }
+            this.fireEvent('contextmenu', e);
+            this.wavesurfer.fireEvent('region-contextmenu', this, e);
         });
 
         /* Drag or resize on mousemove. */


### PR DESCRIPTION
This PR adds support for a context menu event on a region in the regions plugin. It contains an option to disable the native context menu from being opened (`preventContextMenu`, defaults to false).

Fixes #1842.

The functionality was approved by @thijstriemstra [here](https://github.com/katspaugh/wavesurfer.js/issues/1842#issuecomment-570937396).