### PR TITLE
regions plugin: stop dragging region when mouse exits wavesurfer div

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,10 @@
 wavesurfer.js changelog
 =======================
 
-
-4.4.1 (17.01.2021)
+x.x.x (unreleased)
 ------------------
 
-- Regions plugin:
-  - Stop region dragging when mouse leaves canvas (#2158)
-
+- Regions plugin: Stop region dragging when mouse leaves canvas (#2158)
 
 4.4.0 (13.01.2021)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 wavesurfer.js changelog
 =======================
 
+
+4.4.1 (17.01.2021)
+------------------
+
+- Regions plugin:
+  - Stop region dragging when mouse leaves canvas (#2158)
+
+
 4.4.0 (13.01.2021)
 ------------------
 

--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -300,6 +300,7 @@ export default class RegionsPlugin {
 
             region = null;
         };
+        this.wrapper.addEventListener('mouseleave', eventUp);
         this.wrapper.addEventListener('mouseup', eventUp);
         this.wrapper.addEventListener('touchend', eventUp);
 
@@ -310,6 +311,7 @@ export default class RegionsPlugin {
             document.body.removeEventListener('touchend', eventUp);
             this.wrapper.removeEventListener('touchend', eventUp);
             this.wrapper.removeEventListener('mouseup', eventUp);
+            this.wrapper.removeEventListener('mouseleave', eventUp);
         });
 
         const eventMove = e => {


### PR DESCRIPTION
It is difficult to set a region border close to the start or end of a wavesurfer. The intention here is that when the mouse leaves the wavesurfer, the region being adjusted stays at the most recent mousemove position instead of following the mouse after mouseup outside the wavesurfer.
