### PR TITLE
Regions plugin: increase z-index to fix visual inconsistencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ wavesurfer.js changelog
 5.3.0 (unreleased)
 ------------------
 - add additional type to `waveColor` and `progressColor` parameters to support linear gradients (#2345)
+- Regions plugin: increase region z-index to fix stacking inconsistencies
 
 5.2.0 (16.08.2021)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ wavesurfer.js changelog
 5.3.0 (unreleased)
 ------------------
 - add additional type to `waveColor` and `progressColor` parameters to support linear gradients (#2345)
-- Regions plugin: increase region z-index to fix stacking inconsistencies
+- Regions plugin: increase region z-index to fix stacking inconsistencies (#2353)
 
 5.2.0 (16.08.2021)
 ------------------

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -190,7 +190,7 @@ export class Region {
 
         this.style(this.element, {
             position: 'absolute',
-            zIndex: 2,
+            zIndex: 3,
             height: this.regionHeight,
             top: this.marginTop
         });


### PR DESCRIPTION
### Short description of changes:
Increased the `region` element's hardcoded `z-index` from 2 to 3 to fix stacking glitches.

For a demo of one the bugs this aims to fix, go to https://wavesurfer-js.org/plugins/regions.html and advance the playhead to the middle of the waveform. You'll see the 2 regions go from being above the waveform to being behind it. Then drag the blue region's end handle position to be past the playhead. You'll see the end handle of that region now appears above the waveform while its start handle appears behind it.

This also fixes stacking issues with zooming when regions are present, because as the zoom level increases new `canvas` elements with a hardcoded `z-index` of 2 are appended to the same parent as the regions, which can cause regions to appear to jump behind and in front of the waveform depending on the zoom level. The revised `z-index` of 3 for `region` ensures regions will always appear over the waveform.

### Breaking
From an all-else-equal perspective within Wavesurfer, this breaks nothing AFAICT. However, for developers who may have custom UI elements overlaid on a waveform, if their code relies on assuming that Wavesurfer's region elements always have a `z-index` of 2, this could cause side effects. That said I think a simple increment of the `z-index` here makes the most sense as a fix.