### PR TITLE
minimap plugin: added check for drawer presence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@ wavesurfer.js changelog
   - Fixed switch loop region (#1929)
   - Added ability to specify time format for Regions tooltip using timeformatCallback (#1948)
 - Add `splitChannelsOptions` param and `setFilteredChannels` method to configure how channels are drawn (#1947)
-- Added checks in `minimap` plugin for `drawer` presence
+- Added checks in `minimap` plugin for `drawer` presence (#1953)
 
 3.3.3 (16.04.2020)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ wavesurfer.js changelog
   - Fixed switch loop region (#1929)
   - Added ability to specify time format for Regions tooltip using timeformatCallback (#1948)
 - Add `splitChannelsOptions` param and `setFilteredChannels` method to configure how channels are drawn (#1947)
+- Added checks in `minimap` plugin for `drawer` presence
 
 3.3.3 (16.04.2020)
 ------------------

--- a/src/plugin/minimap.js
+++ b/src/plugin/minimap.js
@@ -197,17 +197,17 @@ export default class MinimapPlugin {
 
         this.wavesurfer.on('region-created', region => {
             this.regions[region.id] = region;
-            this.renderRegions();
+            this.drawer.wrapper && this.renderRegions();
         });
 
         this.wavesurfer.on('region-updated', region => {
             this.regions[region.id] = region;
-            this.renderRegions();
+            this.drawer.wrapper && this.renderRegions();
         });
 
         this.wavesurfer.on('region-removed', region => {
             delete this.regions[region.id];
-            this.renderRegions();
+            this.drawer.wrapper && this.renderRegions();
         });
     }
 


### PR DESCRIPTION
### Short description of changes:
Since `minimap` and `regions` plugin are related when the `showRegions` option is setted to `true`, there may be errors when one plugin is destroyed before the other. In particular, when the `minimap` plugin cannot find the `drawer` of regions. So the error which occurs is this:

![image](https://user-images.githubusercontent.com/44341274/82753326-ff43b680-9dc4-11ea-9975-3de97f0554e2.png)

### Breaking changes in the internal API:
Check il the `drawer.wrapper` exists before rendering regions.
