### PR TITLE
add a call to drawBuffer in `loadMediaElement`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,13 +4,11 @@ wavesurfer.js changelog
 Next (unreleased)
 -----------------
 
-- Always call drawBuffer when for media-elements when peaks are provided, fixes
-  a missed call uncovered by #1969 (#1990)
 - Use `clip-path` instead of `width` changes in the multicanvcas drawer
   to avoid layout thrashing. (#1983)
 - Improved and unified loop playback logic in regions plugin. (#1868)
 - Don't call HTMLMediaElement#load when given peaks and preload == 'none'.
-  Prevents browsers from pre-fetching audio (#1969)
+  Prevents browsers from pre-fetching audio (#1969, #1990)
 
 4.0.1 (23.06.2020)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ wavesurfer.js changelog
 Next (unreleased)
 -----------------
 
+- Always call drawBuffer when for media-elements when peaks are provided, fixes
+  a missed call uncovered by #1969
 - Use `clip-path` instead of `width` changes in the multicanvcas drawer
   to avoid layout thrashing. (#1983)
 - Improved and unified loop playback logic in regions plugin. (#1868)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Next (unreleased)
 -----------------
 
 - Always call drawBuffer when for media-elements when peaks are provided, fixes
-  a missed call uncovered by #1969
+  a missed call uncovered by #1969 (#1990)
 - Use `clip-path` instead of `width` changes in the multicanvcas drawer
   to avoid layout thrashing. (#1983)
 - Improved and unified loop playback logic in regions plugin. (#1868)

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1464,9 +1464,9 @@ export default class WaveSurfer extends util.Observer {
             this.drawBuffer();
         }
 
-        // If no pre-decoded peaks provided or pre-decoded peaks are
-        // provided with forceDecode flag, attempt to download the
-        // audio file and decode it with Web Audio.
+        // If no pre-decoded peaks are provided, or are provided with
+        // forceDecode flag, attempt to download the audio file and decode it
+        // with Web Audio.
         if (
             (!peaks || this.params.forceDecode) &&
             this.backend.supportsWebAudio()

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1459,13 +1459,14 @@ export default class WaveSurfer extends util.Observer {
             this.backend.once('error', err => this.fireEvent('error', err))
         );
 
+        if (peaks) {
+            this.backend.setPeaks(peaks, duration);
+            this.drawBuffer();
+        }
+
         // If no pre-decoded peaks provided or pre-decoded peaks are
         // provided with forceDecode flag, attempt to download the
         // audio file and decode it with Web Audio.
-        if (peaks) {
-            this.backend.setPeaks(peaks, duration);
-        }
-
         if (
             (!peaks || this.params.forceDecode) &&
             this.backend.supportsWebAudio()


### PR DESCRIPTION
PR #1969 removed the call to MediaElement#load, but this means that we weren't properly triggering the waveform to render in the case where peaks were provided.

