### PR TITLE
Fix performance issues with seeking while audio is playing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 wavesurfer.js changelog
 =======================
 
+Next (unreleased)
+-----------------
+
+- Fix performance issues with `seekTo` while audio is playing (#2045)
+
 4.1.1 (24.09.2020)
 ------------------
 - Revert Code cleanup for Observer class (#2069)

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -900,20 +900,12 @@ export default class WaveSurfer extends util.Observer {
         }
         this.fireEvent('interaction', () => this.seekTo(progress));
 
-        const paused = this.backend.isPaused();
-        // avoid draw wrong position while playing backward seeking
-        if (!paused) {
-            this.backend.pause();
-        }
         // avoid small scrolls while paused seeking
         const oldScrollParent = this.params.scrollParent;
         this.params.scrollParent = false;
         this.backend.seekTo(progress * this.getDuration());
         this.drawer.progress(progress);
 
-        if (!paused) {
-            this.backend.play();
-        }
         this.params.scrollParent = oldScrollParent;
         this.fireEvent('seek', progress);
     }


### PR DESCRIPTION
When making calls to the `seekTo` method while the audio is playing, we were experiencing a issues with console errors and performance (to the point of the UI becoming completely unresponsive in the case of high-frequency seeking) because of unnecessary calls to `start` and `pause` inside that method.

Making the `seekTo` method `async` and awaiting the calls to `pause` and `start` inside solved the errors and the performance hit for low-frequency seeks (less than ~3 seeks per second) but wasn't good enough for higher-frequency seeking due to too much delay to resolve the promises.

We finally decided to remove those calls altogether, because they appear to be redundant. They were first introduced in #918, and supposedly solved an issue with backward seeking on `MediaElement`, which I wasn't able to replicate (tested with a 30 min long .ogg file).