### PR TITLE
regions plugin: cursor orientation bugfix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ wavesurfer.js changelog
 x.x.x (unreleased) 
 ------------------
 - Markers plugin: add the ability to use custom HTML elements in place of the default marker icon by passing the new `markerElement` parameter to the marker constructor (#2269)
+- Regions plugin: handle rollover cursor bug fix (#2293)
 
 5.0.1 (05.05.2021)
 ------------------

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -211,7 +211,7 @@ export class Region {
 
             // Default CSS properties for both handles.
             const css = {
-                cursor: 'row-resize',
+                cursor: this.vertical ? 'row-resize' : 'col-resize',
                 position: 'absolute',
                 top: '0px',
                 width: '2px',


### PR DESCRIPTION
Recent change to support vertical orientation in the Regions plugin introduced a bug that made the rollover cursor for region handles always show the vertical cursor even when in non-vertical mode.

### Breaking in the external API:
Nothing

### Breaking changes in the internal API:
None

