### PR TITLE
Add reloadMediaElement param and fix region loop

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -184,7 +184,7 @@ export default class MediaElement extends WebAudio {
 
         // load must be called manually on iOS, otherwise peaks won't draw
         // until a user interaction triggers load --> 'ready' event
-        if (typeof media.load == 'function') {
+        if (this.params.reloadMediaElement && typeof media.load == 'function') {
             // Resets the media element and restarts the media resource. Any
             // pending events are discarded. How much media data is fetched is
             // still affected by the preload attribute.

--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -138,8 +138,16 @@ class Region {
      * @param {number} start Optional offset to start playing at
      * */
     playLoop(start) {
-        this.play(start);
-        this.once('out', () => this.playLoop());
+        const s = start || this.start;
+        this.play(s);
+        this.once('out', () => {
+            if (
+                this.wavesurfer.getCurrentTime() >= this.start &&
+                this.wavesurfer.getCurrentTime() <= this.end
+            ) {
+                return this.playLoop();
+            }
+        });
     }
 
     /* Render a region as a DOM element. */

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -100,6 +100,8 @@ import MediaElementWebAudio from './mediaelement-webaudio';
  * @property {boolean} removeMediaElementOnDestroy=true Set to false to keep the
  * media element in the DOM when the player is destroyed. This is useful when
  * reusing an existing media element via the `loadMediaElement` method.
+ * @property {boolean} reloadMediaElement=true Set to false to skip the empty() and
+ * load() operations. Avoid duplication when MediaElement is in the canplay state
  * @property {Object} renderer=MultiCanvas Can be used to inject a custom
  * renderer.
  * @property {boolean|number} responsive=false If set to `true` resize the
@@ -258,6 +260,7 @@ export default class WaveSurfer extends util.Observer {
         plugins: [],
         progressColor: '#555',
         removeMediaElementOnDestroy: true,
+        reloadMediaElement: true,
         renderer: MultiCanvas,
         responsive: false,
         rtl: false,
@@ -1328,7 +1331,9 @@ export default class WaveSurfer extends util.Observer {
         if (!url) {
             throw new Error('url parameter cannot be empty');
         }
-        this.empty();
+        if (this.params.reloadMediaElement) {
+            this.empty();
+        }
         if (preload) {
             // check whether the preload attribute will be usable and if not log
             // a warning listing the reasons why not and nullify the variable


### PR DESCRIPTION
### Short description of changes:
In the example `Annotations`, after shift-click region, and then shift-click other region, you can not jump out of the current loop. Checking current time, continuing the loop if it is in the current region, and stopping the loop if it is not, seems to solve the problem.

When the `url` param for `wavesurfer.load()` is `MediaElement` in `canplay` state, there is no need for empty and load, I suggest adding `reloadMediaElement` parameter.

### Breaking in the external API:
- `reloadMediaElement=false`: When MediaElement is in the canplay state, there is no need to reload.

### Breaking changes in the internal API:
- After drag the region, audio will still pause in its previous position.

