### PR TITLE
Regions plugin: fix click propagation issue

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -342,6 +342,7 @@ class Region {
         });
 
         this.element.addEventListener('click', e => {
+            e.stopPropagation();
             e.preventDefault();
             this.fireEvent('click', e);
             this.wavesurfer.fireEvent('region-click', this, e);


### PR DESCRIPTION
## Short description of changes:
This PR fixes the issue described in Issue #1925 where a click on the region is ignored by the wavesurfer interact click implementation. This behavior can be undesirable and this PR fixes that.

fixes #1925 

### Breaking in the external API:
None

### Breaking changes in the internal API:
None

### Todos/Notes:
Possible improvement is to not stop propagation for when the current behavior is desirable.
The way this could be implemented is by passing the browser event with the region in the handler callback and letting the callback implementation can determine if stopping propagation is needed or not.

### Related Issues and other PRs:
Issue #1925 


## Reproduction and steps:

### User behaviour needed to reproduce the issue:

https://stackblitz.com/edit/js-paffsu?file=index.html

1. Play the reproduction above
2. Click on the region during playback
3. The region will not be played but the playback will seek to where was clicked