### PR TITLE
fixed bars sizing using max peak value in range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,13 @@
 wavesurfer.js changelog
 =======================
+
 6.0.0 (unreleased)
 ------------------
 - Add additional type to `waveColor` and `progressColor` parameters to support linear gradients (#2345)
 - Add `hideCursor` option to hide the mouse cursor when hovering over the waveform (#2367)
 - Add optional `channelIdx` parameter to `setWaveColor`, `getWaveColor`, `setProgressColor` and
   `getProgressColor` methods (#2391)
+- Improved drawing waveform with bars, now bars height is the maximum peak value in range (#2428) 
 - Markers plugin: Add the ability to set markers as draggable using param `draggable=true`,
   `marker-drag` and `marker-drop` events will be triggered (#2398)
 - Regions plugin:

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -305,20 +305,22 @@ export default class MultiCanvas extends Drawer {
                 const scale = length / this.width;
                 const first = start;
                 const last = end;
-                let i = first;
-
-                for (i; i < last; i += step) {
+                let peakIndex = first;
+                for (peakIndex; peakIndex < last; peakIndex += step) {
 
                     // search for the highest peak in the range this bar falls into
                     let peak = 0;
-                    let peakIndex = Math.floor(i * scale) * peakIndexScale; // start index
-                    const peakIndexEnd = Math.floor((i + step) * scale) * peakIndexScale;
+                    let peakIndexRange = Math.floor(peakIndex * scale) * peakIndexScale; // start index
+                    const peakIndexEnd = Math.floor((peakIndex + step) * scale) * peakIndexScale;
                     do { // do..while makes sure at least one peak is always evaluated
-                        peak = Math.max(peak, peaks[peakIndex] || 0); // highest
-                        peakIndex += peakIndexScale; // skip every other value for negatives
-                    } while (peakIndex < peakIndexEnd);
+                        const newPeak = peaks[peakIndexRange];
+                        if (newPeak > peak) {
+                            peak = newPeak; // higher
+                        }
+                        peakIndexRange += peakIndexScale; // skip every other value for negatives
+                    } while (peakIndexRange < peakIndexEnd);
 
-                    // calculate the height this bar according to highest peak found
+                    // calculate the height of this bar according to the highest peak found
                     let h = Math.round((peak / absmax) * halfH);
 
                     // in case of silences, allow the user to specify that we
@@ -328,7 +330,7 @@ export default class MultiCanvas extends Drawer {
                     }
 
                     this.fillRect(
-                        i + this.halfPixel,
+                        peakIndex + this.halfPixel,
                         halfH - h + offsetY,
                         bar + this.halfPixel,
                         h * 2,

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -308,8 +308,13 @@ export default class MultiCanvas extends Drawer {
                 let i = first;
 
                 for (i; i < last; i += step) {
-                    const peak =
-                        peaks[Math.floor(i * scale * peakIndexScale)] || 0;
+                    let peak = 0;
+                    let peakIndex = Math.floor(i * scale) * peakIndexScale;
+                    const peakIndexEnd = Math.floor((i + step) * scale) * peakIndexScale;
+                    do {
+                        peak = Math.max(peak, peaks[peakIndex] || 0);
+                        peakIndex += peakIndexScale;
+                    } while (peakIndex < peakIndexEnd);
                     let h = Math.round((peak / absmax) * halfH);
 
                     /* in case of silences, allow the user to specify that we

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -308,17 +308,21 @@ export default class MultiCanvas extends Drawer {
                 let i = first;
 
                 for (i; i < last; i += step) {
+
+                    // search for the highest peak in the range this bar falls into
                     let peak = 0;
-                    let peakIndex = Math.floor(i * scale) * peakIndexScale;
+                    let peakIndex = Math.floor(i * scale) * peakIndexScale; // start index
                     const peakIndexEnd = Math.floor((i + step) * scale) * peakIndexScale;
-                    do {
-                        peak = Math.max(peak, peaks[peakIndex] || 0);
-                        peakIndex += peakIndexScale;
+                    do { // do..while makes sure at least one peak is always evaluated
+                        peak = Math.max(peak, peaks[peakIndex] || 0); // highest
+                        peakIndex += peakIndexScale; // skip every other value for negatives
                     } while (peakIndex < peakIndexEnd);
+
+                    // calculate the height this bar according to highest peak found
                     let h = Math.round((peak / absmax) * halfH);
 
-                    /* in case of silences, allow the user to specify that we
-                     * always draw *something* (normally a 1px high bar) */
+                    // in case of silences, allow the user to specify that we
+                    // always draw *something* (normally a 1px high bar)
                     if (h == 0 && this.params.barMinHeight) {
                         h = this.params.barMinHeight;
                     }


### PR DESCRIPTION
This changes the way drawer renders bars. Prior to this, the height of each bar was [calculated only on the single peak at the start of bar, in `drawer.multicanvas.js:311`](https://github.com/katspaugh/wavesurfer.js/blob/master/src/drawer.multicanvas.js#L311). This made the bars render almost randomly, especially at smaller widths, since highest peaks were very easily ignored, if not falling exactly where a bar started.

Here's an animated example of **before**, as you can see the original waveform is translated poorly, and then when resizing, bars jump around for no good reason:

![Bars size before](https://user-images.githubusercontent.com/245615/148701271-c5f8372e-220e-4c60-8654-3eb4c93923a3.gif)

Now instead, the height is [calculated on the whole range of peaks that each bar falls into](https://github.com/lorenzos/wavesurfer.js/commit/243a595a5c5684c44b06619d1aed4fe38fa93429#diff-9e1d85325663a8f99b981eac351eef64b1ed40011d998b4d502b6b6ac4115609R311). I used the [maximum peak value](https://github.com/lorenzos/wavesurfer.js/commit/243a595a5c5684c44b06619d1aed4fe38fa93429#diff-9e1d85325663a8f99b981eac351eef64b1ed40011d998b4d502b6b6ac4115609R315); average works too, but it would require normalization to make sure the taller bar is at maximum height.

Here's the same animated example **after**, the translation is better and bars re-sampling is definitely more consistent:

![Bars size after](https://user-images.githubusercontent.com/245615/148701169-d6299965-e38e-48fd-b6b8-b9cd227498e5.gif)

---

### Addendum

While fixing this, I noticed another issue when choosing the peak index to use for heights calculation. There is a [`peakIndexScale` to "skip every other value if there are negatives"](https://github.com/katspaugh/wavesurfer.js/blob/master/src/drawer.multicanvas.js#L292) in the peaks array. It made sense, but was used incorrectly [in the actual formula](https://github.com/katspaugh/wavesurfer.js/blob/master/src/drawer.multicanvas.js#L312), before the rounding (floor) instead of [after](https://github.com/lorenzos/wavesurfer.js/commit/243a595a5c5684c44b06619d1aed4fe38fa93429#diff-9e1d85325663a8f99b981eac351eef64b1ed40011d998b4d502b6b6ac4115609R312).

This made it possible to actually choose odd indexes, and therefore negative peak values. I guess this went unnoticed since the bar is mirrored anyway. Here's a comparison of chosen peaks before and after, note how the fix "snaps" to even indexes only:

![Peak indexes before](https://user-images.githubusercontent.com/245615/148701638-a9187954-a056-402a-bede-40afdbb12a8f.png) ![Peak indexes after](https://user-images.githubusercontent.com/245615/148701632-24db4369-5e9a-4b5f-b366-2cc5f5450fc5.png)

