### PR TITLE
guard against null _disabledEventEmissions in Observer#fireEvent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ wavesurfer.js changelog
 4.0.0 (unreleased)
 ------------------
 
+- Fixes for event handling with certain plugins (regions, microphone).
+  The crash would have involved '_disabledEventEmissions'
 - Fixed mediaelement-webaudio playback under Safari (#1964)
 - Fixed the `destroy` method of the `MediaElementWebAudio` backend. Instead of
   destroying only the media element, the audio nodes are disconnected and the

--- a/src/util/observer.js
+++ b/src/util/observer.js
@@ -116,13 +116,22 @@ export default class Observer {
     }
 
     /**
+     * plugins borrow part of this class without calling the constructor,
+     * so we have to be careful about _disabledEventEmissions
+     */
+
+    _isDisabledEventEmission(event) {
+        return this._disabledEventEmissions && this._disabledEventEmissions.includes(event);
+    }
+
+    /**
      * Manually fire an event
      *
      * @param {string} event The event to fire manually
      * @param {...any} args The arguments with which to call the listeners
      */
     fireEvent(event, ...args) {
-        if (!this.handlers || this._disabledEventEmissions.includes(event)) {
+        if (!this.handlers || this._isDisabledEventEmission(event)) {
             return;
         }
 


### PR DESCRIPTION
due to the odd way the RegionsPlugin pulls in the methods in util.Observer, it needs to setup a private array or it crashes in `fireEvent`.

I could also fix this in `Observer` by checking for the existence of the array.  I dunno.  both seem odd.

fixes #1975 
