### PR TITLE
Support for linear gradients: add additional type to waveColor and progressColor parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 wavesurfer.js changelog
 =======================
+5.3.0 (20.08.2021)
+------------------
+- add additional type to `waveColor` and `progressColor` parameters to support linear gradients (#2345)
 
 5.2.0 (16.08.2021)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 wavesurfer.js changelog
 =======================
-5.3.0 (20.08.2021)
+5.3.0 (unreleased)
 ------------------
 - add additional type to `waveColor` and `progressColor` parameters to support linear gradients (#2345)
 

--- a/example/gradient-fill-styles/index.html
+++ b/example/gradient-fill-styles/index.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>wavesurfer.js | Waveform using bars</title>
+
+    <link href="data:image/gif;" rel="icon" type="image/x-icon" />
+
+    <!-- Bootstrap -->
+    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
+
+    <link rel="stylesheet" href="../css/style.css" />
+    <link rel="stylesheet" href="../css/ribbon.css" />
+    <link rel="screenshot" itemprop="screenshot" href="https://katspaugh.github.io/wavesurfer.js/example/screenshot.png" />
+
+    <!-- wavesurfer.js -->
+    <script src="../../dist/wavesurfer.js"></script>
+
+    <!-- Demo -->
+    <script src="main.js"></script>
+
+    <!-- highlight.js for syntax highlighting in this example -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/default.min.css">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/highlight.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+</head>
+
+<body itemscope itemtype="http://schema.org/WebApplication">
+    <div class="container">
+        <div class="header">
+            <ul class="nav nav-pills pull-right">
+                <li><a href="/"><i class="glyphicon glyphicon-home"></i></a></li>
+            </ul>
+
+            <h1 itemprop="name">Gradient Fill Styles Example</h1>
+        </div>
+
+        <div id="demo">
+            <div id="waveform">
+                <!-- Here be the waveform -->
+            </div>
+
+            <div class="controls">
+                <div class="row">
+                    <div class="col-sm-7">
+                        <button class="btn btn-primary" data-action="play">
+                            <i class="glyphicon glyphicon-play"></i>
+                            Play /
+                            <i class="glyphicon glyphicon-pause"></i>
+                            Pause
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row marketing">
+            <h3>Gradient Fill Styles example</h3>
+            <hr />
+            <p>Draws a waveform with a gradient fill.</p>
+
+            <p>
+                <pre><code>wavesurfer = WaveSurfer.create({
+    container: document.querySelector('#waveform'),
+    waveColor: [ // an array of colors, to be applied as gradient color stops to the waveform.
+        "red",
+        "green",
+        "purple",
+        "yellow",
+        "rgba(0,255,255,.5)",
+    ],
+    progressColor: [ // the gradient fill styles are also available on the progressColor option
+        "orange",
+        "blue",
+        "cyan",
+        "black",
+        "rgba(0,255,255,.5)",
+    ]
+});
+</code></pre>
+            </p>
+        </div>
+
+
+        <div class="row marketing">
+            <h3>Gradient Fill Styles with Bars example</h3>
+            <hr />
+            <p>Draws a waveform using bars with a gradient fill.</p>
+
+            <div id="demo-with-bars">
+                <div id="waveform-with-bars">
+                    <!-- Here be the waveform -->
+                </div>
+
+                <div class="controls">
+                    <button id="play-button" class="btn btn-primary">
+                        <i class="glyphicon glyphicon-play"></i>
+                        Play
+                        /
+                        <i class="glyphicon glyphicon-pause"></i>
+                        Pause
+                    </button>
+                </div>
+            </div>
+            <p>
+                <pre><code>wavesurferWithBars = WaveSurfer.create({
+    container: document.querySelector('#waveform-with-bars'),
+    barGap: 6,
+    barHeight: 1,
+    barMinHeight: 1,
+    barRadius: 6,
+    barWidth: 12,
+    waveColor: [ // an array of colors, to be applied as gradient color stops to the waveform barsr
+        "red",
+        "green",
+        "purple",
+        "yellow",
+        "rgba(0,255,255,.5)",
+    ],
+    progressColor: [ // the gradient fill styles are also available on the progressColor option
+        "orange",
+        "blue",
+        "cyan",
+        "black",
+        "rgba(0,255,255,.5)",
+    ]
+});
+</code></pre>
+            </p>
+        </div>
+
+        <h4>WaveSurfer Options</h4>
+        <p>
+            <code>waveColor</code> - string | array - Can be a string referencing a color value, or an array of strings referencing color values.
+        </p>
+        <p>
+            <code>waveProgress</code> - string | array - Can be a string referencing a color value, or an array of strings referencing color values.
+        </p>
+
+        <div class="footer row">
+            <div class="col-sm-12">
+                <a rel="license" href="https://opensource.org/licenses/BSD-3-Clause"><img alt="BSD-3-Clause License" style="border-width:0" src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg" /></a>
+            </div>
+
+            <div class="col-sm-7">
+                <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">wavesurfer.js</span> by <a href="https://github.com/katspaugh/wavesurfer.js">katspaugh</a> is licensed under a&nbsp;<a style="white-space: nowrap" rel="license" href="https://opensource.org/licenses/BSD-3-Clause">BSD-3-Clause License</a>.
+            </div>
+
+            <div class="col-sm-5">
+                <div class="pull-right">
+                    <noindex>
+                        The audio file is from <a rel="nofollow" href="http://spokencorpora.ru/">spokencorpora.ru</a>, used
+                        with permission.
+                    </noindex>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="github-fork-ribbon-wrapper right">
+        <div class="github-fork-ribbon">
+            <a itemprop="isBasedOnUrl" href="https://github.com/katspaugh/wavesurfer.js">Fork me on GitHub</a>
+        </div>
+    </div>
+
+    <script>
+        (function (i, s, o, g, r, a, m) {
+            i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+                (i[r].q = i[r].q || []).push(arguments)
+            }, i[r].l = 1 * new Date(); a = s.createElement(o),
+                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+
+        ga('create', 'UA-50026819-1', 'wavesurfer.fm');
+        ga('send', 'pageview');
+    </script>
+</body>
+
+</html>

--- a/example/gradient-fill-styles/index.html
+++ b/example/gradient-fill-styles/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>wavesurfer.js | Waveform using bars</title>
+    <title>wavesurfer.js | Gradient Fill Styles Example</title>
 
     <link href="data:image/gif;" rel="icon" type="image/x-icon" />
 

--- a/example/gradient-fill-styles/main.js
+++ b/example/gradient-fill-styles/main.js
@@ -1,0 +1,81 @@
+'use strict';
+
+// Create an instance
+let wavesurfer = {};
+let wavesurferWithBars;
+
+// Init & load audio file
+document.addEventListener('DOMContentLoaded', function() {
+    wavesurfer = WaveSurfer.create({
+        container: document.querySelector('#waveform'),
+        waveColor: [ // waveColor as an array of colors, to be applied as gradient color stops to the waveform.
+            "red",
+            "green",
+            "purple",
+            "yellow",
+            "rgba(0,255,255,.5)"
+        ],
+        progressColor: [ // the gradient fill styles are also available on the progressColor option
+            "orange",
+            "blue",
+            "cyan",
+            "black",
+            "rgba(0,255,255,.5)"
+        ]
+    });
+
+    wavesurfer.on('error', function(e) {
+        console.warn(e);
+    });
+
+    // Load audio from URL
+    wavesurfer.load('../media/demo.wav');
+
+    // Set the playhead to halfway through the media, as to demonstrate the colorProgress gradient
+    wavesurfer.on('ready', () => wavesurfer.seekTo(.5));
+
+    // Play button
+    const button = document.querySelector('[data-action="play"]');
+
+    button.addEventListener('click', wavesurfer.playPause.bind(wavesurfer));
+
+
+    // WaveSurfer with bars example
+    wavesurferWithBars = WaveSurfer.create({
+        container: document.querySelector('#waveform-with-bars'),
+        barGap: 6,
+        barHeight: 1,
+        barMinHeight: 1,
+        barRadius: 6,
+        barWidth: 12,
+        waveColor: [ // waveColor as an array of colors, to be applied as gradient color stops to the waveform.
+            "red",
+            "green",
+            "purple",
+            "yellow",
+            "rgba(0,255,255,.5)"
+        ],
+        progressColor: [ // the gradient fill styles are also available on the progressColor option
+            "orange",
+            "blue",
+            "cyan",
+            "black",
+            "rgba(0,255,255,.5)"
+        ]
+    });
+
+    wavesurferWithBars.on('error', function(e) {
+        console.warn(e);
+    });
+
+    // Load audio from URL
+    wavesurferWithBars.load('../media/stereo.mp3');
+
+    // Set the playhead to halfway through the media, as to demonstrate the colorProgress gradient
+    wavesurferWithBars.on('ready', () => wavesurferWithBars.seekTo(.5));
+
+    // Play/pause on button press
+    document
+        .getElementById('play-button')
+        .addEventListener('click', wavesurferWithBars.playPause.bind(wavesurferWithBars));
+});

--- a/example/gradient-fill-styles/main.js
+++ b/example/gradient-fill-styles/main.js
@@ -40,7 +40,7 @@ document.addEventListener('DOMContentLoaded', function() {
     button.addEventListener('click', wavesurfer.playPause.bind(wavesurfer));
 
 
-    // WaveSurfer with bars example
+    // WaveSurfer with gradient fill styles - bars example
     wavesurferWithBars = WaveSurfer.create({
         container: document.querySelector('#waveform-with-bars'),
         barGap: 6,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Interactive navigable audio visualization using Web Audio and Canvas",
   "main": "dist/wavesurfer.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "5.3.0",
+  "version": "5.2.0",
   "description": "Interactive navigable audio visualization using Web Audio and Canvas",
   "main": "dist/wavesurfer.js",
   "directories": {

--- a/spec/wavesurfer.spec.js
+++ b/spec/wavesurfer.spec.js
@@ -264,6 +264,27 @@ describe('WaveSurfer/playback:', function() {
         expect(waveColor).toEqual(color);
     });
 
+    /** @test {WaveSurfer#setWaveColorGradient} */
+    it('allow setting waveColor gradient', function() {
+        let colors = [
+            "red",
+            "green",
+            "purple",
+            "yellow",
+            "rgba(0,255,255,.5)"
+        ];
+        wavesurfer.setWaveColor(colors);
+        const waveColor = wavesurfer.getWaveColor();
+
+        expect(waveColor).toEqual([
+            "red",
+            "green",
+            "purple",
+            "yellow",
+            "rgba(0,255,255,.5)"
+        ]);
+    });
+
     /** @test {WaveSurfer#getProgressColor} */
     it('allow getting progressColor', function() {
         const progressColor = wavesurfer.getProgressColor();

--- a/spec/wavesurfer.spec.js
+++ b/spec/wavesurfer.spec.js
@@ -276,13 +276,7 @@ describe('WaveSurfer/playback:', function() {
         wavesurfer.setWaveColor(colors);
         const waveColor = wavesurfer.getWaveColor();
 
-        expect(waveColor).toEqual([
-            "red",
-            "green",
-            "purple",
-            "yellow",
-            "rgba(0,255,255,.5)"
-        ]);
+        expect(waveColor).toEqual(colors);
     });
 
     /** @test {WaveSurfer#getProgressColor} */

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -165,7 +165,7 @@ export default class CanvasEntry {
      * @returns {string | CanvasGradient} Returns a string fillstyle value, or a canvas gradient
      */
     getFillStyle(ctx, color) {
-        if (typeof waveColor == 'string') {
+        if (typeof color == 'string') {
             return color;
         }
 

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -145,9 +145,10 @@ export default class CanvasEntry {
 
     /**
      * Set the fill styles for wave and progress
-     *
-     * @param {string|string[]} waveColor Fill color for the wave canvas, or an array of colors to apply as a gradient
-     * @param {?string|string[]} progressColor Fill color for the progress canvas, or an array of colors to apply as a gradient
+     * @param {string|string[]} waveColor Fill color for the wave canvas,
+     * or an array of colors to apply as a gradient
+     * @param {?string|string[]} progressColor Fill color for the progress canvas,
+     * or an array of colors to apply as a gradient
      */
     setFillStyles(waveColor, progressColor) {
         this.waveCtx.fillStyle = this.getFillStyle(this.waveCtx, waveColor);
@@ -158,11 +159,16 @@ export default class CanvasEntry {
     }
 
     /**
-     * Set the fill styles for wave and progress
+     * Utility function to handle wave color arguments
      *
+     * When the color argument type is a string, it will be returned as is.
+     * Otherwise, it will be treated as an array, and a canvas gradient will
+     * be returned
+     *
+     * @since 5.3.0
      * @param {CanvasRenderingContext2D} ctx Rendering context of target canvas
      * @param {string|string[]} color Fill color for the wave canvas, or an array of colors to apply as a gradient
-     * @returns {string | CanvasGradient} Returns a string fillstyle value, or a canvas gradient
+     * @returns {string|CanvasGradient} Returns a string fillstyle value, or a canvas gradient
      */
     getFillStyle(ctx, color) {
         if (typeof color == 'string') {

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -150,22 +150,29 @@ export default class CanvasEntry {
      * @param {?string|string[]} progressColor Fill color for the progress canvas, or an array of colors to apply as a gradient
      */
     setFillStyles(waveColor, progressColor) {
-        if (typeof waveColor == 'string') {
-            this.waveCtx.fillStyle = waveColor;
-        } else if (typeof waveColor == 'object') {
-            const waveGradient = this.waveCtx.createLinearGradient(0, 0, 0, this.waveCtx.canvas.height);
-            waveColor.forEach((color, index) => waveGradient.addColorStop((index / waveColor.length), color));
-            this.waveCtx.fillStyle = waveGradient;
-        }
+        this.waveCtx.fillStyle = this.getFillStyle(this.waveCtx, waveColor);
+
         if (this.hasProgressCanvas) {
-            if (typeof progressColor == 'string') {
-                this.progressCtx.fillStyle = progressColor;
-            } else if (typeof progressColor == 'object') {
-                const progressColorGradient = this.progressCtx.createLinearGradient(0, 0, 0, this.progressCtx.canvas.height);
-                progressColor.forEach((color, index) => progressColorGradient.addColorStop((index / progressColor.length), color));
-                this.progressCtx.fillStyle = progressColorGradient;
-            }
+            this.progressCtx.fillStyle = this.getFillStyle(this.progressCtx, progressColor);
         }
+    }
+
+    /**
+     * Set the fill styles for wave and progress
+     *
+     * @param {CanvasRenderingContext2D} ctx Rendering context of target canvas
+     * @param {string|string[]} color Fill color for the wave canvas, or an array of colors to apply as a gradient
+     * @returns {string | CanvasGradient} Returns a string fillstyle value, or a canvas gradient
+     */
+    getFillStyle(ctx, color) {
+        if (typeof waveColor == 'string') {
+            return color;
+        }
+
+        const waveGradient = ctx.createLinearGradient(0, 0, 0, ctx.canvas.height);
+        color.forEach((value, index) => waveGradient.addColorStop((index / color.length), value));
+
+        return waveGradient;
     }
 
     /**
@@ -368,7 +375,7 @@ export default class CanvasEntry {
         ctx.lineTo(
             (canvasStart - first) * scale,
             halfOffset -
-                Math.round((peaks[2 * canvasStart + 1] || 0) / absmaxHalf)
+            Math.round((peaks[2 * canvasStart + 1] || 0) / absmaxHalf)
         );
 
         ctx.closePath();

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -146,14 +146,25 @@ export default class CanvasEntry {
     /**
      * Set the fill styles for wave and progress
      *
-     * @param {string} waveColor Fill color for the wave canvas
-     * @param {?string} progressColor Fill color for the progress canvas
+     * @param {string|string[]} waveColor Fill color for the wave canvas, or an array of colors to apply as a gradient
+     * @param {?string|string[]} progressColor Fill color for the progress canvas, or an array of colors to apply as a gradient
      */
     setFillStyles(waveColor, progressColor) {
-        this.waveCtx.fillStyle = waveColor;
-
+        if (typeof waveColor == 'string') {
+            this.waveCtx.fillStyle = waveColor;
+        } else if (typeof waveColor == 'object') {
+            const waveGradient = this.waveCtx.createLinearGradient(0, 0, 0, this.waveCtx.canvas.height);
+            waveColor.forEach((color, index) => waveGradient.addColorStop((index / waveColor.length), color));
+            this.waveCtx.fillStyle = waveGradient;
+        }
         if (this.hasProgressCanvas) {
-            this.progressCtx.fillStyle = progressColor;
+            if (typeof progressColor == 'string') {
+                this.progressCtx.fillStyle = progressColor;
+            } else if (typeof progressColor == 'object') {
+                const progressColorGradient = this.progressCtx.createLinearGradient(0, 0, 0, this.progressCtx.canvas.height);
+                progressColor.forEach((color, index) => progressColorGradient.addColorStop((index / progressColor.length), color));
+                this.progressCtx.fillStyle = progressColorGradient;
+            }
         }
     }
 

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1125,7 +1125,7 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Get the fill color of the waveform after the cursor.
      *
-     * @return {string} A CSS color string.
+     * @return {string|object} A CSS color string, or an array of CSS color strings.
      */
     getWaveColor() {
         return this.params.waveColor;
@@ -1134,8 +1134,9 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Set the fill color of the waveform after the cursor.
      *
-     * @param {string} color A CSS color string.
+     * @param {string|object} color A CSS color string, or an array of CSS color strings.
      * @example wavesurfer.setWaveColor('#ddd');
+     * @example wavesurfer.setWavecolor(['blue','black','yellow']);
      */
     setWaveColor(color) {
         this.params.waveColor = color;
@@ -1145,7 +1146,7 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Get the fill color of the waveform behind the cursor.
      *
-     * @return {string} A CSS color string.
+     * @return {string|object} A CSS color string, or an array of CSS color strings.
      */
     getProgressColor() {
         return this.params.progressColor;
@@ -1154,8 +1155,9 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Set the fill color of the waveform behind the cursor.
      *
-     * @param {string} color A CSS color string.
+     * @param {string|object} color A CSS color string, or an array of CSS color strings.
      * @example wavesurfer.setProgressColor('#400');
+     * @example wavesurfer.setWavecolor(['blue','black','yellow']);
      */
     setProgressColor(color) {
         this.params.progressColor = color;

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1136,7 +1136,6 @@ export default class WaveSurfer extends util.Observer {
      *
      * @param {string|object} color A CSS color string, or an array of CSS color strings.
      * @example wavesurfer.setWaveColor('#ddd');
-     * @example wavesurfer.setWavecolor(['blue','black','yellow']);
      */
     setWaveColor(color) {
         this.params.waveColor = color;
@@ -1157,7 +1156,6 @@ export default class WaveSurfer extends util.Observer {
      *
      * @param {string|object} color A CSS color string, or an array of CSS color strings.
      * @example wavesurfer.setProgressColor('#400');
-     * @example wavesurfer.setWavecolor(['blue','black','yellow']);
      */
     setProgressColor(color) {
         this.params.progressColor = color;


### PR DESCRIPTION
### Short description of changes:
Added feature to pass an array of colors into the waveColor and progressColor parameters.  Edited the setFillStyles function to check if the provided argument is a string or an object.  In the case of an object, a linear gradient is created, with each item in the array added as a color stop.

![wavecolorgradient](https://user-images.githubusercontent.com/2645777/130211579-9347aa5a-ca9d-48d9-9e03-110b2953d610.png)
![wavecolorgradientcodeexample](https://user-images.githubusercontent.com/2645777/130211583-e6d5f064-5f14-48b7-ab36-fc27d51642b0.png)

### Breaking in the external API:
Not sure.

### Breaking changes in the internal API:
None, as it runs the check to see if it is a string, therefore should be backwards compatible.

### Todos/Notes:
If this feature is integrated, I would eventually like to integrate the ability to pass images and even a video as the wave background.

### Related Issues and other PRs:

