### PR TITLE
Use requestAnimationFrame for clearWave

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 wavesurfer.js changelog
 =======================
 
+3.3.2 (unreleased)
+
+- Use requestAnimationFrame for clearWave (#1884)
+
 3.3.1 (13.01.2020)
 ------------------
 

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -260,7 +260,9 @@ export default class MultiCanvas extends Drawer {
      * Clear the whole multi-canvas
      */
     clearWave() {
-        this.canvases.forEach(entry => entry.clearWave());
+        util.frame(() => {
+            this.canvases.forEach(entry => entry.clearWave());
+        })();
     }
 
     /**


### PR DESCRIPTION
As discussed [here](https://github.com/katspaugh/wavesurfer.js/issues/1884#issue-586311889), this is a workaround for #1884.

fixes #1884 