### PR TITLE
Fix Unable to get property 'toLowerCase' of undefined or null reference in IE11

### DIFF
--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -57,7 +57,11 @@ export default class CanvasEntry {
          *
          * @type {string}
          */
-        this.id = getId(this.constructor.name.toLowerCase() + '_');
+        this.id = getId(
+            typeof this.constructor.name !== 'undefined'
+                ? this.constructor.name.toLowerCase() + '_'
+                : 'canvasentry_'
+        );
         /**
          * Canvas 2d context attributes
          *


### PR DESCRIPTION
Fix Unable to get property 'toLowerCase' of undefined or null reference in IE11

### Short description of changes:
Check if constructor name exist before converting it to lowercase, else use hardcoded value 


### Breaking in the external API:
none

### Breaking changes in the internal API:
none

### Todos/Notes:
none

### Related Issues and other PRs:
fixes #1771