### PR TITLE
regions plugin: improve loop playback logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,16 @@
 wavesurfer.js changelog
 =======================
 
-4.0.0 (21.06.2020)
+4.0.1 (In progress)
 ------------------
 
 - Fixes for event handling with certain plugins (regions, microphone).
   The crash would have involved '_disabledEventEmissions'
+- Improved and unified loop playback logic in regions plugin. (#1868)
+
+4.0.0 (21.06.2020)
+------------------
+
 - Fixed mediaelement-webaudio playback under Safari (#1964)
 - Fixed the `destroy` method of the `MediaElementWebAudio` backend. Instead of
   destroying only the media element, the audio nodes are disconnected and the

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -149,16 +149,18 @@ export class Region {
      * @param {number} start Optional offset to start playing at
      * */
     playLoop(start) {
-        const s = start || this.start;
-        this.wavesurfer.play(s);
-        this.once('out', () => {
-            const realTime = this.wavesurfer.getCurrentTime();
-            if (realTime >= this.start && realTime <= this.end) {
-                return this.playLoop();
-            }
-        });
+        this.loop = true;
+        this.play(start);
     }
 
+    /**
+     * Set looping on/off.
+     * @param {boolean} loop True if should play in loop
+     */
+    setLoop(loop) {
+        this.loop = loop;
+    }
+    
     /* Render a region as a DOM element. */
     render() {
         const regionEl = document.createElement('region');

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -70,7 +70,7 @@ export class Region {
                 this.marginTop = this.wavesurfer.getHeight() * channelIdx + 'px';
             }
         }
-        
+
         this.formatTimeCallback = params.formatTimeCallback;
 
         this.bindInOut();
@@ -160,7 +160,7 @@ export class Region {
     setLoop(loop) {
         this.loop = loop;
     }
-    
+
     /* Render a region as a DOM element. */
     render() {
         const regionEl = document.createElement('region');
@@ -338,7 +338,10 @@ export class Region {
         /* Loop playback. */
         this.on('out', () => {
             if (this.loop) {
-                this.wavesurfer.play(this.start);
+                const realTime = this.wavesurfer.getCurrentTime();
+                if (realTime >= this.start && realTime <= this.end) {
+                    this.wavesurfer.play(this.start);
+                }
             }
         });
     }


### PR DESCRIPTION
### Short description of changes:

`regions` plugin has doubled loop playback logic.

**First** can be found here, binding `out` event:
```js
    /* Bind audio events. */
    bindInOut() {
        // ...

        /* Loop playback. */
        this.on('out', () => {
            if (this.loop) {
                this.wavesurfer.play(this.start);
            }
        });
    }
```
https://github.com/katspaugh/wavesurfer.js/blob/master/src/plugin/regions/region.js#L336

**Second** is in `playLoop()` method:
```js
    /**
     * Play the audio region in a loop.
     * @param {number} start Optional offset to start playing at
     * */
    playLoop(start) {
        const s = start || this.start;
        this.wavesurfer.play(s);
        this.once('out', () => {
            const realTime = this.wavesurfer.getCurrentTime();
            if (realTime >= this.start && realTime <= this.end) {
                return this.playLoop();
            }
        });
    }
```
https://github.com/katspaugh/wavesurfer.js/blob/master/src/plugin/regions/region.js#L151

**The problem** is that both "loops" cannot be canceled in any way. So instead of doubling the same logics about looping and to allow disabling the loop – I propose to remove logics from `playLoop()` but keep method itself it for BC, **but** depend on `this.loop: boolean` flag to handle looping via `bindInOut()`. This way we can add `setLoop(boolean)` method to control the looping and remove strange logic from `playLoop()` if.

### Breaking in the external API:

No breaking changes.

### Breaking changes in the internal API:

No breaking changes.

### Todos/Notes:

- [ ] Update documentation.

### Related Issues and other PRs:

fixes #1868



EDIT: Removed TODO from example.