### PR TITLE
Add option hideCursor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ wavesurfer.js changelog
 ------------------
 - add additional type to `waveColor` and `progressColor` parameters to support linear gradients (#2345)
 - Regions plugin: increase region z-index to fix stacking inconsistencies (#2353)
+- add `hideCursor` option to hide the mouse cursor when hovering over the waveform (#2367)
 
 5.2.0 (16.08.2021)
 ------------------

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -69,6 +69,7 @@ export default class Drawer extends util.Observer {
         if (this.params.fillParent || this.params.scrollParent) {
             this.style(this.wrapper, {
                 width: '100%',
+                cursor: this.params.hideCursor ? 'hidden' : 'auto',
                 overflowX: this.params.hideScrollbar ? 'hidden' : 'auto',
                 overflowY: 'hidden'
             });

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -69,7 +69,7 @@ export default class Drawer extends util.Observer {
         if (this.params.fillParent || this.params.scrollParent) {
             this.style(this.wrapper, {
                 width: '100%',
-                cursor: this.params.hideCursor ? 'hidden' : 'auto',
+                cursor: this.params.hideCursor ? 'none' : 'auto',
                 overflowX: this.params.hideScrollbar ? 'hidden' : 'auto',
                 overflowY: 'hidden'
             });

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -270,6 +270,7 @@ export default class WaveSurfer extends util.Observer {
         forceDecode: false,
         height: 128,
         hideScrollbar: false,
+        hideCursor: false,
         ignoreSilenceMode: false,
         interact: true,
         loopSelection: true,

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -69,6 +69,8 @@ import MediaElementWebAudio from './mediaelement-webaudio';
  * pixels.
  * @property {boolean} hideScrollbar=false Whether to hide the horizontal
  * scrollbar when one would normally be shown.
+ * @property {boolean} hideCursor=false Whether to hide the mouse cursor
+ * when one would normally be shown by default.
  * @property {boolean} ignoreSilenceMode=false If true, ignores device silence mode
  * when using the `WebAudio` backend.
  * @property {boolean} interact=true Whether the mouse interaction will be


### PR DESCRIPTION
Add option `hideCursor`.
- hides the cursor if set to true, by default it will always show.

fixes #2366