### PR TITLE
Draft: Tests for WebAudio Backend

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,7 +36,7 @@ const firefoxFlags = {
 };
 
 module.exports = function(config) {
-    var configuration = {
+    let configuration = {
         basePath: '',
         frameworks: ['jasmine', 'jasmine-matchers', 'webpack'],
         hostname: 'localhost',
@@ -61,7 +61,8 @@ module.exports = function(config) {
             'spec/peakcache.spec.js',
             'spec/mediaelement.spec.js',
             'spec/mediaelement-webaudio.spec.js',
-            'spec/drawer.spec.js'
+            'spec/drawer.spec.js',
+            'spec/webaudio.spec.js'
         ],
         customHeaders: [
             {
@@ -78,6 +79,7 @@ module.exports = function(config) {
             'spec/mediaelement.spec.js': ['webpack'],
             'spec/mediaelement-webaudio.spec.js': ['webpack'],
             'spec/drawer.spec.js': ['webpack'],
+            'spec/webaudio.spec.js': ['webpack'],
 
             // source files, that you want to generate coverage for
             // do not include tests or libraries

--- a/spec/mediaelement-shared.js
+++ b/spec/mediaelement-shared.js
@@ -312,10 +312,18 @@ export function sharedErrorTests(backend) {
         }).toThrow(new Error('media parameter is not a valid media element'));
     });
 }
+
 function loadElement() {
     // set src
     audioElement.src = TestHelpers.EXAMPLE_FILE_PATH;
-    wavesurfer.load(audioElement);
+
+    // These tests should work with all backends?
+    // WebAudio requires the URL instead of the HTMLAudioElement to be passed in
+    if (wavesurfer.params.backend === 'WebAudio') {
+        wavesurfer.load(audioElement.src);
+    } else {
+        wavesurfer.load(audioElement);
+    }
 }
 
 /** Retrieve normalized waveform peaks, then load an audio resource giving peaks and setting preload attribute to 'none' **/

--- a/spec/webaudio.spec.js
+++ b/spec/webaudio.spec.js
@@ -1,0 +1,8 @@
+/* eslint-env jasmine */
+
+import { sharedTests } from './mediaelement-shared';
+
+/** @test {WaveSurfer} */
+describe('WebAudio: Shared audio backend tests', function() {
+    sharedTests('WebAudio');
+});


### PR DESCRIPTION
It looks like the WebAudio backend has no tests? I made it so we now run the shared audio backend tests with WebAudio too. But now `WaveSurfer/MediaElementWebAudio` tests started failing...