### PR TITLE
regions plugin: ability to specify time format using timeformatCallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ wavesurfer.js changelog
 - Added the ability to use a customized regions plugin in the `minimap` plugin through a new parameter
   `regionsPluginName` (#1943)
 - Fixed waveform display to not always connect to the sample=0 point (#1942)
+- Added ability to specify time format for Regions tooltip using timeformatCallback (#1948)
 
 3.3.3 (16.04.2020)
 ------------------

--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -12,6 +12,7 @@
  * @property {?boolean} deferInit Set to true to manually call
  * @property {number[]} maxRegions Maximum number of regions that may be created by the user at one time.
  * `initPlugin('regions')`
+ * @property {function} formatTimeCallback Allows custom formating for region tooltip.
  */
 
 /**

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -70,6 +70,8 @@ export class Region {
                 this.marginTop = this.wavesurfer.getHeight() * channelIdx + 'px';
             }
         }
+        
+        this.formatTimeCallback = params.formatTimeCallback;
 
         this.bindInOut();
         this.render();
@@ -231,6 +233,9 @@ export class Region {
     }
 
     formatTime(start, end) {
+        if (this.formatTimeCallback) {
+            return this.formatTimeCallback(start, end);
+        }
         return (start == end ? [start] : [start, end])
             .map(time =>
                 [


### PR DESCRIPTION
Adds timeformatCallback functionality to Regions

fixes #1948 