### PR TITLE
add `returnToPlayhead` parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 wavesurfer.js changelog
 =======================
 
+4.6.1 (unreleased)
+------------------
+- Add `returnToPlayhead` parameter, emulating ProTools behavior
+
 4.6.0 (04.03.2021)
 ------------------
 - Webaudio: fix `decodeAudioData` handling in Safari (#2201)


### PR DESCRIPTION
This emulates default behavior in some DAWs (notably protools), where you may be working on audio from a specific point; in these cases it's a lousy experience to constantly seek back to your previous play position.