### PR TITLE
WaveSurfer load() should accept HTMLMediaElement when using WebAudio

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ x.x.x (unreleased)
 ------------------
 
 - Regions plugin: Stop region dragging when mouse leaves canvas (#2158)
+- Fixed `WaveSurfer.load(url)` not working when passing a HTMLMediaElement as the url parameter, with the WebAudio backend. 
 
 4.4.0 (13.01.2021)
 ------------------

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,7 +36,7 @@ const firefoxFlags = {
 };
 
 module.exports = function(config) {
-    var configuration = {
+    let configuration = {
         basePath: '',
         frameworks: ['jasmine', 'jasmine-matchers', 'webpack'],
         hostname: 'localhost',
@@ -61,7 +61,8 @@ module.exports = function(config) {
             'spec/peakcache.spec.js',
             'spec/mediaelement.spec.js',
             'spec/mediaelement-webaudio.spec.js',
-            'spec/drawer.spec.js'
+            'spec/drawer.spec.js',
+            'spec/webaudio.spec.js'
         ],
         customHeaders: [
             {
@@ -78,6 +79,7 @@ module.exports = function(config) {
             'spec/mediaelement.spec.js': ['webpack'],
             'spec/mediaelement-webaudio.spec.js': ['webpack'],
             'spec/drawer.spec.js': ['webpack'],
+            'spec/webaudio.spec.js': ['webpack'],
 
             // source files, that you want to generate coverage for
             // do not include tests or libraries

--- a/spec/webaudio.spec.js
+++ b/spec/webaudio.spec.js
@@ -1,0 +1,46 @@
+/* eslint-env jasmine */
+import TestHelpers from './test-helpers';
+
+/**
+ * Doesn't call load() automatically so you can test loading behaviour here
+ */
+describe('WebAudio/load:', function() {
+    let wavesurfer;
+    let element;
+    let manualDestroy = false;
+
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+
+    beforeEach(function(done) {
+        manualDestroy = false;
+
+        element = TestHelpers.createElement();
+        let wave = TestHelpers.createWaveform({
+            container: element,
+            backend: 'WebAudio',
+            waveColor: '#90F09B',
+            progressColor: 'purple',
+            cursorColor: 'white'
+        });
+
+        wavesurfer = wave[0];
+        element = wave[1];
+        done();
+    });
+
+    afterEach(function() {
+        if (!manualDestroy) {
+            wavesurfer.destroy();
+            TestHelpers.removeElement(element);
+        }
+    });
+
+    /**
+     * @test {WaveSurfer#load}
+     */
+    it('load should accept HTMLMediaElement as the url', function(done) {
+        let audio = new Audio(TestHelpers.EXAMPLE_FILE_PATH);
+        wavesurfer.load(audio);
+        wavesurfer.once('ready', done);
+    });
+});

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1406,6 +1406,12 @@ export default class WaveSurfer extends util.Observer {
             }
         }
 
+        // loadBuffer(url, peaks, duration) requires that url is a string
+        // but users can pass in a HTMLMediaElement to WaveSurfer
+        if (this.params.backend === 'WebAudio' && url instanceof HTMLMediaElement) {
+            url = url.src;
+        }
+
         switch (this.params.backend) {
             case 'WebAudio':
                 return this.loadBuffer(url, peaks, duration);


### PR DESCRIPTION
The WaveSurfer.load function's documentation says that the url parameter can be a string or a HTMLMediaElement, but when using the `WebAudio` backend, the loadBuffer function will assume the URL is always a string, and send incorrect HTTP requests like this:

![image](https://user-images.githubusercontent.com/11685806/103366676-25e47100-4abb-11eb-967f-66b07528a526.png)

### Breaking in the external API:
Technically this affects the external API, but instead of breaking existing code, it will fix currently broken code.


