### PR TITLE
Regions plugin: fix switch loop region

### DIFF
--- a/src/plugin/regions.js
+++ b/src/plugin/regions.js
@@ -138,8 +138,14 @@ class Region {
      * @param {number} start Optional offset to start playing at
      * */
     playLoop(start) {
-        this.play(start);
-        this.once('out', () => this.playLoop());
+        const s = start || this.start;
+        this.wavesurfer.play(s);
+        this.once('out', () => {
+            const realTime = this.wavesurfer.getCurrentTime();
+            if (realTime >= this.start && realTime <= this.end) {
+                return this.playLoop();
+            }
+        });
     }
 
     /* Render a region as a DOM element. */


### PR DESCRIPTION
## Short description of changes:

If a region is in loop, try to loop another region at this time, the `out` event will still occur, causing the jump to fail, and will bind multiple events, browser may crash.

In order to solve this problem, I added a judgment in the `playLoop()` function, only looped when the play time was in the current region.

### Breaking in the external API:

None

### Breaking changes in the internal API:

None

## Reproduction and steps:

https://wavesurfer-js.org/example/annotation/index.html

1. Hold down shift and click on a region to start loop.
2. Click any region before the region to reproduce the bug.
