### PR TITLE
Revert "performance: use clip-path css instead of width (#1983)"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,6 @@ wavesurfer.js changelog
 Next (unreleased)
 -----------------
 
-- Use `clip-path` instead of `width` changes in the multicanvcas drawer
-  to avoid layout thrashing. (#1983)
 - Don't call HTMLMediaElement#load when given peaks and preload == 'none'.
   Prevents browsers from pre-fetching audio (#1969)
 - Regions plugin:

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -156,9 +156,6 @@ export default class MultiCanvas extends Drawer {
 
             entry.clearWave();
         });
-
-        this.style(this.progressWave, { width: totalWidth + "px" });
-        this.style(this.progressWave, { "clip-path": this.makeInset(totalWidth)});
     }
 
     /**
@@ -559,26 +556,11 @@ export default class MultiCanvas extends Drawer {
     }
 
     /**
-     * build a css inset string for masking off portions of the progessWave
-     *
-     * In order to avoid browser layout passes, we leave our progress wave at full width
-     * but mask a portion of it off using the `clip-path` CSS property.
-     *
-     * @param {number} rightInset=number of pixels to clip off the right
-     * @return {string} css
-     */
-    makeInset(rightInset) {
-        return `inset(0px ${rightInset}px 0px 0px)`;
-    }
-
-    /**
      * Render the new progress
      *
      * @param {number} position X-offset of progress position in pixels
      */
     updateProgress(position) {
-        let actualWidth = this.width / this.params.pixelRatio;
-
-        this.style(this.progressWave, { 'clip-path': this.makeInset(actualWidth - position)});
+        this.style(this.progressWave, { width: position + 'px' });
     }
 }


### PR DESCRIPTION
this killed off the cursor functionality.  we're using the right-hand-border of the progressWave to show a "audio cursor" element.

It's a pity, it was worth some nice performance in safari.  I poked at doing a `canvas` based cursor but didn't get very far.

fixes #1992 