### PR TITLE
Add option to seekTo method to allow diabling event emissions

### DIFF
--- a/spec/wavesurfer.spec.js
+++ b/spec/wavesurfer.spec.js
@@ -357,6 +357,46 @@ describe('WaveSurfer/playback:', function() {
         });
         wavesurfer.destroy();
     });
+
+    describe('seekTo: event emission', () => {
+        let interactionEventSpy;
+        let seekEventSpy;
+
+        beforeEach(function() {
+            interactionEventSpy = jasmine.createSpy();
+            seekEventSpy = jasmine.createSpy();
+
+            wavesurfer.on('interaction', () => {
+                interactionEventSpy();
+            });
+            wavesurfer.on('seek', () => {
+                seekEventSpy();
+            });
+        });
+
+        describe('when emitEvents is not passed', () => {
+            it('defaults to emitting events', () => {
+                wavesurfer.seekTo(0.5);
+
+                expect(interactionEventSpy).toHaveBeenCalled();
+                expect(seekEventSpy).toHaveBeenCalled();
+            });
+        });
+
+        describe('when emitEvents is false', () => {
+            it('should not emit an interaction event', () => {
+                wavesurfer.seekTo(0.5, false);
+
+                expect(interactionEventSpy).not.toHaveBeenCalled();
+            });
+
+            it('should not emit a seek event', () => {
+                wavesurfer.seekTo(0.5, false);
+
+                expect(seekEventSpy).not.toHaveBeenCalled();
+            });
+        });
+    });
 });
 
 /** @test {WaveSurfer} */

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -880,13 +880,14 @@ export default class WaveSurfer extends util.Observer {
      * Seeks to a position
      *
      * @param {number} progress Between 0 (=beginning) and 1 (=end)
+     * @param {boolean} emitEvents Whether or not to emit events for this invocation
      * @emits WaveSurfer#interaction
      * @emits WaveSurfer#seek
      * @example
      * // seek to the middle of the audio
      * wavesurfer.seekTo(0.5);
      */
-    seekTo(progress) {
+    seekTo(progress, emitEvents = true) {
         // return an error if progress is not a number between 0 and 1
         if (
             typeof progress !== 'number' ||
@@ -898,7 +899,7 @@ export default class WaveSurfer extends util.Observer {
                 'Error calling wavesurfer.seekTo, parameter must be a number between 0 and 1!'
             );
         }
-        this.fireEvent('interaction', () => this.seekTo(progress));
+        if (emitEvents) { this.fireEvent('interaction', () => this.seekTo(progress)); }
 
         const paused = this.backend.isPaused();
         // avoid draw wrong position while playing backward seeking
@@ -915,7 +916,7 @@ export default class WaveSurfer extends util.Observer {
             this.backend.play();
         }
         this.params.scrollParent = oldScrollParent;
-        this.fireEvent('seek', progress);
+        if (emitEvents) { this.fireEvent('seek', progress); }
     }
 
     /**


### PR DESCRIPTION
### Short description of changes:

Trying to update the playhead position in a `seek` event handler cause a recursive loop. This is because `seekTo` and most methods I'd use to do this (methods like `seekAndCenter`, `stop`, etc... also seem to use `seekTo` under the hood), also emits a `seek` event.

Background: I ran into this problem when I was trying to synchronize the playhead for multiple waveform instances.

### Breaking in the external API:

No breaking changes. I only added an optional parameter to `seekTo` called `emitEvents` that defaults to true (which was the behavior before this change)

### Breaking changes in the internal API:

None

### Related Issues and other PRs:

Coordinating multiple waveforms at once: https://github.com/katspaugh/wavesurfer.js/issues/1672