### PR TITLE
renamed requestHeaders to headers in util.fetchFile()

### DIFF
--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -125,9 +125,9 @@ export default function fetchFile(options) {
     instance.controller = new AbortController();
 
     // check if headers have to be added
-    if (options && options.requestHeaders) {
+    if (options && options.headers) {
         // add custom request headers
-        options.requestHeaders.forEach(header => {
+        options.headers.forEach(header => {
             fetchHeaders.append(header.key, header.value);
         });
     }


### PR DESCRIPTION
### Short description of changes: Renaming requestHeaders to headers as named in options 

### Related Issue: https://github.com/katspaugh/wavesurfer.js/issues/2025
