### PR TITLE
Add optional parameter channelIdx to colors methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ wavesurfer.js changelog
 - add `hideCursor` option to hide the mouse cursor when hovering over the waveform (#2367)
 - Regions plugin: check `maxLength` before resizing region (#2374)
 - Regions plugin: Add support for drag selection to be separated for each channel (#2380)
+- add optional `channelIdx` parameter to `setWaveColor`, `getWaveColor`, `setProgressColor`, `getProgressColor` methods (#2391)
 
 5.2.0 (16.08.2021)
 ------------------

--- a/example/split-channels/index.html
+++ b/example/split-channels/index.html
@@ -114,6 +114,13 @@
         }
     }
 });
+
+// change channel 0 progress color
+wavesurfer.setProgressColor('red', 0);
+// change channel 1 wave color
+wavesurfer.setWaveColor('blue', 1);
+// get channel 0 progress color
+wavesurfer.getProgressColor(0);
 </code></pre>
             </p>
             </div>

--- a/spec/wavesurfer.spec.js
+++ b/spec/wavesurfer.spec.js
@@ -293,6 +293,61 @@ describe('WaveSurfer/playback:', function() {
         expect(progressColor).toEqual('green');
     });
 
+    describe('split channels options', function() {
+        beforeEach(function() {
+            wavesurfer.params.splitChannels = true;
+            wavesurfer.params.splitChannelsOptions = {
+                channelColors: {
+                    0: {
+                        progressColor: 'green',
+                        waveColor: 'pink'
+                    },
+                    1: {
+                        progressColor: 'orange',
+                        waveColor: 'purple'
+                    }
+                }
+            };
+        });
+
+        afterEach(function() {
+            wavesurfer.params.splitChannels = false;
+            wavesurfer.params.splitChannelsOptions = {
+                channelColors: {}
+            };
+        });
+
+        /** @test {WaveSurfer#getChannelWaveColor} */
+        it('allow getting channel waveColor', function() {
+            const waveColor = wavesurfer.getWaveColor(1);
+            expect(waveColor).toEqual('purple');
+        });
+
+        /** @test {WaveSurfer#setChannelWaveColor} */
+        it('allow setting channel waveColor', function() {
+            let color = 'blue';
+            wavesurfer.setWaveColor(color, 1);
+            const waveColor = wavesurfer.getWaveColor(1);
+
+            expect(waveColor).toEqual(color);
+        });
+
+        /** @test {WaveSurfer#getChannelProgressColor} */
+        it('allow getting channel progressColor', function() {
+            const progressColor = wavesurfer.getProgressColor(1);
+            expect(progressColor).toEqual('orange');
+        });
+
+        /** @test {WaveSurfer#setChannelProgressColor} */
+        it('allow setting channel progressColor', function() {
+            let color = 'blue';
+            wavesurfer.setProgressColor(color, 1);
+            const progressColor = wavesurfer.getProgressColor(1);
+
+            expect(progressColor).toEqual(color);
+        });
+    });
+
     /** @test {WaveSurfer#getCursorColor} */
     it('allow getting cursorColor', function() {
         const cursorColor = wavesurfer.getCursorColor();

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1128,9 +1128,13 @@ export default class WaveSurfer extends util.Observer {
     /**
      * Get the fill color of the waveform after the cursor.
      *
+     * @param {?number} channelIdx Optional index of the channel to get its wave color if splitChannels is true
      * @return {string|object} A CSS color string, or an array of CSS color strings.
      */
-    getWaveColor() {
+    getWaveColor(channelIdx = null) {
+        if (this.params.splitChannelsOptions.channelColors[channelIdx]) {
+            return this.params.splitChannelsOptions.channelColors[channelIdx].waveColor;
+        }
         return this.params.waveColor;
     }
 
@@ -1138,19 +1142,27 @@ export default class WaveSurfer extends util.Observer {
      * Set the fill color of the waveform after the cursor.
      *
      * @param {string|object} color A CSS color string, or an array of CSS color strings.
+     * @param {?number} channelIdx Optional index of the channel to set its wave color if splitChannels is true
      * @example wavesurfer.setWaveColor('#ddd');
      */
-    setWaveColor(color) {
+    setWaveColor(color, channelIdx = null) {
         this.params.waveColor = color;
+        if (this.params.splitChannelsOptions.channelColors[channelIdx]) {
+            this.params.splitChannelsOptions.channelColors[channelIdx].waveColor = color;
+        }
         this.drawBuffer();
     }
 
     /**
      * Get the fill color of the waveform behind the cursor.
      *
+     * @param {?number} channelIdx Optional index of the channel to get its progress color if splitChannels is true
      * @return {string|object} A CSS color string, or an array of CSS color strings.
      */
-    getProgressColor() {
+    getProgressColor(channelIdx = null) {
+        if (this.params.splitChannelsOptions.channelColors[channelIdx]) {
+            return this.params.splitChannelsOptions.channelColors[channelIdx].progressColor;
+        }
         return this.params.progressColor;
     }
 
@@ -1158,10 +1170,14 @@ export default class WaveSurfer extends util.Observer {
      * Set the fill color of the waveform behind the cursor.
      *
      * @param {string|object} color A CSS color string, or an array of CSS color strings.
+     * @param {?number} channelIdx Optional index of the channel to set its progress color if splitChannels is true
      * @example wavesurfer.setProgressColor('#400');
      */
-    setProgressColor(color) {
+    setProgressColor(color, channelIdx) {
         this.params.progressColor = color;
+        if (this.params.splitChannelsOptions.channelColors[channelIdx]) {
+            this.params.splitChannelsOptions.channelColors[channelIdx].progressColor = color;
+        }
         this.drawBuffer();
     }
 

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1146,9 +1146,10 @@ export default class WaveSurfer extends util.Observer {
      * @example wavesurfer.setWaveColor('#ddd');
      */
     setWaveColor(color, channelIdx = null) {
-        this.params.waveColor = color;
         if (this.params.splitChannelsOptions.channelColors[channelIdx]) {
             this.params.splitChannelsOptions.channelColors[channelIdx].waveColor = color;
+        } else {
+            this.params.waveColor = color;
         }
         this.drawBuffer();
     }
@@ -1174,9 +1175,10 @@ export default class WaveSurfer extends util.Observer {
      * @example wavesurfer.setProgressColor('#400');
      */
     setProgressColor(color, channelIdx) {
-        this.params.progressColor = color;
         if (this.params.splitChannelsOptions.channelColors[channelIdx]) {
             this.params.splitChannelsOptions.channelColors[channelIdx].progressColor = color;
+        } else {
+            this.params.progressColor = color;
         }
         this.drawBuffer();
     }


### PR DESCRIPTION
### Short description of changes:
Add optional parameter `channelIdx` to these methods
- `setWaveColor`
- `getWaveColor`
- `setProgressColor`
- `getProgressColor`
