### PR TITLE
Drawer: removed private methods 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ wavesurfer.js changelog
 - Add `splitChannelsOptions` param and `setFilteredChannels` method to configure how channels are drawn (#1947)
 - Added checks in `minimap` plugin for `drawer` presence (#1953)
 - Add `setDisabledEventEmissions` method to optionally disable calls to event handlers for specific events (#1960)
+- Drawer: removed private methods to allow inheriting them (#1962)
 
 3.3.3 (16.04.2020)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ wavesurfer.js changelog
 - Add `splitChannelsOptions` param and `setFilteredChannels` method to configure how channels are drawn (#1947)
 - Added checks in `minimap` plugin for `drawer` presence (#1953)
 - Add `setDisabledEventEmissions` method to optionally disable calls to event handlers for specific events (#1960)
-- Drawer: removed private methods to allow inheriting them (#1962)
+- Drawer: removed private methods to allow overriding them (#1962)
 
 3.3.3 (16.04.2020)
 ------------------

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -42,14 +42,12 @@ export default class CanvasEntry {
          * Start of the area the canvas should render, between 0 and 1
          *
          * @type {number}
-         * @private
          */
         this.start = 0;
         /**
          * End of the area the canvas should render, between 0 and 1
          *
          * @type {number}
-         * @private
          */
         this.end = 1;
         /**
@@ -186,7 +184,6 @@ export default class CanvasEntry {
     /**
      * Draw the actual rectangle on a `canvas` element
      *
-     * @private
      * @param {CanvasRenderingContext2D} ctx Rendering context of target canvas
      * @param {number} x X start position
      * @param {number} y Y start position
@@ -209,7 +206,6 @@ export default class CanvasEntry {
     /**
      * Draw a rounded rectangle on Canvas
      *
-     * @private
      * @param {CanvasRenderingContext2D} ctx Canvas context
      * @param {number} x X-position of the rectangle
      * @param {number} y Y-position of the rectangle
@@ -288,7 +284,6 @@ export default class CanvasEntry {
     /**
      * Render the actual waveform line on a `canvas` element
      *
-     * @private
      * @param {CanvasRenderingContext2D} ctx Rendering context of target canvas
      * @param {number[]} peaks Array with peaks data
      * @param {number} absmax Maximum peak value (absolute)

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -12,11 +12,10 @@ export default class Drawer extends util.Observer {
      */
     constructor(container, params) {
         super();
-        /** @private */
+
         this.container = container;
         /**
          * @type {WavesurferParams}
-         * @private
          */
         this.params = params;
         /**
@@ -29,7 +28,7 @@ export default class Drawer extends util.Observer {
          * @type {number}
          */
         this.height = params.height * this.params.pixelRatio;
-        /** @private */
+
         this.lastPos = 0;
         /**
          * The `<wave>` element which is added to the container
@@ -116,9 +115,6 @@ export default class Drawer extends util.Observer {
         return progress;
     }
 
-    /**
-     * @private
-     */
     setupWrapperEvents() {
         this.wrapper.addEventListener('click', e => {
             const scrollbarHeight =

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -19,12 +19,10 @@ export default class MultiCanvas extends Drawer {
 
         /**
          * @type {number}
-         * @private
          */
         this.maxCanvasWidth = params.maxCanvasWidth;
 
         /**
-         * @private
          * @type {number}
          */
         this.maxCanvasElementWidth = Math.round(
@@ -40,7 +38,6 @@ export default class MultiCanvas extends Drawer {
         this.hasProgressCanvas = params.waveColor != params.progressColor;
 
         /**
-         * @private
          * @type {number}
          */
         this.halfPixel = 0.5 / params.pixelRatio;
@@ -48,13 +45,11 @@ export default class MultiCanvas extends Drawer {
         /**
          * List of `CanvasEntry` instances.
          *
-         * @private
          * @type {Array}
          */
         this.canvases = [];
 
         /**
-         * @private
          * @type {HTMLElement}
          */
         this.progressWave = null;
@@ -62,7 +57,6 @@ export default class MultiCanvas extends Drawer {
         /**
          * Class used to generate entries.
          *
-         * @private
          * @type {function}
          */
         this.EntryClass = CanvasEntry;
@@ -70,7 +64,6 @@ export default class MultiCanvas extends Drawer {
         /**
          * Canvas 2d context attributes.
          *
-         * @private
          * @type {object}
          */
         this.canvasContextAttributes = params.drawingContextAttributes;
@@ -86,7 +79,6 @@ export default class MultiCanvas extends Drawer {
         /**
          * The radius of the wave bars. Makes bars rounded
          *
-         * @private
          * @type {number}
          */
         this.barRadius = params.barRadius || 0;
@@ -103,7 +95,6 @@ export default class MultiCanvas extends Drawer {
     /**
      * Create the canvas elements and style them
      *
-     * @private
      */
     createElements() {
         this.progressWave = this.wrapper.appendChild(
@@ -170,7 +161,6 @@ export default class MultiCanvas extends Drawer {
     /**
      * Add a canvas to the canvas list
      *
-     * @private
      */
     addCanvas() {
         const entry = new this.EntryClass();
@@ -215,7 +205,6 @@ export default class MultiCanvas extends Drawer {
     /**
      * Pop single canvas from the list
      *
-     * @private
      */
     removeCanvas() {
         let lastEntry = this.canvases[this.canvases.length - 1];
@@ -240,7 +229,6 @@ export default class MultiCanvas extends Drawer {
     /**
      * Update the dimensions of a canvas element
      *
-     * @private
      * @param {CanvasEntry} entry Target entry
      * @param {number} width The new width of the element
      * @param {number} height The new height of the element
@@ -382,14 +370,13 @@ export default class MultiCanvas extends Drawer {
     /**
      * Tell the canvas entries to render their portion of the waveform
      *
-     * @private
      * @param {number[]} peaks Peaks data
      * @param {number} absmax Maximum peak value (absolute)
      * @param {number} halfH Half the height of the waveform
      * @param {number} offsetY Offset to the top
      * @param {number} start The x-offset of the beginning of the area that
      * should be rendered
-     * @param {number} end The x-offset of the end of the area that 
+     * @param {number} end The x-offset of the end of the area that
      * should be rendered
      * @param {channelIndex} channelIndex The channel index of the line drawn
      */
@@ -448,7 +435,6 @@ export default class MultiCanvas extends Drawer {
     /**
      * Returns whether to hide the channel from being drawn based on params.
      *
-     * @private
      * @param {number} channelIndex The index of the current channel.
      * @returns {bool} True to hide the channel, false to draw.
      */
@@ -460,7 +446,6 @@ export default class MultiCanvas extends Drawer {
      * Performs preparation tasks and calculations which are shared by `drawBars`
      * and `drawWave`
      *
-     * @private
      * @param {number[]|Number.<Array[]>} peaks Can also be an array of arrays for
      * split channel rendering
      * @param {number} channelIndex The index of the current channel. Normally
@@ -487,11 +472,11 @@ export default class MultiCanvas extends Drawer {
                                 this.params.height *
                                 this.params.pixelRatio
                         );
-                    } 
+                    }
 
-                    return channels.forEach((channelPeaks, i) => 
+                    return channels.forEach((channelPeaks, i) =>
                         this.prepareDraw(channelPeaks, i, start, end, fn, filteredChannels.indexOf(channelPeaks))
-                    );                    
+                    );
                 }
                 peaks = channels[0];
             }
@@ -533,7 +518,6 @@ export default class MultiCanvas extends Drawer {
     /**
      * Set the fill styles for a certain entry (wave and progress)
      *
-     * @private
      * @param {CanvasEntry} entry Target entry
      * @param {string} waveColor Wave color to draw this entry
      * @param {string} progressColor Progress color to draw this entry


### PR DESCRIPTION
### Short description of changes:
Removed private methods from wavesurfer drawer, so a new one can be created, inheriting the existing ones, and overriding only the necessary features.

### Breaking changes in the internal API:
Removed all private clauses from `drawer.js`, `drawer.canvasentry.js` and `drawer.multicanvas.js`.
