### PR TITLE
Adding deinterleaving to scale_json.py script in FAQ to support multichannel peak data generated by audiowaveform

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -22,6 +22,8 @@ layout: default
     You can use the <a href="https://github.com/bbcrd/audiowaveform">audiowaveform</a> program. For example, let's generate peaks for a MP3 file called 'long_clip.mp3'.
   <p>Generate JSON-formatted peaks data from the file <code>long_clip.mp3</code>:</p>
   <pre><code>audiowaveform -i long_clip.mp3 -o long_clip.json --pixels-per-second 20 --bits 8</code></pre>
+  <p>To generate waveforms for each audio channel separately, add the '--split-channels' flag <code>long_clip.mp3</code>:</p>
+  <pre><code>audiowaveform -i long_clip.mp3 -o long_clip.json --pixels-per-second 20 --bits 8 --split-channels</code></pre>
   <p>Then normalize the peak data so the values stay between 0 and 1 using the Python script below:</p>
   <pre><code>python scale-json.py long_clip.json</code></pre>
   <pre><code>
@@ -35,6 +37,7 @@ def scale_json(filename):
 
     json_content = json.loads(file_content)
     data = json_content["data"]
+    channels = json_content["channels"]
     # number of decimals to use when rounding the peak value
     digits = 2
 
@@ -42,9 +45,12 @@ def scale_json(filename):
     new_data = []
     for x in data:
         new_data.append(round(x / max_val, digits))
-
-    deinterleaved_data = deinterleave(new_data, json_content["channels"])
-    json_content["data"] = deinterleaved_data
+    # audiowaveform is generating interleaved peak data when using the --split-channels flag, so we have to deinterleave it
+    if channels > 1:
+        deinterleaved_data = deinterleave(new_data, channels)
+        json_content["data"] = deinterleaved_data
+    else:
+        json_content["data"] = new_data
     file_content = json.dumps(json_content, separators=(',', ':'))
 
     with open(filename, "w") as f:
@@ -52,8 +58,11 @@ def scale_json(filename):
 
 
 def deinterleave(data, channelCount):
+    # first step is to separate the values for each audio channel and min/max value pair, hence we get an array with channelCount * 2 arrays
     deinterleaved = [data[idx::channelCount * 2] for idx in range(channelCount * 2)]
     new_data = []
+
+    # this second step combines each min and max value again in one array so we have one array for each channel
     for ch in range(channelCount):
         idx1 = 2 * ch
         idx2 = 2 * ch + 1


### PR DESCRIPTION
### Short description of changes:
BBC's audiowaveform is generating a interleaved version when using the --split-channels flag, see https://github.com/bbc/audiowaveform/blob/master/doc/DataFormat.md . wavesurfer.js, however, seems to expect an separate array for each audio channel for the externally generated peak data. This updated script should generate appropriate peak data for multichannel files (8 channels is currently the maximum supported number by BBC's audiowaveform).

### Breaking in the external API:
None

### Breaking changes in the internal API:
None

### Todos/Notes:
Tested with 1 - 8 channels for different backends and it seemed to work as expected.

### Related Issues and other PRs:
#356, #1954