### PR TITLE
examples: fix wrong url path in markers example

### DIFF
--- a/plugins/markers.js
+++ b/plugins/markers.js
@@ -46,5 +46,5 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     // Load audio from URL
-    wavesurfer.load('../media/demo.wav');
+    wavesurfer.load('../example/media/demo.wav');
 });


### PR DESCRIPTION
**Title:** fix: wrong resource path in marker plugin doc

Sorry to put the wrong link.

### Related Issues and other PRs: 
https://github.com/katspaugh/wavesurfer.js/pull/2300
