### PR TITLE
FIX: IOS webview implementation of FileReader doesn't support `addEventListener`

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1336,13 +1336,9 @@ export default class WaveSurfer extends util.Observer {
     loadBlob(blob) {
         // Create file reader
         const reader = new FileReader();
-        reader.addEventListener('progress', e => this.onProgress(e));
-        reader.addEventListener('load', e =>
-            this.loadArrayBuffer(e.target.result)
-        );
-        reader.addEventListener('error', () =>
-            this.fireEvent('error', 'Error reading file')
-        );
+        reader.onprogress = e => this.onProgress(e);
+        reader.onload = e => this.loadArrayBuffer(e.target.result);
+        reader.onerror = () => this.fireEvent('error', 'Error reading file');
         reader.readAsArrayBuffer(blob);
         this.empty();
     }


### PR DESCRIPTION
### Short description of changes:
- This bug was discovered while developing an IOS app using Ionic.
- Currently, when loading a blob via `wavesurfer.loadBlob(blob)`, the IOS webview implementation of FileReader throws an error complaining:
  ```
  TypeError: n.addEventListener is not a function. (In 'n.addEventListener("progress",(function(e){return t.onProgress(e)}))', 'n.addEventListener' is undefined)
  ```
  In this error message, `n` is initialized as the `new FileReader`
- By replacing the calls to `addEventListener` with the equivalent `onprogress`/`onload`/`onerror`, this bug is resolved and the blob load correctly.
