### PR TITLE
regions plugin: fix region-in and region-out events

### DIFF
--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -325,9 +325,10 @@ export class Region {
         this.firedIn = false;
         this.firedOut = false;
 
-        const onProcess = (time) => {
-            let start = Math.round(this.start * 10) / 10;
-            let end = Math.round(this.end * 10) / 10;
+        let start = Math.round(this.start * 10) / 10;
+        let end = Math.round(this.end * 10) / 10;
+
+        const fireRegionOut = (time) => {
             time = Math.round(time * 10) / 10;
 
             if (
@@ -340,6 +341,11 @@ export class Region {
                 this.fireEvent('out');
                 this.wavesurfer.fireEvent('region-out', this);
             }
+        };
+
+        const fireRegionIn = (time) => {
+            time = Math.round(time * 10) / 10;
+
             if (!this.firedIn && start <= time && end > time) {
                 this.firedIn = true;
                 this.firedOut = false;
@@ -348,10 +354,12 @@ export class Region {
             }
         };
 
-        this.wavesurfer.backend.on('audioprocess', onProcess);
+        this.wavesurfer.backend.on('audioprocess', fireRegionOut);
+        this.wavesurfer.backend.on('audioprocess', fireRegionIn);
 
         this.on('remove', () => {
-            this.wavesurfer.backend.un('audioprocess', onProcess);
+            this.wavesurfer.backend.un('audioprocess', fireRegionOut);
+            this.wavesurfer.backend.un('audioprocess', fireRegionIn);
         });
 
         /* Loop playback. */

--- a/src/util/observer.js
+++ b/src/util/observer.js
@@ -136,9 +136,24 @@ export default class Observer {
         }
 
         const handlers = this.handlers[event];
-        handlers &&
-            handlers.forEach(fn => {
-                fn(...args);
-            });
+        // run fireRegionOut handlers first
+        if (handlers) {
+            if (event == "audioprocess") {
+                handlers.forEach(fn => {
+                    if (fn.name == "fireRegionOut") {
+                        fn(...args);
+                    }
+                });
+                handlers.forEach(fn => {
+                    if (fn.name != "fireRegionOut") {
+                        fn(...args);
+                    }
+                });
+            } else {
+                handlers.forEach(fn => {
+                    fn(...args);
+                });
+            }
+        }
     }
 }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -740,6 +740,10 @@ export default class WaveSurfer extends util.Observer {
             this.fireEvent('audioprocess', time);
         });
 
+        this.backend.on('seek', () => {
+            this.backend.fireEvent("audioprocess", this.getCurrentTime());
+        });
+
         // only needed for MediaElement and MediaElementWebAudio backend
         if (
             this.params.backend === 'MediaElement' ||


### PR DESCRIPTION
### Short description of changes:
- Make firing region-out events run before firing region-in events regardless of the order of the creation of regions. (Fixes #2307) 
- Fire region-out and region-in when seeking while the audio is paused. (Fixes #2140)

### TODOs and Notes
I know that handling the order of running the events should not be the responsibility of the observer and the code is ugly, but that what I came up with, but you got the idea anyway, and the code can be modified.

### Related Issues and other PRs:
#2307 
#2140 