### PR TITLE
improve error handling in ws.decodeArrayBuffer and WebAudio backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 wavesurfer.js changelog
 =======================
 
+x.x.x (unreleased)
+------------------
+- Fixed unhandled `Failed to execute 'stop' on 'AudioScheduledSourceNode'` error (#1473)
+- Fixed unhandled `Cannot read property 'decodeArrayBuffer' of null` error (#2279)
+
 5.1.0 (20.06.2021)
 ------------------
 - Markers plugin:

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1538,19 +1538,21 @@ export default class WaveSurfer extends util.Observer {
      * @param {function} callback The function to call on complete
      */
     decodeArrayBuffer(arraybuffer, callback) {
-        this.arraybuffer = arraybuffer;
-        this.backend.decodeArrayBuffer(
-            arraybuffer,
-            data => {
-                // Only use the decoded data if we haven't been destroyed or
-                // another decode started in the meantime
-                if (!this.isDestroyed && this.arraybuffer == arraybuffer) {
-                    callback(data);
-                    this.arraybuffer = null;
-                }
-            },
-            () => this.fireEvent('error', 'Error decoding audiobuffer')
-        );
+        if (!this.isDestroyed) {
+            this.arraybuffer = arraybuffer;
+            this.backend.decodeArrayBuffer(
+                arraybuffer,
+                data => {
+                    // Only use the decoded data if we haven't been destroyed or
+                    // another decode started in the meantime
+                    if (!this.isDestroyed && this.arraybuffer == arraybuffer) {
+                        callback(data);
+                        this.arraybuffer = null;
+                    }
+                },
+                () => this.fireEvent('error', 'Error decoding audiobuffer')
+            );
+        }
     }
 
     /**

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -705,7 +705,12 @@ export default class WebAudio extends util.Observer {
         try {
             this.source && this.source.stop(0);
         } catch (err) {
-            // no-op, see https://github.com/katspaugh/wavesurfer.js/issues/1473
+            // Calling stop can throw the following 2 errors:
+            // - RangeError (The value specified for when is negative.)
+            // - InvalidStateNode (The node has not been started by calling start().)
+            // We can safely ignore both errors, because:
+            // - The range is surely correct
+            // - The node might not have been started yet, in which case we just want to carry on without causing any trouble.
         }
 
         this.setState(PAUSED);

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -702,7 +702,11 @@ export default class WebAudio extends util.Observer {
         this.scheduledPause = null;
 
         this.startPosition += this.getPlayedTime();
-        this.source && this.source.stop(0);
+        try {
+            this.source && this.source.stop(0);
+        } catch (err) {
+            // no-op, see https://github.com/katspaugh/wavesurfer.js/issues/1473
+        }
 
         this.setState(PAUSED);
 


### PR DESCRIPTION
Fixes

`Failed to execute 'stop' on 'AudioScheduledSourceNode'`

and

`Cannot read property 'decodeArrayBuffer' of null`

(both timing / state issues)

### Short description of changes:

Adds the necessary checks to stop errors from happening.

### Breaking in the external API:

none

### Breaking changes in the internal API:

none

### Todos/Notes:

none

### Related Issues and other PRs:

fixes #2279
fixes #1473
