### PR TITLE
Allow handleStyle and play with out ending time for regions plug-in.

### DIFF
--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -35,7 +35,7 @@ export class Region {
         this.color = params.color || 'rgba(0, 0, 0, 0.1)';
         // The left and right handleStyle properties can be set to 'none' for
         // no styling or can be assigned an object containing CSS properties.
-        this.handleStyle = params.handleStyle || {
+        this.handleStyle = params.params.handleStyle || {
             left: {},
             right: {}
         };
@@ -147,7 +147,7 @@ export class Region {
      */
     play(start) {
         const s = start || this.start;
-        this.wavesurfer.play(s, this.end);
+        this.wavesurfer.play(s);
         this.fireEvent('play');
         this.wavesurfer.fireEvent('region-play', this);
     }


### PR DESCRIPTION
The changes made to line 38 allow css styles to be passed when the region is created so that the left and right handles can be styled.

The second change takes the ending time when play is caused.  The only time this is a problem is when there is a region selected.  If the region is playing and the user selects the ending handle and increases the region the player will stop at the original end time and not continue to the new end time for the region.  onProcess() seems to handle this so the play does not need an ending time.
