### PR TITLE
Elan plugin: optional params.tiers (#1910)

### DIFF
--- a/src/plugin/elan.js
+++ b/src/plugin/elan.js
@@ -237,7 +237,6 @@ export default class ElanPlugin {
             const th = document.createElement('th');
             th.className = 'wavesurfer-tier-' + tier.id;
             th.textContent = tier.id;
-            th.style.width = true;
             headRow.appendChild(th);
         });
 

--- a/src/plugin/elan.js
+++ b/src/plugin/elan.js
@@ -237,7 +237,7 @@ export default class ElanPlugin {
             const th = document.createElement('th');
             th.className = 'wavesurfer-tier-' + tier.id;
             th.textContent = tier.id;
-            th.style.width = this.params.tiers[tier.id];
+            th.style.width = true;
             headRow.appendChild(th);
         });
 

--- a/src/plugin/elan.js
+++ b/src/plugin/elan.js
@@ -237,6 +237,7 @@ export default class ElanPlugin {
             const th = document.createElement('th');
             th.className = 'wavesurfer-tier-' + tier.id;
             th.textContent = tier.id;
+            if (this.params.tiers) { th.style.width = this.params.tiers[tier.id]; }
             headRow.appendChild(th);
         });
 


### PR DESCRIPTION
### Short description of changes:

This fixes a bug where undefined Elan `params.tiers` would lead to an error, thus making the parameter truly optional. #1910 

### Breaking in the external API:

N/A

### Breaking changes in the internal API:

N/A

### Todos/Notes:


### Related Issues and other PRs:
