### PR TITLE
docs: add upgrade instructions for 6.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade
 
+## Upgrading to version 6 from version 5
+
+- `CursorPlugin.outerWidth(element)` was removed. You can use [`element.getBoundingClientRect().width`](https://developer.mozilla.org/docs/Web/API/Element/getBoundingClientRect) instead.
+
 ## Upgrading to version 5 from version 4
 
 1. **`MultiCanvas` and `Drawer` now use [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) objects for DOM elements**: You can access the original instances via the `domElement` property on the Proxy objects (e.g. `CanvasEntry.wave.domElement`).

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -165,7 +165,7 @@ export default class CanvasEntry {
      * Otherwise, it will be treated as an array, and a canvas gradient will
      * be returned
      *
-     * @since 5.3.0
+     * @since 6.0.0
      * @param {CanvasRenderingContext2D} ctx Rendering context of target canvas
      * @param {string|string[]} color Fill color for the wave canvas, or an array of colors to apply as a gradient
      * @returns {string|CanvasGradient} Returns a string fillstyle value, or a canvas gradient


### PR DESCRIPTION
See: https://github.com/katspaugh/wavesurfer.js/pull/2437