### PR TITLE
Include properties in Regions instance

### DIFF
--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -123,6 +123,9 @@ export default class RegionsPlugin {
         observerPrototypeKeys.forEach(key => {
             Region.prototype[key] = this.util.Observer.prototype[key];
         });
+        this._disabledEventEmissions = [];
+        this.handlers = [];
+
         this.wavesurfer.Region = Region;
 
         this._onBackendCreated = () => {


### PR DESCRIPTION
Include the _disabledEventEmissions and handlers properties in the Regions class

Notes:
Destroying a wavesurfer instance in version 4.0.0 with the regions plugin active would result in an undefined access to the _disabledEventEmissions property. This is just a small patch to include those properties, but I'm not sure this is the correct fix, feel free to disregard!

Thanks for the great project!

