### PR TITLE
drawer: use `barMinHeight` according to docs

### DIFF
--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -301,10 +301,7 @@ export default class MultiCanvas extends Drawer {
                         peaks[Math.floor(i * scale * peakIndexScale)] || 0;
                     let h = Math.round((peak / absmax) * halfH);
 
-                    /* in case of silences, allow the user to specify that we
-                     * always draw *something* (normally a 1px high bar) */
-                    if (h == 0 && this.params.barMinHeight)
-                        h = this.params.barMinHeight;
+                    h = Math.max(h, this.params.barMinHeight);
 
                     this.fillRect(
                         i + this.halfPixel,


### PR DESCRIPTION
## Please make sure you provide the information below:

### Short description of changes:

Documentation says that `barMinHeight` is:

    If specified, draw at least a bar of this height, eliminating
    waveform gaps

However, the code uses minimum bar height only in cases of absolute
silence, leading to waveforms with bars significantly smaller than
`barMinHeight`.

Update implementation to always apply `barMinHeight` even if there is
non-zero signal at the timestamp.

### Breaking in the external API:

I would say this is a bugfix and not a major change since it makes module behave according to its documentation.

### Breaking changes in the internal API:

N/A.

### Todos/Notes:

N/A

### Related Issues and other PRs:

N/A