### PR TITLE
regions plugin: fix region resize event direction

### DIFF
--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -749,7 +749,7 @@ export class Region {
         const duration = this.wavesurfer.getDuration();
         const eventParams = {
             action: 'resize',
-            direction: direction === 'start' ? 'right' : 'left'
+            direction: direction === 'start' ? 'left' : 'right'
         };
 
         if (direction === 'start') {


### PR DESCRIPTION
### Short description of changes:
Event param `direction` on region resize is not correct. 
`start` means `left`
`end` - `right`

### Related Issues and other PRs:
#2339