### PR TITLE
Split channels: overlay param now properly displays a single canvas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ wavesurfer.js changelog
 
 x.x.x (unreleased)
 ------------------
-
+- Split Channels: `overlay` param now properly displays a single canvas (#2161)
 - Regions plugin: Stop region dragging when mouse leaves canvas (#2158)
 - Fixed `WaveSurfer.load(url)` not working when passing a HTMLMediaElement as the url parameter, with the WebAudio backend. 
 

--- a/build-config/fragments/dev.js
+++ b/build-config/fragments/dev.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 
 const path = require('path');
+const rootDir = path.resolve(__dirname, '..', '..');
 
 module.exports = {
     mode: 'development',
@@ -11,7 +12,7 @@ module.exports = {
     devServer: {
         static: [
             {
-                directory: path.resolve(__dirname, '..', '..'),
+                directory: path.join(rootDir, 'dist'),
                 staticOptions: {},
                 publicPath: '/dist/',
                 serveIndex: true,

--- a/build-config/fragments/dev.js
+++ b/build-config/fragments/dev.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 
 const path = require('path');
-const rootDir = path.resolve(__dirname, '..', '..');
 
 module.exports = {
     mode: 'development',
@@ -12,7 +11,7 @@ module.exports = {
     devServer: {
         static: [
             {
-                directory: path.join(rootDir, 'dist'),
+                directory: path.resolve(__dirname, '..', '..'),
                 staticOptions: {},
                 publicPath: '/dist/',
                 serveIndex: true,

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -510,12 +510,13 @@ export default class MultiCanvas extends Drawer {
             // so we don't need negative values
             const hasMinVals = [].some.call(peaks, val => val < 0);
             const height = this.params.height * this.params.pixelRatio;
-            const offsetY = height * drawIndex || 0;
             const halfH = height / 2;
 
+            let offsetY = height * drawIndex || 0;
+
             // Override offsetY if overlay is true
-            if(_this7.params.splitChannelsOptions.overlay) {
-              offsetY = 0;
+            if (this.params.splitChannelsOptions.overlay) {
+                offsetY = 0;
             }
 
             return fn({

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -513,6 +513,11 @@ export default class MultiCanvas extends Drawer {
             const offsetY = height * drawIndex || 0;
             const halfH = height / 2;
 
+            // Override offsetY if overlay is true
+            if(_this7.params.splitChannelsOptions.overlay) {
+              offsetY = 0;
+            }
+
             return fn({
                 absmax: absmax,
                 hasMinVals: hasMinVals,

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -515,7 +515,7 @@ export default class MultiCanvas extends Drawer {
             let offsetY = height * drawIndex || 0;
 
             // Override offsetY if overlay is true
-            if (this.params.splitChannelsOptions.overlay) {
+            if (this.params.splitChannelsOptions && this.params.splitChannelsOptions.overlay) {
                 offsetY = 0;
             }
 


### PR DESCRIPTION
#2161 

When setting overlay: true on split channels the height of the waveform becomes equal to a single channel height but does not overlay the second channel. 

The issue is that the offsetY value is set based on height multiplied by the drawIndex or default to zero. In this case we should check for the splitChannelOptions.overlay and set the offsetY to zero regardless of the drawIndex.