### PR TITLE
markers plugin: markers at the begin/end of file were screwing up seeking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 wavesurfer.js changelog
 =======================
 
+x.x.x (unreleased)
+------------------
+- Markers plugin: fix a bug where markers at the end of a track would cause
+  incorrect click-to-seek behavior (#2208)
+
 4.6.0 (04.03.2021)
 ------------------
 - Webaudio: fix `decodeAudioData` handling in Safari (#2201)

--- a/example/markers/app.js
+++ b/example/markers/app.js
@@ -15,6 +15,11 @@ document.addEventListener('DOMContentLoaded', function() {
             WaveSurfer.markers.create({
                 markers: [
                     {
+                        time: 0,
+                        label: "BEGIN",
+                        color: '#ff990a'
+                    },
+                    {
                         time: 5.5,
                         label: "V1",
                         color: '#ff990a'
@@ -22,6 +27,12 @@ document.addEventListener('DOMContentLoaded', function() {
                     {
                         time: 10,
                         label: "V2",
+                        color: '#00ffcc',
+                        position: 'top'
+                    },
+                    {
+                        time: 24,
+                        label: "END",
                         color: '#00ffcc',
                         position: 'top'
                     }

--- a/src/plugin/markers/index.js
+++ b/src/plugin/markers/index.js
@@ -181,6 +181,7 @@ export default class MarkersPlugin {
         this.style(el, {
             width: this.markerWidth + "px",
             height: this.markerHeight + "px",
+            "min-width": this.markerWidth + "px",
             "margin-right": "5px",
             "z-index": 4
         });
@@ -198,6 +199,7 @@ export default class MarkersPlugin {
             position: "absolute",
             height: "100%",
             display: "flex",
+            overflow: "hidden",
             "flex-direction": (marker.position == "top" ? "column-reverse" : "column")
         });
 
@@ -250,9 +252,11 @@ export default class MarkersPlugin {
                 this.wavesurfer.drawer.width /
                 this.wavesurfer.params.pixelRatio;
 
-            const positionPct = marker.time / duration;
+            const positionPct = Math.min(marker.time / duration, 1);
+            const leftPx = ((elementWidth * positionPct) - (this.markerWidth / 2));
             this.style(marker.el, {
-                left: ((elementWidth * positionPct) - (this.markerWidth / 2)) + "px"
+                "left":  leftPx + "px",
+                "max-width": (elementWidth - leftPx) + "px"
             });
         }
     }


### PR DESCRIPTION
markers placed at the beginning or the end of a region weren't properly overflowing, instead they pushed the wavesurfer container to be wider and that messed up calculations when seeking around a waveform.

Does this need a CHANGELOG?  not sure if you've released the marker stuff into the wild yet.
