### PR TITLE
spectrogram plugin: Use ImageData to draw pixel-by-pixel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ wavesurfer.js changelog
 ------------------
 
 - Add `relativeNormalization` option to maintain proportionality between waveforms when `splitChannels` and `normalize` are `true` (#2108)
+- Spectrogram plugin: Use `ImageData` to draw pixel-by-pixel (#2127)
 
 4.2.0 (20.10.2020)
 ------------------

--- a/src/plugin/spectrogram/index.js
+++ b/src/plugin/spectrogram/index.js
@@ -250,34 +250,34 @@ export default class SpectrogramPlugin {
 
     drawSpectrogram(frequenciesData, my) {
         const spectrCc = my.spectrCc;
-        const length = my.wavesurfer.backend.getDuration();
         const height = my.height;
+        const width = my.width;
         const pixels = my.resample(frequenciesData);
         const heightFactor = my.buffer ? 2 / my.buffer.numberOfChannels : 1;
+        const imageData = spectrCc.createImageData(width, height);
         let i;
         let j;
+        let k;
 
         for (i = 0; i < pixels.length; i++) {
             for (j = 0; j < pixels[i].length; j++) {
                 const colorMap = my.colorMap[pixels[i][j]];
-                my.spectrCc.fillStyle =
-                    'rgba(' +
-                    colorMap[0] * 256 +
-                    ', ' +
-                    colorMap[1] * 256 +
-                    ', ' +
-                    colorMap[2] * 256 +
-                    ',' +
-                    colorMap[3] +
-                    ')';
-                my.spectrCc.fillRect(
-                    i,
-                    height - j * heightFactor,
-                    1,
-                    heightFactor
-                );
+                /* eslint-disable max-depth */
+                for (k = 0; k < heightFactor; k++) {
+                    let y = height - j * heightFactor;
+                    if (heightFactor === 2 && k === 1) {
+                        y--;
+                    }
+                    const redIndex = y * (width * 4) + i * 4;
+                    imageData.data[redIndex] = colorMap[0] * 255;
+                    imageData.data[redIndex + 1] = colorMap[1] * 255;
+                    imageData.data[redIndex + 2] = colorMap[2] * 255;
+                    imageData.data[redIndex + 3] = colorMap[3] * 255;
+                }
+                /* eslint-enable max-depth */
             }
         }
+        spectrCc.putImageData(imageData, 0, 0);
     }
 
     getFrequencies(callback) {


### PR DESCRIPTION
### Short description of changes:
Use `ImageData` to perform the pixel-by-pixel drawing operation instead of calling `fillStyle` and `fillRect` thousands of times since that translates to thousands of DOM operations within one frame.

Removed `const length` because it was unused in the method.

### Breaking in the external API:
none

### Breaking changes in the internal API:
none

### Testing

Since there are no automated tests for the spectro plugin, I manually performed the following steps with and without the changes:

1. Set the device pixel ratio (1, 2, and 3) using Chrome dev tool's Device Mode
2. Load the spectro example page
3. Right click the spectro canvas to save image (need to turn off Device Mode to do this step)

I did this for both the mono and stereo test audio files. Here are the saved images for you to compare: 
[Compare Spectro.zip](https://github.com/katspaugh/wavesurfer.js/files/5649398/Compare.Spectro.zip)

The images are identical except for the slight downward shift for mono audio DPR 1 and 3. Stereo audio doesn't have these differences. Perhaps having to manually draw two pixel tall data points rather than drawing two pixel tall rectangles on the canvas causes a minor change in the scaling? I leave it to the maintainers if this is acceptable.

### Justification

I discovered [this perf bottleneck while working on my own spectro](https://github.com/ilovecomputers/spectrogram/commit/78c8bfb087499abbc8a355451d921932eb849f63). Thought I would contribute what I learned to wavesurfer. You can see this perf bottleneck by using Chrome dev tool's Performance tool when you click "Start profiling and reload page":

<img width="440" alt="Screen Shot 2020-12-06 at 10 34 16 AM" src="https://user-images.githubusercontent.com/427597/101289758-4b7ba480-37b3-11eb-8ea0-4476e66a4906.png">

Here's the result with the change:

<img width="426" alt="Screen Shot 2020-12-06 at 10 34 28 AM" src="https://user-images.githubusercontent.com/427597/101289776-61896500-37b3-11eb-87eb-f2696d892e0b.png">

The self and total time of `drawSpectrogram` went down significantly because instead of mutating the DOM thousands of times (from  calling `fillStyle` and `fillRect`), the DOM is mutated once with `putImageData`.