### PR TITLE
Fix for unhandled AbortError thrown during cancelAjax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Next (unreleased)
 - Timeline plugin: move to separate directory (#2018)
 - Remove `util.ajax`: deprecated since v3.0.0 (#2033)
 - seekTo bugfix inc. basic unit tests (#2047)
+- Fix unhandled AbortError thrown during cancelAjax (#2063)
 
 4.0.1 (23.06.2020)
 ------------------

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1632,6 +1632,14 @@ export default class WaveSurfer extends util.Observer {
      */
     cancelAjax() {
         if (this.currentRequest && this.currentRequest.controller) {
+            // If the current request has a ProgressHandler, then its ReadableStream might need to be cancelled too
+            // See: Wavesurfer issue #2042
+            // See Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1583815
+            if (this.currentRequest._reader) {
+                // Ignoring exceptions thrown by call to cancel()
+                this.currentRequest._reader.cancel().catch(err => {});
+            }
+
             this.currentRequest.controller.abort();
             this.currentRequest = null;
         }


### PR DESCRIPTION
# Short description of changes:
Cancel the current ajax request's ReadableStream during wavesurfer destroy to prevent unhandled AbortError (which was breaking tests).

Firefox only bug?


### Related Issues and other PRs:
Closes #2042