### PR TITLE
spectrogram: Add multi-channel, Remove inaccurate doubling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ wavesurfer.js changelog
   - Use of default `edgeScrollWidth` value no longer dependent on regions being created via
     plugin params (#2401)
   - Disable `region-remove` event emission during plugin teardown (#2403)
+- Spectrogram plugin:
+  - Remove inaccurate frequency doubling of spectrogram (#2232)
+  - Add `splitChannels` option to draw spectrograms for each channels (#2424)
 
 5.2.0 (16.08.2021)
 ------------------

--- a/src/plugin/spectrogram/index.js
+++ b/src/plugin/spectrogram/index.js
@@ -253,8 +253,8 @@ export default class SpectrogramPlugin {
     }
 
     drawSpectrogram(frequenciesData, my) {
-        if (!isNaN(frequenciesData[0][0])) { // data is 1ch [sample, fft] format
-            // to [channel, sample, fft] format
+        if (!isNaN(frequenciesData[0][0])) { // data is 1ch [sample, freq] format
+            // to [channel, sample, freq] format
             frequenciesData = [frequenciesData];
         }
 
@@ -290,13 +290,15 @@ export default class SpectrogramPlugin {
         const fftSamples = this.fftSamples;
         const buffer = (this.buffer = this.wavesurfer.backend.buffer);
         const channels = this.channels;
-        const sampleRate = buffer.sampleRate;
-        const frequencies = [];
 
         if (!buffer) {
             this.fireEvent('error', 'Web Audio buffer is not available');
             return;
         }
+
+        // This may differ from file samplerate. Browser resamples audio.
+        const sampleRate = buffer.sampleRate;
+        const frequencies = [];
 
         let noverlap = this.noverlap;
         if (!noverlap) {
@@ -311,7 +313,7 @@ export default class SpectrogramPlugin {
             this.alpha
         );
 
-        for (let c = 0; c < channels; c++) {
+        for (let c = 0; c < channels; c++) { // for each channel
             const channelData = buffer.getChannelData(c);
             const channelFreq = [];
             let currentOffset = 0;
@@ -393,7 +395,7 @@ export default class SpectrogramPlugin {
             return;
         }
 
-        for (let c = 0; c < this.channels; c++) {
+        for (let c = 0; c < this.channels; c++) { // for each channel
             // fill background
             ctx.fillStyle = bgFill;
             ctx.fillRect(0, c * getMaxY, bgWidth, (1 + c) * getMaxY);

--- a/src/plugin/spectrogram/index.js
+++ b/src/plugin/spectrogram/index.js
@@ -253,33 +253,26 @@ export default class SpectrogramPlugin {
         const height = my.height;
         const width = my.width;
         const pixels = my.resample(frequenciesData);
-        const heightFactor = my.buffer ? 2 / my.buffer.numberOfChannels : 1;
-        if (spectrCc) {
-            const imageData = spectrCc.createImageData(width, height);
-            let i;
-            let j;
-            let k;
 
-            for (i = 0; i < pixels.length; i++) {
-                for (j = 0; j < pixels[i].length; j++) {
-                    const colorMap = my.colorMap[pixels[i][j]];
-                    /* eslint-disable max-depth */
-                    for (k = 0; k < heightFactor; k++) {
-                        let y = height - j * heightFactor;
-                        if (heightFactor === 2 && k === 1) {
-                            y--;
-                        }
-                        const redIndex = y * (width * 4) + i * 4;
-                        imageData.data[redIndex] = colorMap[0] * 255;
-                        imageData.data[redIndex + 1] = colorMap[1] * 255;
-                        imageData.data[redIndex + 2] = colorMap[2] * 255;
-                        imageData.data[redIndex + 3] = colorMap[3] * 255;
-                    }
-                    /* eslint-enable max-depth */
-                }
-            }
-            spectrCc.putImageData(imageData, 0, 0);
+        if (!spectrCc) {
+            return;
         }
+
+        const imageData = spectrCc.createImageData(width, height);
+        let i;
+        let j;
+
+        for (i = 0; i < pixels.length; i++) {
+            for (j = 0; j < pixels[i].length; j++) {
+                const colorMap = my.colorMap[pixels[i][j]];
+                const redIndex = ((height - j) * width + i) * 4;
+                imageData.data[redIndex] = colorMap[0] * 255;
+                imageData.data[redIndex + 1] = colorMap[1] * 255;
+                imageData.data[redIndex + 2] = colorMap[2] * 255;
+                imageData.data[redIndex + 3] = colorMap[3] * 255;
+            }
+        }
+        spectrCc.putImageData(imageData, 0, 0);
     }
 
     getFrequencies(callback) {


### PR DESCRIPTION
### Short description of changes:
1. Remove inaccurate doubling of spectrogram (#2232)
2. Setting `splitChannels: true` going to draw spectrograms for each channels.

![3ch spectrogram example](https://user-images.githubusercontent.com/8174871/148345653-e4e2ffaa-0995-420d-9514-2097c7e0b47f.png)
3ch spectrogram example

### Breaking in the external API:
None.

### Breaking changes in the internal API:
None.

### Todos/Notes:
**This PR will change output of spectrogram.**

It seems like web browser resamples audio to fixed samplerate(in my case, 48kHz). #1248
So top of spectrogram frequency will be fixed regardless of original samplerate.

We can scale spectrogram, if there are nice way to get original samplerate(I couldn't find it).

### Related Issues and other PRs:
#1248

fixes #2232
