### PR TITLE
regions plugin: take formatTimeCallback from plugin params

### DIFF
--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -201,7 +201,7 @@ export default class RegionsPlugin {
             params = {...params, minLength: this.regionsMinLength};
         }
 
-        const region = new this.wavesurfer.Region(params, this.util, this.wavesurfer);
+        const region = new this.wavesurfer.Region(params, this.params, this.util, this.wavesurfer);
 
         this.list[region.id] = region;
 

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -9,7 +9,7 @@
  * @extends {Observer}
  */
 export class Region {
-    constructor(params, regionsUtils, ws) {
+    constructor(params, pluginParams, regionsUtils, ws) {
         this.wavesurfer = ws;
         this.wrapper = ws.drawer.wrapper;
         this.util = ws.util;
@@ -77,7 +77,7 @@ export class Region {
             }
         }
 
-        this.formatTimeCallback = params.formatTimeCallback;
+        this.formatTimeCallback = pluginParams.formatTimeCallback;
         this.edgeScrollWidth = params.edgeScrollWidth;
         this.bindInOut();
         this.render();


### PR DESCRIPTION
**Title:** regions plugin: take formatTimeCallback from plugin params

### Short description of changes:

The region plugin documentation for formatTimeCallback gives it as being a plugin parameter, so that's where it's now taken from.

### Breaking in the external API:

If anyone was relying on being able to set formatTimeCallback on a per-region basis, the this would be a breaking change.

### Breaking changes in the internal API:

None

### Todos/Notes:

My assumption here is that the existing behaviour - taking this setting from the region parameters - was an accident, and that the documented behaviour is correct. It would be possible, of course, to keep compatibility with the existing behaviour by having the code look to both sets of parameters.

There appears to be a similar discrepancy between documentation and implementation regarding edgeScrollWidth, but I haven't done anything about that.

### Related Issues and other PRs:
