### PR TITLE
get examples working again

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
     {
         'files': ['example/**/*.js', 'spec/**/*.js'],
         'rules': {
+            'no-var': 'off',
             'no-console': 'off',
             'require-jsdoc': 0,
             'valid-jsdoc': 0

--- a/example/audio-element/main.js
+++ b/example/audio-element/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/audio-element/main.js
+++ b/example/audio-element/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/elan/app.js
+++ b/example/elan/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/elan/app.js
+++ b/example/elan/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/equalizer/main.js
+++ b/example/equalizer/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/equalizer/main.js
+++ b/example/equalizer/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/main.js
+++ b/example/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/main.js
+++ b/example/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/media-session/app.js
+++ b/example/media-session/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/media-session/app.js
+++ b/example/media-session/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/minimap/app.js
+++ b/example/minimap/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 function init() {
     // configure

--- a/example/minimap/app.js
+++ b/example/minimap/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 function init() {
     // configure

--- a/example/mute/app.js
+++ b/example/mute/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/mute/app.js
+++ b/example/mute/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/panner/main.js
+++ b/example/panner/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/panner/main.js
+++ b/example/panner/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/playlist/app.js
+++ b/example/playlist/app.js
@@ -1,5 +1,5 @@
 // Create a WaveSurfer instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init on DOM ready
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/playlist/app.js
+++ b/example/playlist/app.js
@@ -1,5 +1,5 @@
 // Create a WaveSurfer instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init on DOM ready
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/plugin-system/app.js
+++ b/example/plugin-system/app.js
@@ -2,7 +2,7 @@
 
 import CursorCustomPlugin from './custom-plugin/CursorCustomPlugin.js';
 
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/plugin-system/app.js
+++ b/example/plugin-system/app.js
@@ -2,7 +2,7 @@
 
 import CursorCustomPlugin from './custom-plugin/CursorCustomPlugin.js';
 
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/regions/app.js
+++ b/example/regions/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/regions/app.js
+++ b/example/regions/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/rtl/main.js
+++ b/example/rtl/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/rtl/main.js
+++ b/example/rtl/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/spectrogram/app.js
+++ b/example/spectrogram/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load
 function initAndLoadSpectrogram(colorMap) {

--- a/example/spectrogram/app.js
+++ b/example/spectrogram/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load
 function initAndLoadSpectrogram(colorMap) {

--- a/example/split-channels/app.js
+++ b/example/split-channels/app.js
@@ -1,5 +1,5 @@
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 let wavesurferWithOptions;
 
 window.onload = function() {

--- a/example/split-channels/app.js
+++ b/example/split-channels/app.js
@@ -1,5 +1,5 @@
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 let wavesurferWithOptions;
 
 window.onload = function() {

--- a/example/timeline-notches/main.js
+++ b/example/timeline-notches/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 /**
  * Use formatTimeCallback to style the notch labels as you wish, such

--- a/example/timeline-notches/main.js
+++ b/example/timeline-notches/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 /**
  * Use formatTimeCallback to style the notch labels as you wish, such

--- a/example/timeline/app.js
+++ b/example/timeline/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/timeline/app.js
+++ b/example/timeline/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/trivia.js
+++ b/example/trivia.js
@@ -1,20 +1,20 @@
-var wavesurfer = window.wavesurfer; // eslint-disable-line no-var
+let ws = window.wavesurfer;
 
-let GLOBAL_ACTIONS = {
+var GLOBAL_ACTIONS = { // eslint-disable-line
     play: function() {
-        wavesurfer.playPause();
+        window.wavesurfer.playPause();
     },
 
     back: function() {
-        wavesurfer.skipBackward();
+        window.wavesurfer.skipBackward();
     },
 
     forth: function() {
-        wavesurfer.skipForward();
+        window.wavesurfer.skipForward();
     },
 
     'toggle-mute': function() {
-        wavesurfer.toggleMute();
+        window.wavesurfer.toggleMute();
     }
 };
 
@@ -58,6 +58,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Navbar links
     let ul = document.querySelector('.nav-pills');
+    if ( !ul ) {
+        return;
+    }
+
     let pills = ul.querySelectorAll('li');
     let active = pills[0];
     if (location.search) {

--- a/example/video-annotation/main.js
+++ b/example/video-annotation/main.js
@@ -1,5 +1,5 @@
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/video-annotation/main.js
+++ b/example/video-annotation/main.js
@@ -1,5 +1,5 @@
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/video-element/main.js
+++ b/example/video-element/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/video-element/main.js
+++ b/example/video-element/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/zoom/main.js
+++ b/example/zoom/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-var wavesurfer; //eslint-disable-line
+var wavesurfer;
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/zoom/main.js
+++ b/example/zoom/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Create an instance
-let wavesurfer;
+var wavesurfer; //eslint-disable-line
 
 // Init & load audio file
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
many of them are sharing a wavesurfer instance with `trivia.js` via a global variable.  I can't say this is the best idea, but this is at least explicit about it.

If there's a better approach I'm all ears, I looked down the road of timeline.js fishing out the wavesurfer instance from the DOM but didn't see an easy way.
