### PR TITLE
markers plugin: trigger click event on wavesurfer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,6 @@ wavesurfer.js changelog
 x.x.x (unreleased)
 ------------------
 - Markers plugin: add the ability to use custom HTML elements in place of the default marker icon by passing the new `markerElement` parameter to the marker constructor (#2269)
-
 - Regions plugin: handle rollover cursor bug fix (#2293)
 - Markers plugin:  trigger `marker-click` event on wavesurfer (#2287)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,10 @@
 wavesurfer.js changelog
 =======================
 
-x.x.x (unreleased) 
+x.x.x (unreleased)
 ------------------
 - Markers plugin: add the ability to use custom HTML elements in place of the default marker icon by passing the new `markerElement` parameter to the marker constructor (#2269)
+- Markers plugin:  trigger `marker-click` event on wavesurfer
 
 5.0.1 (05.05.2021)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ x.x.x (unreleased)
 ------------------
 - Markers plugin: add the ability to use custom HTML elements in place of the default marker icon by passing the new `markerElement` parameter to the marker constructor (#2269)
 - Regions plugin: handle rollover cursor bug fix (#2293)
-- Markers plugin:  trigger `marker-click` event on wavesurfer (#2287)
+- Markers plugin: trigger `marker-click` event on wavesurfer (#2287)
 
 5.0.1 (05.05.2021)
 ------------------

--- a/src/plugin/markers/index.js
+++ b/src/plugin/markers/index.js
@@ -40,6 +40,7 @@ export default class MarkersPlugin {
     /**
      * @typedef {Object} MarkersPluginParams
      * @property {?MarkerParams[]} markers Initial set of markers
+     * @fires MarkersPlugin#marker-click
      */
 
     /**

--- a/src/plugin/markers/index.js
+++ b/src/plugin/markers/index.js
@@ -241,7 +241,6 @@ export default class MarkersPlugin {
         labelDiv.addEventListener("click", e => {
             e.stopPropagation();
             this.wavesurfer.setCurrentTime(time);
-            this.fireEvent("click", e);
             this.wavesurfer.fireEvent("marker-click", marker, e);
         });
 

--- a/src/plugin/markers/index.js
+++ b/src/plugin/markers/index.js
@@ -241,6 +241,8 @@ export default class MarkersPlugin {
         labelDiv.addEventListener("click", e => {
             e.stopPropagation();
             this.wavesurfer.setCurrentTime(time);
+            this.fireEvent("click", e);
+            this.wavesurfer.fireEvent("marker-click", marker, e);
         });
 
         return el;


### PR DESCRIPTION
### Short description of changes:

Changes: When you click `labelDiv`, the `marker-click`event of wavesurfer is triggered (not previously).

Reasons:  In fact, when I want to do more when I click on marker, event is necessary


### Breaking in the external API:

No

### Breaking changes in the internal API:

No
### Todos/Notes:


### Related Issues and other PRs:
