### PR TITLE
docs: add upgrade instructions for 5.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,10 @@ This affects the following objects:
 
 2. **`WaveSurfer.exportPCM()` now returns a `Promise` that resolves to an `Array`**: Before, the Promise resolved to a JSON `string` representing the `Array`. You can get the same result by converting the resulting `Array` via [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
 
+## Upgrading to version 4 from version 3
+
+(No backward-incompatible changes.)
+
 ## Upgrading to version 3 from version 2
 
 - `util.ajax` was deprecated; use `util.fetchFile instead.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,18 @@
 # Upgrade
 
+## Upgrading to version 5 from version 4
+
+1. **`MultiCanvas` and `Drawer` now use [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) objects for DOM elements**: You can access the original instances via the `domElement` property on the Proxy objects (e.g. `CanvasEntry.wave.domElement`).
+
+This affects the following objects:
+
+- `CanvasEntry.progress` (e.g. `MultiCanvas.canvases[n].progress`)
+- `CanvasEntry.wave` (e.g. `MultiCanvas.canvases[n].wave`)
+- `Drawer.wrapper`
+- `MultiCanvas.container`
+
+2. **`WaveSurfer.exportPCM()` now returns a `Promise` that resolves to an `Array`**: Before, the Promise resolved to a JSON `string` representing the `Array`. You can get the same result by converting the resulting `Array` via [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
+
 ## Upgrading to version 3 from version 2
 
 - `util.ajax` was deprecated; use `util.fetchFile instead.


### PR DESCRIPTION
Ref: https://github.com/katspaugh/wavesurfer.js/commit/a262e6993ffded2f06b65bb4ac373312e9e6aff8#commitcomment-50513905