### PR TITLE
[setPlaybackRate] Webaudio backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ wavesurfer.js changelog
 ------------------
 
 - Add `relativeNormalization` option to maintain proportionality between waveforms when `splitChannels` and `normalize` are `true` (#2108)
+- WebAudio backend: set playback rate modifying directly the playback property of the source node (#2118)
 
 4.2.0 (20.10.2020)
 ------------------

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -576,10 +576,7 @@ export default class WebAudio extends util.Observer {
         this.source.start = this.source.start || this.source.noteGrainOn;
         this.source.stop = this.source.stop || this.source.noteOff;
 
-        this.source.playbackRate.setValueAtTime(
-            this.playbackRate,
-            this.ac.currentTime
-        );
+        this.setPlaybackRate(this.playbackRate);
         this.source.buffer = this.buffer;
         this.source.connect(this.analyser);
     }
@@ -736,14 +733,11 @@ export default class WebAudio extends util.Observer {
      * @param {number} value The playback rate to use
      */
     setPlaybackRate(value) {
-        value = value || 1;
-        if (this.isPaused()) {
-            this.playbackRate = value;
-        } else {
-            this.pause();
-            this.playbackRate = value;
-            this.play();
-        }
+        this.playbackRate = value || 1;
+        this.source.playbackRate.setValueAtTime(
+            this.playbackRate,
+            this.ac.currentTime
+        );
     }
 
     /**

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -734,7 +734,7 @@ export default class WebAudio extends util.Observer {
      */
     setPlaybackRate(value) {
         this.playbackRate = value || 1;
-        this.source.playbackRate.setValueAtTime(
+        this.source && this.source.playbackRate.setValueAtTime(
             this.playbackRate,
             this.ac.currentTime
         );


### PR DESCRIPTION
webaudio backend: set playback rate modifying directly the playback property of the source node. Removed invocation to pause and play

### Breaking in the external API:
None

### Breaking changes in the internal API:
none

### Related Issues and other PRs:

fixes #2113