### PR TITLE
RFC: defer script node creation until play time

### DIFF
--- a/src/mediaelement-webaudio.js
+++ b/src/mediaelement-webaudio.js
@@ -30,7 +30,6 @@ export default class MediaElementWebAudio extends MediaElement {
         this.setPlaybackRate(this.params.audioRate);
         this.createTimer();
         this.createVolumeNode();
-        this.createScriptNode();
         this.createAnalyserNode();
     }
     /**

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -21,6 +21,7 @@ export default class WebAudio extends util.Observer {
     stateBehaviors = {
         [PLAYING]: {
             init() {
+                this.createScriptNode();
                 this.addOnAudioProcess();
             },
             getPlayedPercents() {
@@ -156,7 +157,6 @@ export default class WebAudio extends util.Observer {
      */
     init() {
         this.createVolumeNode();
-        this.createScriptNode();
         this.createAnalyserNode();
 
         this.setState(PAUSED);
@@ -227,6 +227,9 @@ export default class WebAudio extends util.Observer {
     }
     /** Create ScriptProcessorNode to process audio */
     createScriptNode() {
+        if ( this.scriptNode )
+            return;
+
         if (this.params.audioScriptProcessor) {
             this.scriptNode = this.params.audioScriptProcessor;
         } else {


### PR DESCRIPTION
hey folks,

I've been try to trace down a weird issue where my webpage is using 50% of a cpu core when the webpage is entirely idle.  The webpage has many, many (idle) instances of wavesurfer present.

I dove all the way down to the bottom and found that chrome begins to chew CPU as soon as the `AudioScriptNode` is instantiated.  With this change, an idle webpage with 50 or so wavesurfer instances sits at around 7% cpu as opposed to about 16-22%.  It seems that the very act of creating a webaudio context at all incurs some cpu time.

Now, this is technically a breaking change as users who rely on the script node may be in for an unwelcome surprise.  We *technically* don't expose the interface, but hey, it's javascript, reach down into whatever you like.

thoughts?  I can also work around this issue by simply defering wavesurfer initialization until play-time entirely, but I thought it'd be nice to try to fix it the core.

Perhaps better would be to lazy-instantiate the node using `Object.defineProperty`?  dunno.
