### PR TITLE
Fix muting behavior with the MediaElement backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ wavesurfer.js changelog
 - Added checks in `minimap` plugin for `drawer` presence (#1953)
 - Add `setDisabledEventEmissions` method to optionally disable calls to event handlers for specific events (#1960)
 - Drawer: removed private methods to allow overriding them (#1962)
+- Add optional `setMute` method to backends to fix muting behavior with the `MediaElement` backend (#1966)
 
 3.3.3 (16.04.2020)
 ------------------

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -398,6 +398,7 @@ export default class MediaElement extends WebAudio {
     /**
      * Enable or disable muted audio
      *
+     * @since 4.0.0
      * @param {boolean} mute Specify `true` to mute audio.
      */
     setMute(muted) {

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -396,6 +396,17 @@ export default class MediaElement extends WebAudio {
     }
 
     /**
+     * Enable or disable muted audio
+     *
+     * @param {boolean} mute Specify `true` to mute audio.
+     */
+    setMute(muted) {
+      // This causes a volume change to be emitted too through the
+      // volumechange event listener.
+      this.isMuted = this.media.muted = muted;
+    }
+
+    /**
      * This is called when wavesurfer is destroyed
      *
      */

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1013,19 +1013,26 @@ export default class WaveSurfer extends util.Observer {
             return;
         }
 
-        if (mute) {
-            // If currently not muted then save current volume,
-            // turn off the volume and update the mute properties
-            this.savedVolume = this.backend.getVolume();
-            this.backend.setVolume(0);
-            this.isMuted = true;
-            this.fireEvent('volume', 0);
+        if (this.backend.setMute) {
+          // Backends such as the MediaElement backend have their own handling
+          // of mute, let them handle it.
+          this.backend.setMute(mute);
+          this.isMuted = true;
         } else {
-            // If currently muted then restore to the saved volume
-            // and update the mute properties
-            this.backend.setVolume(this.savedVolume);
-            this.isMuted = false;
-            this.fireEvent('volume', this.savedVolume);
+          if (mute) {
+              // If currently not muted then save current volume,
+              // turn off the volume and update the mute properties
+              this.savedVolume = this.backend.getVolume();
+              this.backend.setVolume(0);
+              this.isMuted = true;
+              this.fireEvent('volume', 0);
+          } else {
+              // If currently muted then restore to the saved volume
+              // and update the mute properties
+              this.backend.setVolume(this.savedVolume);
+              this.isMuted = false;
+              this.fireEvent('volume', this.savedVolume);
+          }
         }
         this.fireEvent('mute', this.isMuted);
     }


### PR DESCRIPTION
### Short description of changes:

`wavesurfer.js` currently handles muting the media by setting the backend's volume to 0 and remembering the previous value, **but** it also checks whether the backend maintains muting state and uses it to override its own. This is currently used by the `MediaElement` to make wavesurfer aware of muting/volume changes performed directly on the `Audio` element, but muting through `wavesurfer.js` itself triggers a backend volume change without changing the backend's `isMuted` state, so the end result is the volume switching to 0 and the media being unmuted, leading to inconsistent and erratic behavior.

This PR adds an optional `setMute` method to backends so that the `MediaElement` backend can handle muting by itself.

### Breaking in the external API:

None.

### Breaking changes in the internal API:

None (the `setMute` method is optional so that other backends do not need change—but if we are ok with breaking the internal API by requiring the `setMute` method, we can move the `wavesurfer.js` code to the WebAudio backend).

### Related Issues and other PRs:

I believe the “immediately unmuting” behavior was introduced by #1635. This PR fixes it while still handling external changes to the `Audio` element state.

refs #1931
refs #1703 