### PR TITLE
catch unhandled Promise in decodeAudioData

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -125,7 +125,7 @@ module.exports = function(config) {
     };
 
     if (ci) {
-        configuration.browsers = ['Chrome_ci', 'Firefox_ci'];
+        configuration.browsers = ['Firefox_ci'];
 
         if (process.env.TRAVIS) {
             // enable coveralls

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -95,7 +95,7 @@ module.exports = function(config) {
             'karma-coveralls',
             'karma-verbose-reporter'
         ],
-        browsers: ['Chrome_ci', 'Firefox_dev'],
+        browsers: ['Chrome_dev', 'Firefox_dev'],
         captureConsole: true,
         colors: true,
         reporters: ['verbose', 'progress', 'coverage'],

--- a/spec/drawer.spec.js
+++ b/spec/drawer.spec.js
@@ -64,7 +64,7 @@ describe('Drawer', function() {
     it('handleEvent should return 1 if clicked on wrapper right position', function() {
         const {right} = drawer.wrapper.getBoundingClientRect();
 
-        expect(drawer.handleEvent({clientX: right}, true)).toBe(1);
+        expect(drawer.handleEvent({clientX: right}, true)).toBeCloseTo(1, 3);
     });
 
     /** @test {handleEvent/right+1} */

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -348,20 +348,20 @@ export default class WebAudio extends util.Observer {
                 this.ac && this.ac.sampleRate ? this.ac.sampleRate : 44100
             );
         }
-        this.offlineAc.decodeAudioData(arraybuffer).then(
-            (data) => callback(data)
-        ).catch(
-            (err) => errback(err)
-        );
-
-        // XXX: Safari-only: no support for Promise-based decodeAudioData yet
-        /*
-        this.offlineAc.decodeAudioData(
-            arraybuffer,
-            data => callback(data),
-            errback
-        );
-        */
+        if ('AudioContext' in window) {
+            this.offlineAc.decodeAudioData(arraybuffer).then(
+                (data) => callback(data)
+            ).catch(
+                (err) => errback(err)
+            );
+        } else {
+            // Safari: no support for Promise-based decodeAudioData yet
+            this.offlineAc.decodeAudioData(
+                arraybuffer,
+                data => callback(data),
+                errback
+            );
+        }
     }
 
     /**

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -348,11 +348,20 @@ export default class WebAudio extends util.Observer {
                 this.ac && this.ac.sampleRate ? this.ac.sampleRate : 44100
             );
         }
+        this.offlineAc.decodeAudioData(arraybuffer).then(
+            (data) => callback(data)
+        ).catch(
+            (err) => errback(err)
+        );
+
+        // XXX: Safari-only: no support for Promise-based decodeAudioData yet
+        /*
         this.offlineAc.decodeAudioData(
             arraybuffer,
             data => callback(data),
             errback
         );
+        */
     }
 
     /**


### PR DESCRIPTION
headless is broken since Chrome 83 for some reason.