### PR TITLE
webaudio: fix decodeAudioData handling in Safari

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 wavesurfer.js changelog
 =======================
 
-x.x.x (unreleased)
+4.6.0 (unreleased)
 ------------------
+- Webaudio: fix `decodeAudioData` handling in Safari (#2201)
 - Markers plugin: add new plugin that allows for timeline markers (#2196)
 
 4.5.0 (14.02.2021)

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -348,18 +348,19 @@ export default class WebAudio extends util.Observer {
                 this.ac && this.ac.sampleRate ? this.ac.sampleRate : 44100
             );
         }
-        if ('AudioContext' in window) {
-            this.offlineAc.decodeAudioData(arraybuffer).then(
-                (data) => callback(data)
-            ).catch(
-                (err) => errback(err)
-            );
-        } else {
-            // Safari: no support for Promise-based decodeAudioData yet
+        if ('webkitAudioContext' in window) {
+            // Safari: no support for Promise-based decodeAudioData enabled
+            // Enable it in Safari using the Experimental Features > Modern WebAudio API option
             this.offlineAc.decodeAudioData(
                 arraybuffer,
                 data => callback(data),
                 errback
+            );
+        } else {
+            this.offlineAc.decodeAudioData(arraybuffer).then(
+                (data) => callback(data)
+            ).catch(
+                (err) => errback(err)
             );
         }
     }


### PR DESCRIPTION
The previous check was not sufficient and broken in some cases.

Related webkit commit: https://trac.webkit.org/changeset/265352/webkit

```
BaseAudioContext.decodeAudioData() should return a Promise as per:
- https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-decodeaudiodata
 
Behavior is unchanged for prefixed WebKitAudioContext.decodeAudioData() to ensure
backward compatibility.
```

`window.webkitAudioContext` can be flipped on/off using the `Experimental Features > Modern WebAudio API` option in Safari.
