### PR TITLE
regions plugin: fix region ignoring minLength when being resized

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Next (unreleased)
 - Regions plugin:
   - Removed 'col-resize' cursor when resize is disabled (#1985)
   - Improved and unified loop playback logic (#1868)
+  - Check `minLength` before resizing region (#2001)
 - Microphone plugin: move to separate directory (#1997)
 - Minimap plugin: move plugin to separate directory (#1999)
 - Cursor plugin: move plugin to separate directory (#1998)

--- a/example/regions/app.js
+++ b/example/regions/app.js
@@ -24,7 +24,8 @@ document.addEventListener('DOMContentLoaded', function() {
                         start: 5,
                         end: 7,
                         loop: false,
-                        color: 'hsla(200, 50%, 70%, 0.4)'
+                        color: 'hsla(200, 50%, 70%, 0.4)',
+                        minLength: 1,
                     }
                 ],
                 dragSelection: {

--- a/example/regions/index.html
+++ b/example/regions/index.html
@@ -83,7 +83,8 @@
                     start: 5,
                     end: 7,
                     loop: false,
-                    color: 'hsla(200, 50%, 70%, 0.4)'
+                    color: 'hsla(200, 50%, 70%, 0.4)',
+                    minLength: 1,
                 }
             ],
             dragSelection: {

--- a/example/regions/index.html
+++ b/example/regions/index.html
@@ -29,6 +29,13 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/default.min.css">
         <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/highlight.min.js"></script>
         <script>hljs.initHighlightingOnLoad();</script>
+
+        <!-- Fix strange default css that makes handles hard to grab when the region is small -->
+        <style>
+            .wavesurfer-region > handle {
+                width: 2px !important;
+            }
+        </style>
     </head>
 
     <body itemscope itemtype="http://schema.org/WebApplication">

--- a/example/regions/index.html
+++ b/example/regions/index.html
@@ -29,13 +29,6 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/default.min.css">
         <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/highlight.min.js"></script>
         <script>hljs.initHighlightingOnLoad();</script>
-
-        <!-- Fix strange default css that makes handles hard to grab when the region is small -->
-        <style>
-            .wavesurfer-region > handle {
-                width: 2px !important;
-            }
-        </style>
     </head>
 
     <body itemscope itemtype="http://schema.org/WebApplication">

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -606,13 +606,33 @@ export class Region {
         });
     }
 
+    /**
+     * @example
+     * onResize(-5, 'start') // Moves the start point 5 seconds back
+     * onResize(0.5, 'end') // Moves the end point 0.5 seconds forward
+     *
+     * @param {number} delta How much to add or subtract, given in seconds
+     * @param {string} direction 'start 'or 'end'
+     */
     onResize(delta, direction) {
         if (direction === 'start') {
+            // Check if changing the start by the given delta would result in the region being smaller than minLength
+            // Ignore cases where we are making the region wider rather than shrinking it
+            if (delta > 0 && Math.abs(this.end - (this.start + delta) < this.minLength)) {
+                return;
+            }
+
             this.update({
                 start: Math.min(this.start + delta, this.end),
                 end: Math.max(this.start + delta, this.end)
             });
         } else {
+            // Check if changing the end by the given delta would result in the region being smaller than minLength
+            // Ignore cases where we are making the region wider rather than shrinking it
+            if (delta < 0 && Math.abs((this.end + delta) - this.start) < this.minLength) {
+                return;
+            }
+
             this.update({
                 start: Math.min(this.end + delta, this.start),
                 end: Math.max(this.end + delta, this.start)

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -617,7 +617,7 @@ export class Region {
         if (direction === 'start') {
             // Check if changing the start by the given delta would result in the region being smaller than minLength
             // Ignore cases where we are making the region wider rather than shrinking it
-            if (delta > 0 && Math.abs(this.end - (this.start + delta) < this.minLength)) {
+            if (delta > 0 && this.end - (this.start + delta) < this.minLength) {
                 return;
             }
 
@@ -628,7 +628,7 @@ export class Region {
         } else {
             // Check if changing the end by the given delta would result in the region being smaller than minLength
             // Ignore cases where we are making the region wider rather than shrinking it
-            if (delta < 0 && Math.abs((this.end + delta) - this.start) < this.minLength) {
+            if (delta < 0 && (this.end + delta) - this.start < this.minLength) {
                 return;
             }
 

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -203,8 +203,7 @@ export class Region {
                 cursor: 'col-resize',
                 position: 'absolute',
                 top: '0px',
-                width: '1%',
-                maxWidth: '4px',
+                width: '2px',
                 height: '100%',
                 backgroundColor: 'rgba(0, 0, 0, 1)'
             };


### PR DESCRIPTION
### Short description of changes:

- Fix region onResize code not checking minLength, which allowed you to "push" regions while dragging them past the point where they should stop shrinking. See related issue for better description.
- Fix handles CSS in region example. They were set to width: 1% which made them scale with the size of the region, and they became invisible when the region was small enough. Now they're always 2px.


### Breaking in the external API:
None

### Breaking changes in the internal API:
None

### Todos/Notes:
The resizing behaviour in general could do with some improvements. For example I don't think you should be able to drag regions to size 0, because then you can't grab them again and you lose them. Maybe regions could have a default minLength: 0.1 or so.

Other possible future enhancements:
- minLength is not documented in the example page.
- minLength/maxLength don't seem to be used a lot in the code, maybe they were never fully implemented?
- Resizing delta is calculated by checking difference between current and last mouse position. It would be better if you could only resize the region when your mouse was near the handle (maybe calculate delta as handle position change)
- Other functions which affect region size should probably check minLength, not just onResize


### Related Issues and other PRs:
fixes #2001