### PR TITLE
regions plugin: fix region ignoring maxLength when being resized

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ wavesurfer.js changelog
 - add additional type to `waveColor` and `progressColor` parameters to support linear gradients (#2345)
 - Regions plugin: increase region z-index to fix stacking inconsistencies (#2353)
 - add `hideCursor` option to hide the mouse cursor when hovering over the waveform (#2367)
+- Regions plugin: check `maxLength` before resizing region (#2374)
 
 5.2.0 (16.08.2021)
 ------------------

--- a/example/regions/app.js
+++ b/example/regions/app.js
@@ -26,7 +26,8 @@ document.addEventListener('DOMContentLoaded', function() {
                         end: 7,
                         loop: false,
                         color: 'hsla(200, 50%, 70%, 0.4)',
-                        minLength: 1
+                        minLength: 1,
+                        maxLength: 5
                     }
                 ],
                 dragSelection: {

--- a/example/regions/index.html
+++ b/example/regions/index.html
@@ -86,6 +86,7 @@
                     loop: false,
                     color: 'hsla(200, 50%, 70%, 0.4)',
                     minLength: 1,
+                    maxLength: 5,
                 }
             ],
             dragSelection: {

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -754,9 +754,13 @@ export class Region {
 
         if (direction === 'start') {
             // Check if changing the start by the given delta would result in the region being smaller than minLength
-            // Ignore cases where we are making the region wider rather than shrinking it
             if (delta > 0 && this.end - (this.start + delta) < this.minLength) {
                 delta = this.end - this.minLength - this.start;
+            }
+
+            // Check if changing the start by the given delta would result in the region being larger than maxLength
+            if (delta < 0 && this.end - (this.start + delta) > this.maxLength) {
+                delta = this.end - this.start - this.maxLength;
             }
 
             if (delta < 0 && (this.start + delta) < 0) {
@@ -769,9 +773,13 @@ export class Region {
             }, eventParams);
         } else {
             // Check if changing the end by the given delta would result in the region being smaller than minLength
-            // Ignore cases where we are making the region wider rather than shrinking it
             if (delta < 0 && this.end + delta - this.start < this.minLength) {
                 delta = this.start + this.minLength - this.end;
+            }
+
+            // Check if changing the end by the given delta would result in the region being larger than maxLength
+            if (delta > 0 && this.end + delta - this.start > this.maxLength) {
+                delta = this.maxLength - (this.end - this.start);
             }
 
             if (delta > 0 && (this.end + delta) > duration) {


### PR DESCRIPTION
### Short description of changes:
On region resize take in consideration the `maxLength` param and recalculate the delta

### Related Issues and other PRs:
fixes #2297

### Recording

https://user-images.githubusercontent.com/37517049/136545184-8cdb7fc4-6626-4a08-a3ac-9c9cd85a867d.mov

