### PR TITLE
Automate GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: NPM Package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ test-release ]
 
 jobs:
   publish-npm:
@@ -47,11 +47,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo '4.4.0' > version.txt
           if [ -f version.txt ]; then
             curl \
               -X POST \
               -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: token $GITHUB_TOKEN"
-              https://api.github.com/repos/katspaugh/wavesurfer.js/releases \
-              -d "{\"tag_name":\"$(cat version.txt)\"}\"
+              -H "Authorization: token $GITHUB_TOKEN" \
+              'https://api.github.com/repos/katspaugh/wavesurfer.js/releases' \
+              -d "{\"tag_name\":\"$(cat version.txt)\"}"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: NPM Package
 
 on:
   push:
-    branches: [ test-release ]
+    branches: [ master ]
 
 jobs:
   publish-npm:
@@ -47,7 +47,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo '4.4.0' > version.txt
           if [ -f version.txt ]; then
             curl \
               -X POST \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,14 @@ jobs:
           NEW_VERSION=$(node -p 'require("./package.json").version')
           if [ $NEW_VERSION != $OLD_VERSION ]; then
             echo $NEW_VERSION > version.txt
+            echo "New version $NEW_VERSION detected"
+          else
+            echo "Version $OLD_VERSION hasn't changed, skipping the release"
           fi
-      - name: Tag
+      - name: Create a git tag
         run: |
           if [ -f version.txt ]; then
+            echo "Creating a git tag"
             git tag $(cat version.txt)
             git push --tags
           fi
@@ -41,6 +45,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
         run: |
           if [ -f version.txt ]; then
+            echo "Publishing to NPM"
             npm publish
           fi
       - name: Release on GitHub
@@ -49,10 +54,11 @@ jobs:
         run: |
           if [ -f version.txt ]; then
             NEW_VERSION=$(cat version.txt)
+            echo "Releasing $NEW_VERSION on GitHub"
             curl \
               -X POST \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: token $GITHUB_TOKEN" \
               'https://api.github.com/repos/katspaugh/wavesurfer.js/releases' \
-              -d "{\"tag_name\":\"$NEW_VERSION\", \"name\": \"$NEW_VERSION\"}"
+              -d "{\"tag_name\":\"$NEW_VERSION\", \"name\": \"$NEW_VERSION\", \"owner\": \"wavesurfer.js\" }"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           fi
       - name: Publish to NPM
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
         run: |
           if [ -f version.txt ]; then
             npm publish
@@ -48,10 +48,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -f version.txt ]; then
+            NEW_VERSION=$(cat version.txt)
             curl \
               -X POST \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: token $GITHUB_TOKEN" \
               'https://api.github.com/repos/katspaugh/wavesurfer.js/releases' \
-              -d "{\"tag_name\":\"$(cat version.txt)\"}"
+              -d "{\"tag_name\":\"$NEW_VERSION\", \"name\": \"$NEW_VERSION\"}"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,14 +23,35 @@ jobs:
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
       - run: npm install
-      - name: Tag & publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - name: Extract version
         run: |
           OLD_VERSION=$(npm show wavesurfer.js version)
           NEW_VERSION=$(node -p 'require("./package.json").version')
           if [ $NEW_VERSION != $OLD_VERSION ]; then
-            git tag "$NEW_VERSION"
+            echo $NEW_VERSION > version.txt
+          fi
+      - name: Tag
+        run: |
+          if [ -f version.txt ]; then
+            git tag $(cat version.txt)
             git push --tags
+          fi
+      - name: Publish to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+        run: |
+          if [ -f version.txt ]; then
             npm publish
+          fi
+      - name: Release on GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -f version.txt ]; then
+            curl \
+              -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token $GITHUB_TOKEN"
+              https://api.github.com/repos/katspaugh/wavesurfer.js/releases \
+              -d "{\"tag_name":\"$(cat version.txt)\"}\"
           fi


### PR DESCRIPTION
@thijstriemstra thanks for the docs link, it worked nicely 👍 

I've also reorganised the steps a bit, so that each command has a separate title.

Here's the build that published release 4.4.0: https://github.com/katspaugh/wavesurfer.js/runs/2271665459?check_suite_focus=true

Closes #2231.