### PR TITLE
performance: use clip-path css instead of width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Next (unreleased)
 ------------------
 
 - Use `clip-path` instead of `width` changes in the multicanvcas drawer
-  to avoid layout thrashing.
+  to avoid layout thrashing. (#1983)
 - Improved and unified loop playback logic in regions plugin. (#1868)
 
 4.0.1 (23.06.2020)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 wavesurfer.js changelog
 =======================
 
+Next (unreleased)
+------------------
+
+- Use `clip-path` instead of `width` changes in the multicanvcas drawer
+  to avoid layout thrashing.
+
 4.0.1 (23.06.2020)
 ------------------
 

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -156,6 +156,9 @@ export default class MultiCanvas extends Drawer {
 
             entry.clearWave();
         });
+
+        this.style(this.progressWave, { width: totalWidth + "px" });
+        this.style(this.progressWave, { "clip-path": this.makeInset(totalWidth)});
     }
 
     /**
@@ -555,12 +558,18 @@ export default class MultiCanvas extends Drawer {
         }
     }
 
+    makeInset(rightInset) {
+        return "inset(0px " + rightInset + "px 0px 0px)";
+    }
+
     /**
      * Render the new progress
      *
      * @param {number} position X-offset of progress position in pixels
      */
     updateProgress(position) {
-        this.style(this.progressWave, { width: position + 'px' });
+        let actualWidth = this.width / this.params.pixelRatio;
+
+        this.style(this.progressWave, { "clip-path": this.makeInset(actualWidth - position)});
     }
 }

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -558,8 +558,17 @@ export default class MultiCanvas extends Drawer {
         }
     }
 
+    /**
+     * build a css inset string for masking off portions of the progessWave
+     *
+     * In order to avoid browser layout passes, we leave our progress wave at full width
+     * but mask a portion of it off using the `clip-path` CSS property.
+     *
+     * @param {number} rightInset=number of pixels to clip off the right
+     * @return {string} css
+     */
     makeInset(rightInset) {
-        return "inset(0px " + rightInset + "px 0px 0px)";
+        return `inset(0px ${rightInset}px 0px 0px)`;
     }
 
     /**
@@ -570,6 +579,6 @@ export default class MultiCanvas extends Drawer {
     updateProgress(position) {
         let actualWidth = this.width / this.params.pixelRatio;
 
-        this.style(this.progressWave, { "clip-path": this.makeInset(actualWidth - position)});
+        this.style(this.progressWave, { 'clip-path': this.makeInset(actualWidth - position)});
     }
 }


### PR DESCRIPTION
constantly changing the width of the multi-canvas `progressWave` element triggers a layout pass in the browser.  This doesn't seem to be a huge problem for Chrome, but in Safari on mac it's worth quite a hunk of performance.

This is Safari pre-patch  (I played the whole file on /example/html-init/ for these tests):

<img width="1143" alt="Screen Shot 2020-06-23 at 9 17 18 PM" src="https://user-images.githubusercontent.com/260084/85501213-c18ba680-b599-11ea-86b4-facf4d12b694.png">

Safari post-patch:

<img width="1170" alt="Screen Shot 2020-06-23 at 9 15 15 PM" src="https://user-images.githubusercontent.com/260084/85501238-cd776880-b599-11ea-9943-772ac84d1b88.png">

Chrome seems to jitter more and benefit less, but note the ~10% of rendering that we seem to save:

pre-patch:
<img width="415" alt="Screen Shot 2020-06-23 at 9 28 19 PM" src="https://user-images.githubusercontent.com/260084/85501310-f7308f80-b599-11ea-80d2-11baa51167a1.png">
<img width="448" alt="Screen Shot 2020-06-23 at 9 29 08 PM" src="https://user-images.githubusercontent.com/260084/85501313-f7c92600-b599-11ea-95f2-7380f20433c7.png">

post-patch:
<img width="428" alt="Screen Shot 2020-06-23 at 9 30 35 PM" src="https://user-images.githubusercontent.com/260084/85501296-ee3fbe00-b599-11ea-93ea-711ffc7c2895.png">
<img width="434" alt="Screen Shot 2020-06-23 at 9 31 30 PM" src="https://user-images.githubusercontent.com/260084/85501298-eed85480-b599-11ea-8c37-174d5cf057b2.png">


would love to know if I'm missing anything with the logic here or if other people can run benchmarks and see if this feels like a win.
