### PR TITLE
Fix setMute setting incorrect isMuted

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1017,7 +1017,7 @@ export default class WaveSurfer extends util.Observer {
             // Backends such as the MediaElement backend have their own handling
             // of mute, let them handle it.
             this.backend.setMute(mute);
-            this.isMuted = true;
+            this.isMuted = mute;
         } else {
             if (mute) {
                 // If currently not muted then save current volume,


### PR DESCRIPTION
#1966 incorrectly set wavesurfer object's `isMuted` to `true` even when it's supposed to be `false`.

This is not an issue in practice, as it gets correctly re-set by the `volumechange` handler, but this is wrong anyway, and as a result make the tests fail.