### PR TITLE
Code cleanup for Observer class

### DIFF
--- a/src/util/observer.js
+++ b/src/util/observer.js
@@ -15,11 +15,13 @@ export default class Observer {
     constructor() {
         /**
          * @private
-         * @todo Initialise the handlers here already and remove the conditional
-         * assignment in `on()`
          */
         this._disabledEventEmissions = [];
-        this.handlers = null;
+
+        /**
+         * @type {Object.<string, ListenerDescriptor[]>} Map of event name to array of handler functions
+         */
+        this.handlers = {};
     }
     /**
      * Attach a handler function for an event.
@@ -29,10 +31,6 @@ export default class Observer {
      * @return {ListenerDescriptor} The event descriptor
      */
     on(event, fn) {
-        if (!this.handlers) {
-            this.handlers = {};
-        }
-
         let handlers = this.handlers[event];
         if (!handlers) {
             handlers = this.handlers[event] = [];
@@ -55,10 +53,6 @@ export default class Observer {
      * @param {function} fn The callback that should be removed
      */
     un(event, fn) {
-        if (!this.handlers) {
-            return;
-        }
-
         const handlers = this.handlers[event];
         let i;
         if (handlers) {
@@ -131,7 +125,7 @@ export default class Observer {
      * @param {...any} args The arguments with which to call the listeners
      */
     fireEvent(event, ...args) {
-        if (!this.handlers || this._isDisabledEventEmission(event)) {
+        if (this._isDisabledEventEmission(event)) {
             return;
         }
 

--- a/src/util/observer.js
+++ b/src/util/observer.js
@@ -14,15 +14,17 @@ export default class Observer {
      */
     constructor() {
         /**
+         * @type {string[]}
          * @private
          */
         this._disabledEventEmissions = [];
 
         /**
-         * @type {Object.<string, ListenerDescriptor[]>} Map of event name to array of handler functions
+         * @type {Object.<string, Function[]>} Map of event name to array of handler functions
          */
         this.handlers = {};
     }
+
     /**
      * Attach a handler function for an event.
      *
@@ -54,11 +56,10 @@ export default class Observer {
      */
     un(event, fn) {
         const handlers = this.handlers[event];
-        let i;
         if (handlers) {
             if (fn) {
-                for (i = handlers.length - 1; i >= 0; i--) {
-                    if (handlers[i] == fn) {
+                for (let i = handlers.length - 1; i >= 0; i--) {
+                    if (handlers[i] === fn) {
                         handlers.splice(i, 1);
                     }
                 }
@@ -88,9 +89,7 @@ export default class Observer {
             /*  eslint-disable no-invalid-this */
             handler.apply(this, args);
             /*  eslint-enable no-invalid-this */
-            setTimeout(() => {
-                this.un(event, fn);
-            }, 0);
+            setTimeout(() => this.un(event, fn), 0);
         };
         return this.on(event, fn);
     }
@@ -130,9 +129,6 @@ export default class Observer {
         }
 
         const handlers = this.handlers[event];
-        handlers &&
-            handlers.forEach(fn => {
-                fn(...args);
-            });
+        handlers && handlers.forEach(fn => fn(...args));
     }
 }

--- a/src/util/observer.js
+++ b/src/util/observer.js
@@ -72,7 +72,7 @@ export default class Observer {
      * Remove all event handlers.
      */
     unAll() {
-        this.handlers = null;
+        this.handlers = {};
     }
 
     /**


### PR DESCRIPTION
Complete a todo note: initialize Observer handlers in constructor and remove checks in `un` and `on` methods, this.handlers can never be null anymore.

Also clean up a little bit (=== instead of ==, jsdoc and shorter arrow functions)