### PR TITLE
Corrected "barMinHeight" option typo in documentation.

### DIFF
--- a/docs/options.html
+++ b/docs/options.html
@@ -71,7 +71,7 @@ layout: default
         <td>Height of the waveform bars. Higher number than 1 will increase the waveform bar heights.</td>
       </tr>
       <tr>
-        <td><code>barHeight</code></td>
+        <td><code>barMinHeight</code></td>
         <td>number</td>
         <td><em>null</em></td>
         <td>Minimum height to draw a waveform bar.  Default behavior is to not draw a bar during silence.</td>


### PR DESCRIPTION
## Please make sure you provide the information below:

### Short description of changes:
barMinHeight was mistakenly labelled barHeight on the options page.

### Breaking in the external API:
No

### Breaking changes in the internal API:
No

### Todos/Notes:
None

### Related Issues and other PRs:
None