### PR TITLE
spectrogram plugin: perform null check when removing scroll listener

### DIFF
--- a/src/plugin/spectrogram.js
+++ b/src/plugin/spectrogram.js
@@ -364,7 +364,7 @@ export default class SpectrogramPlugin {
         this.unAll();
         this.wavesurfer.un('ready', this._onReady);
         this.wavesurfer.un('redraw', this._onRender);
-        this.drawer ? this.drawer.wrapper.removeEventListener('scroll', this._onScroll);
+        this.drawer && this.drawer.wrapper.removeEventListener('scroll', this._onScroll);
         this.wavesurfer = null;
         this.util = null;
         this.params = null;

--- a/src/plugin/spectrogram.js
+++ b/src/plugin/spectrogram.js
@@ -364,7 +364,7 @@ export default class SpectrogramPlugin {
         this.unAll();
         this.wavesurfer.un('ready', this._onReady);
         this.wavesurfer.un('redraw', this._onRender);
-        this.drawer.wrapper.removeEventListener('scroll', this._onScroll);
+        this.drawer ? this.drawer.wrapper.removeEventListener('scroll', this._onScroll);
         this.wavesurfer = null;
         this.util = null;
         this.params = null;


### PR DESCRIPTION
### Short description of changes:
It turns out, if the parent WaveSurfer instance is not ready by the time `destroy()` is called, this line will throw an error.

Reason being https://github.com/katspaugh/wavesurfer.js/blob/master/src/plugin/spectrogram.js#L306 shows `this.drawer` is only assigned when `this._onReady` is called.

### Breaking in the external API:
None

### Breaking changes in the internal API:
None

### Todos/Notes:


### Related Issues and other PRs:
