### PR TITLE
regions plugin: drag bugfix & showTooltip parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ x.x.x (unreleased)
 ------------------
 - Markers plugin: fix a bug where markers at the end of a track would cause
   incorrect click-to-seek behavior (#2208)
+- Regions plugin:
+  - Fix mouseup not firing if click & drag a region handle & release outside browser window (#2213)
+  - Added new `showTooltip` param allowing disabling region `title` tooltip (#2213)
 
 4.6.0 (04.03.2021)
 ------------------

--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -30,6 +30,7 @@
  * @property {?number} channelIdx Select channel to draw the region on (if there are multiple channel waveforms).
  * @property {?object} handleStyle A set of CSS properties used to style the left and right handle.
  * @property {?boolean} preventContextMenu=false Determines whether the context menu is prevented from being opened.
+ * @property {boolean} showTooltip=true Enable/disable tooltip displaying start and end times when hovering over region.
  */
 
 import {Region} from "./region.js";

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -675,18 +675,18 @@ export class Region {
         document.body.addEventListener('mousemove', onMove);
         document.body.addEventListener('touchmove', onMove);
 
-        document.body.addEventListener('mouseup', onUp);
+        document.addEventListener('mouseup', onUp);
         document.body.addEventListener('touchend', onUp);
 
         this.on('remove', () => {
-            document.body.removeEventListener('mouseup', onUp);
+            document.removeEventListener('mouseup', onUp);
             document.body.removeEventListener('touchend', onUp);
             document.body.removeEventListener('mousemove', onMove);
             document.body.removeEventListener('touchmove', onMove);
         });
 
         this.wavesurfer.on('destroy', () => {
-            document.body.removeEventListener('mouseup', onUp);
+            document.removeEventListener('mouseup', onUp);
             document.body.removeEventListener('touchend', onUp);
         });
     }

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -42,6 +42,7 @@ export class Region {
         this.handleRightEl = null;
         this.data = params.data || {};
         this.attributes = params.attributes || {};
+		this.showTooltip = params.showTooltip ?? true;
 
         this.maxLength = params.maxLength;
         // It assumes the minLength parameter value, or the regionsMinLength parameter value, if the first one not provided
@@ -171,7 +172,7 @@ export class Region {
         const regionEl = document.createElement('region');
 
         regionEl.className = 'wavesurfer-region';
-        regionEl.title = this.formatTime(this.start, this.end);
+        if (this.showTooltip) regionEl.title = this.formatTime(this.start, this.end);
         regionEl.setAttribute('data-id', this.id);
 
         for (const attrname in this.attributes) {
@@ -301,7 +302,7 @@ export class Region {
                 );
             }
 
-            this.element.title = this.formatTime(this.start, this.end);
+            if (this.showTooltip) this.element.title = this.formatTime(this.start, this.end);
         }
     }
 

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -172,7 +172,9 @@ export class Region {
         const regionEl = document.createElement('region');
 
         regionEl.className = 'wavesurfer-region';
-        if (this.showTooltip) regionEl.title = this.formatTime(this.start, this.end);
+        if (this.showTooltip) {
+            regionEl.title = this.formatTime(this.start, this.end);
+        }
         regionEl.setAttribute('data-id', this.id);
 
         for (const attrname in this.attributes) {
@@ -302,7 +304,9 @@ export class Region {
                 );
             }
 
-            if (this.showTooltip) this.element.title = this.formatTime(this.start, this.end);
+            if (this.showTooltip) {
+                this.element.title = this.formatTime(this.start, this.end);
+            }
         }
     }
 

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -42,7 +42,7 @@ export class Region {
         this.handleRightEl = null;
         this.data = params.data || {};
         this.attributes = params.attributes || {};
-		this.showTooltip = params.showTooltip ?? true;
+        this.showTooltip = params.showTooltip ?? true;
 
         this.maxLength = params.maxLength;
         // It assumes the minLength parameter value, or the regionsMinLength parameter value, if the first one not provided


### PR DESCRIPTION
### Short description of changes:
Improvements addressing 2 minor annoyances (including 1 legit bug fix):

1. Fix a bug that prevented firing mouseup to end a region drag if the user clicked and dragged a region handle and released the mouse button outside of the browser window. Fixed by attaching the `mouseup` event listener to `document` instead of `document.body`.
2. Added new `RegionParams` option `showTooltip` allowing disabling the `title=...` tooltip (just because I found the unstyleable tooltip obtrusive and got tired of having to do `element.removeAttribute("title")` all the time).

### Breaking in the external API:
Nothing. The default value for the new `showTooltip` parameter is the old behavior.

### Breaking changes in the internal API:
Nothing

