### PR TITLE
regions plugin: ensure edgeScrollWidth is set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ wavesurfer.js changelog
 - Regions plugin: allow `formatTimeCallback` from plugin params to be used (#2294)
 - Markers plugin: Add the ability to set markers as draggable using param `draggable=true`,
   `marker-drag` and `marker-drop` events will be triggered (#2398)
+- Regions plugin: use of default `edgeScrollWidth` value no longer dependent on
+  regions being created via plugin params (#2401)
 
 5.2.0 (16.08.2021)
 ------------------

--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -129,15 +129,14 @@ export default class RegionsPlugin {
         this.wavesurfer.Region = Region;
 
         // By default, scroll the container if the user drags a region
-        // within 5% of its edge
+        // within 5% (based on its initial size) of its edge
         const scrollWidthProportion = 0.05;
         this._onBackendCreated = () => {
             this.wrapper = this.wavesurfer.drawer.wrapper;
             this.orientation = this.wavesurfer.drawer.orientation;
+            this.defaultEdgeScrollWidth = this.wrapper.clientWidth * scrollWidthProportion;
             if (this.params.regions) {
                 this.params.regions.forEach(region => {
-                    region.edgeScrollWidth = this.params.edgeScrollWidth ||
-                        this.wrapper.clientWidth * scrollWidthProportion;
                     this.add(region);
                 });
             }
@@ -196,6 +195,11 @@ export default class RegionsPlugin {
         if (this.wouldExceedMaxRegions()) {
             return null;
         }
+
+        params = {
+            edgeScrollWidth: this.params.edgeScrollWidth || this.defaultEdgeScrollWidth,
+            ...params
+        };
 
         // Take formatTimeCallback from plugin params if not already set
         if (!params.formatTimeCallback && this.params.formatTimeCallback) {


### PR DESCRIPTION
**Title:** Fix edgescroll for regions created after region plugin

### Short description of changes:

Looking for a value for edgeScrollWidth for a region, either from plugin params or a default value, was only happening for regions specified in the plugin params; it now happens for all regions. The consequence of it not being set was that the logic for doing edgescrolling was doing calculations with `undefined`, and so never doing any scrolling.

### Breaking in the external API:

None

### Breaking changes in the internal API:

None

### Todos/Notes:


### Related Issues and other PRs:

fixes #2401.

The problem was noticed in the course of pull request #2294.