### PR TITLE
regions plugin: disable "region-removed" event during plugin teardown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ wavesurfer.js changelog
   - Use of default `edgeScrollWidth` value no longer dependent on regions being created via
     plugin params (#2401)
 
+5.3.0 (21.11.2021)
+------------------
+- Regions plugin: disable `region-remove` event emission during plugin teardown (#2403)
+
 5.2.0 (16.08.2021)
 ------------------
 - Add `ignoreSilenceMode` option to ignore iOS hardware silence switch when using the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,10 +15,7 @@ wavesurfer.js changelog
   - Allow `formatTimeCallback` from plugin params to be used (#2294)
   - Use of default `edgeScrollWidth` value no longer dependent on regions being created via
     plugin params (#2401)
-
-5.3.0 (21.11.2021)
-------------------
-- Regions plugin: disable `region-remove` event emission during plugin teardown (#2403)
+  - Disable `region-remove` event emission during plugin teardown (#2403)
 
 5.2.0 (16.08.2021)
 ------------------

--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -170,6 +170,7 @@ export default class RegionsPlugin {
     destroy() {
         this.wavesurfer.un('ready', this._onReady);
         this.wavesurfer.un('backend-created', this._onBackendCreated);
+        this.wavesurfer.setDisabledEventEmissions(['region-removed']);
         this.disableDragSelection();
         this.clear();
     }

--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -170,6 +170,10 @@ export default class RegionsPlugin {
     destroy() {
         this.wavesurfer.un('ready', this._onReady);
         this.wavesurfer.un('backend-created', this._onBackendCreated);
+        // Disabling `region-removed' because destroying the plugin calls
+        // the Region.remove() method that is also used to remove regions based
+        // on user input. This can cause confusion since teardown is not a
+        // user event, but would emit `region-removed` as if it was.
         this.wavesurfer.setDisabledEventEmissions(['region-removed']);
         this.disableDragSelection();
         this.clear();


### PR DESCRIPTION
### Short description of changes:

Currently when wavesurfer is destroyed the `RegionPlugin` will emit a `region-removed` event the same way it would when a user removes a region. This can be confusing in applicaton code since `region-removed` can emit without users interacting with the plugin.

### Breaking in the external API:

If anybody relied on `region-removed` being emitted during plugin destruction this would break that functionality.

### Breaking changes in the internal API:


### Todos/Notes:

Spent some time looking around at different ways to handle `RegionPlugin.destroy()` without emitting `region-removed` in the call chain. I came across `setDisabledEventEmissions` and that seems like a good way to suppress the event without duplicating functionality, adding conditional paths, etc.

### Related Issues and other PRs:

fixes #2403
