### PR TITLE
fix: missing headers

### DIFF
--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -129,6 +129,7 @@ export default function fetchFile(options) {
         // add custom request headers
         options.requestHeaders.forEach(header => {
             fetchHeaders.append(header.key, header.value);
+            fetchRequest.headers.append(header.key, header.value);
         });
     }
 


### PR DESCRIPTION
**Title:** XHR headers not sent (on Chrome 86)

## Please make sure you provide the information below:
Provided headers through config were not sent with request

### Short description of changes:
Headers are now also appended to `fetchRequest.headers`

### Breaking in the external API:
none

### Breaking changes in the internal API:
none

### Todos/Notes:
If `fetchOptions.headers` are not working, maybe they should be removed?
Left them as not sure if this will break any other functionality if it was working on older browsers.

### Related Issues and other PRs:
Closes #2025 
