### PR TITLE
Marker time option typo

### DIFF
--- a/plugins/markers.html
+++ b/plugins/markers.html
@@ -52,10 +52,10 @@ layout: default
     </thead>
     <tbody>
       <tr>
-        <td><code>id</code></td>
+        <td><code>time</code></td>
         <td>number</td>
         <td></td>
-        <td>The time to set the marker at</td>
+        <td>The time in seconds to set the marker at</td>
       </tr>
       <tr>
         <td><code>label</code></td>


### PR DESCRIPTION
had "id" instead of "time"...also specified "in seconds" since there was no telling if it was milliseconds or what