### PR TITLE
When splitting channels, allow coloring and filtering of channels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ wavesurfer.js changelog
 - Added the ability to use a customized regions plugin in the `minimap` plugin through a new parameter
   `regionsPluginName` (#1943)
 - Fixed waveform display to not always connect to the sample=0 point (#1942)
+- Add `splitChannelsOptions` param and `setFilteredChannels` method to configure how channels are drawn (#1947)
 
 3.3.3 (16.04.2020)
 ------------------

--- a/example/split-channels/app.js
+++ b/example/split-channels/app.js
@@ -1,5 +1,6 @@
 // Create an instance
 var wavesurfer;
+var wavesurferWithOptions;
 
 window.onload = function() {
     wavesurfer = WaveSurfer.create({
@@ -56,4 +57,36 @@ window.onload = function() {
     Object.keys(handlers).forEach(function(event) {
         dropTarget.addEventListener(event, handlers[event]);
     });
+
+    // WaveSurfer with options example
+    wavesurferWithOptions = WaveSurfer.create({
+        container: document.querySelector('#waveform-with-options'),
+        splitChannels: true,
+        splitChannelsOptions: {
+            overlay: false,
+            channelColors: {
+                0: {
+                    progressColor: 'green',
+                    waveColor: 'pink'
+                },
+                1: {
+                    progressColor: 'orange',
+                    waveColor: 'purple'
+                }
+            }
+        }
+    });
+
+    wavesurferWithOptions.on('error', function(e) {
+        console.warn(e);
+    });
+
+    // Load audio from URL
+    wavesurferWithOptions.load('../media/stereo.mp3');
+
+    // Play/pause on button press
+    document
+        .getElementById('play-button')
+        .addEventListener('click', wavesurferWithOptions.playPause.bind(wavesurferWithOptions));
+
 };

--- a/example/split-channels/app.js
+++ b/example/split-channels/app.js
@@ -73,7 +73,8 @@ window.onload = function() {
                     progressColor: 'orange',
                     waveColor: 'purple'
                 }
-            }
+            },
+            filterChannels: [],
         }
     });
 

--- a/example/split-channels/index.html
+++ b/example/split-channels/index.html
@@ -123,6 +123,9 @@
             </p>
             <p>
                 <code>channelColors</code> - object - Pass this to set colors for each channel. If the channel index is not found on the object, colors will default to the top level color params.
+            </p>          
+            <p>
+                <code>filterChannels</code> - array - Array of channel numbers. Channels included in the array will not be drawn.
             </p>
 
 

--- a/example/split-channels/index.html
+++ b/example/split-channels/index.html
@@ -75,6 +75,57 @@
 
             </div>
 
+            <div class="row marketing">
+                <h3>Split Channel Options</h3>
+
+                <p>
+                    The split channel view can be modified with the <code>splitChannelsOptions</code>. The waveforms can be stacked on top of each other. And colors can be added to each channel.
+                </p>
+                <div id="demo-with-options">
+                    <div id="waveform-with-options">
+                        <!-- Here be the waveform -->
+                    </div>
+
+                    <div class="controls">
+                        <button id="play-button" class="btn btn-primary">
+                            <i class="glyphicon glyphicon-play"></i>
+                            Play
+                            /
+                            <i class="glyphicon glyphicon-pause"></i>
+                            Pause
+                        </button>
+                    </div>
+                </div>
+                <p>
+<pre><code>var wavesurfer = WaveSurfer.create({
+    container: document.querySelector('#wave'),
+    splitChannels: true,
+    splitChannelsOptions: {
+        overlay: false,
+        channelColors: {
+            0: {
+                progressColor: 'green',
+                waveColor: 'pink'
+            },
+            1: {
+                progressColor: 'orange',
+                waveColor: 'purple'
+            }
+        }
+    }
+});
+</code></pre>
+            </p>
+            </div>
+            <h4>splitChannelOptions</h4>
+            <p>
+                <code>overlay</code> - boolean - This determines whether channels are drawn on top of each  other.
+            </p>
+            <p>
+                <code>channelColors</code> - object - Pass this to set colors for each channel. If the channel index is not found on the object, colors will default to the top level color params.
+            </p>
+
+
             <div class="footer row">
                 <div class="col-sm-12">
                     <a rel="license" href="https://opensource.org/licenses/BSD-3-Clause"><img alt="BSD-3-Clause License" style="border-width:0" src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg" /></a>

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -483,11 +483,12 @@ export default class MultiCanvas extends Drawer {
                     const filteredChannels =  channels.filter((c, i) => !this.hideChannel(i));
                     if (!this.params.splitChannelsOptions.overlay) {
                         this.setHeight(
-                            filteredChannels.length *
+                            Math.max(filteredChannels.length, 1) *
                                 this.params.height *
                                 this.params.pixelRatio
                         );
                     } 
+
                     return channels.forEach((channelPeaks, i) => 
                         this.prepareDraw(channelPeaks, i, start, end, fn, filteredChannels.indexOf(channelPeaks))
                     );                    

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -389,9 +389,9 @@ export default class MultiCanvas extends Drawer {
      * @param {number} offsetY Offset to the top
      * @param {number} start The x-offset of the beginning of the area that
      * should be rendered
-     * @param {number} end The x-offset of the end of the area that
-     * @param {channelIndex} channelIndex The channel index of the line drawn
+     * @param {number} end The x-offset of the end of the area that 
      * should be rendered
+     * @param {channelIndex} channelIndex The channel index of the line drawn
      */
     drawLine(peaks, absmax, halfH, offsetY, start, end, channelIndex) {
        const { waveColor, progressColor } = this.params.splitChannelsOptions.channelColors[channelIndex] || {};
@@ -496,6 +496,7 @@ export default class MultiCanvas extends Drawer {
                 peaks = channels[0];
             }
 
+            // Return and do not draw channel peaks if hidden.
             if (this.hideChannel(channelIndex)) {
                 return;
             }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1174,7 +1174,14 @@ export default class WaveSurfer extends util.Observer {
     }
 
     /**
-     * When splitChannels is true, hides channels from being drawn on the waveform.
+     * Hide channels from being drawn on the waveform if splitting channels.
+     * 
+     * For example, if we want to draw only the peaks for the right stereo channel:
+     *
+     * const wavesurfer = new WaveSurfer.create({...splitChannels: true});
+     * wavesurfer.load('stereo_audio.mp3');
+     * 
+     * wavesurfer.setFilteredChannel([0]); <-- hide left channel peaks.
      *
      * @param {array} channelIndices Channels to be filtered out from drawing.
      */

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1174,6 +1174,16 @@ export default class WaveSurfer extends util.Observer {
     }
 
     /**
+     * When splitChannels is true, hides channels from being drawn on the waveform.
+     *
+     * @param {array} channelIndices Channels to be filtered out from drawing.
+     */
+    setFilteredChannels(channelIndices) {
+        this.params.splitChannelsOptions.filterChannels = channelIndices;
+        this.drawBuffer();
+    }
+
+    /**
      * Get the correct peaks for current wave view-port and render wave
      *
      * @private

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -266,7 +266,8 @@ export default class WaveSurfer extends util.Observer {
         splitChannels: false,
         splitChannelsOptions: {
             overlay: false,
-            channelColors: {}
+            channelColors: {},
+            filterChannels: [],
         },
         waveColor: '#999',
         xhr: {}

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -264,6 +264,10 @@ export default class WaveSurfer extends util.Observer {
         scrollParent: false,
         skipLength: 2,
         splitChannels: false,
+        splitChannelsOptions: {
+            overlay: false,
+            channelColors: {}
+        },
         waveColor: '#999',
         xhr: {}
     };

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1184,6 +1184,7 @@ export default class WaveSurfer extends util.Observer {
      * wavesurfer.setFilteredChannel([0]); <-- hide left channel peaks.
      *
      * @param {array} channelIndices Channels to be filtered out from drawing.
+     * @version 4.0.0
      */
     setFilteredChannels(channelIndices) {
         this.params.splitChannelsOptions.filterChannels = channelIndices;


### PR DESCRIPTION
Our project would like to allow the user to filter out channels from the audio for playing/viewing. The filtering for playing will be done via setFilters. This pr is to add the rest via a new parameter **splitChannelsOptions** and a new method **setFilteredChannels**.

## Short description of changes:
1) Add splitChannelsOptions parameter that applies if splitChannels is true.
Contains the following options:
overlay - draws channels on over each other when splitting
channelColors - defines colors for channels individually
filteredChannels - channel indices to filter (do not draw on the waveform)

2) Add setFilteredChannels method to update the filteredChannels param.

3) Update split channels example to include info on the above.

### Breaking in the external API:
none

### Breaking changes in the internal API:
none

### Todos/Notes:
The splitChannelsOptions currently only works with drawWave.

### Related Issues and other PRs:
coloring:
https://github.com/katspaugh/wavesurfer.js/pull/1889

