### PR TITLE
Publish to NPM via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,11 @@ name: NPM Package
 
 on:
   push:
-    branches: [ release ]
+    branches: [ master ]
 
 jobs:
   publish-npm:
+    if: startsWith(github.ref, 'refs/heads/release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   publish-npm:
-    if: startsWith(github.ref, 'refs/heads/release')
+    env:
+      OLD_VERSION: $(npm show wavesurfer.js version)
+      NEW_VERSION: $(node -p 'require("./package.json").version')
+    if: env.NEW_VERSION != env.OLD_VERSION
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,5 +30,5 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-      - run: git tag $(node -p 'require("./package.json").version')
+      - run: git tag "$NEW_VERSION"
       - run: git push --tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,6 @@ on:
 
 jobs:
   publish-npm:
-    env:
-      OLD_VERSION: $(npm show wavesurfer.js version)
-      NEW_VERSION: $(node -p 'require("./package.json").version')
-    if: env.NEW_VERSION != env.OLD_VERSION
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,8 +23,14 @@ jobs:
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
       - run: npm install
-      - run: npm publish
+      - name: Tag & publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-      - run: git tag "$NEW_VERSION"
-      - run: git push --tags
+        run: |
+          OLD_VERSION=$(npm show wavesurfer.js version)
+          NEW_VERSION=$(node -p 'require("./package.json").version')
+          if [ $NEW_VERSION != $OLD_VERSION ]; then
+            git tag "$NEW_VERSION"
+            git push --tags
+            npm publish
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: NPM Package
+
+on:
+  push:
+    branches: [ release ]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - run: npm install
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,5 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - run: git tag $(node -p 'require("./package.json").version')
+      - run: git push --tags

--- a/README.md
+++ b/README.md
@@ -135,11 +135,16 @@ If you want to use [the VS Code - Debugger for Chrome](https://github.com/Micros
 ## Editing documentation
 The homepage and documentation files are maintained in the [`gh-pages` branch](https://github.com/katspaugh/wavesurfer.js/tree/gh-pages). Contributions to the documentation are especially welcome.
 
+## Updating the NPM package
+When preparing a new release, update the version in the `package.json` and have it merged to master. Also don't forget to update the changelog.
+
+Once the updated version is on master, create a pull request to the protected `release` branch. When it's merged (please use the rebase option on GitHub), a new version of the package will be published to NPM.
+
 ## Credits
 
-Initial idea by [Alex Khokhulin](https://github.com/xoxulin). Many
-thanks to
-[the awesome contributors](https://github.com/katspaugh/wavesurfer.js/contributors)!
+The main maintainer: <img src="https://avatars.githubusercontent.com/u/305679" width="16" height="16" /> [Thijs Triemstra](https://github.com/thijstriemstra)
+
+Many thanks to [all the awesome contributors](https://github.com/katspaugh/wavesurfer.js/contributors)!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,7 @@ If you want to use [the VS Code - Debugger for Chrome](https://github.com/Micros
 The homepage and documentation files are maintained in the [`gh-pages` branch](https://github.com/katspaugh/wavesurfer.js/tree/gh-pages). Contributions to the documentation are especially welcome.
 
 ## Updating the NPM package
-When preparing a new release, update the version in the `package.json` and have it merged to master. Also don't forget to update the changelog.
-
-Once the updated version is on master, create a pull request to the protected `release` branch. When it's merged (please use the rebase option on GitHub), a new version of the package will be published to NPM.
+When preparing a new release, update the version in the `package.json` and have it merged to master. The new version of the package will be published to NPM automatically via GitHub Actions.
 
 ## Credits
 


### PR DESCRIPTION
As discussed in #2191, let's automate the publishing of our NPM package.

When a pull request is merged to the protected `release` branch, a new version of the package will be published. Ideally, we should choose the rebase merge option so that the `release` branch is identical to master.

Here's the first successful job: https://github.com/katspaugh/wavesurfer.js/runs/2037945086?check_suite_focus=true