### PR TITLE
fixed bars rendering for peaks array starting with a negative value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 wavesurfer.js changelog
 =======================
 
+6.0.1 (unreleased)
+------------------
+- Fixed a regression that broke bars rendering when using a certain format for the peaks array (#2439, #2446)
+
 6.0.0 (07.02.2022)
 ------------------
 - Add additional type to `waveColor` and `progressColor` parameters to support linear gradients (#2345)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ wavesurfer.js changelog
 
 6.0.1 (unreleased)
 ------------------
-- Fixed a regression that broke bars rendering when using a certain format for the peaks array (#2439, #2446)
+- Fixed a regression that broke bars rendering when using a certain format for the peaks array (#2439)
 
 6.0.0 (07.02.2022)
 ------------------

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -313,7 +313,7 @@ export default class MultiCanvas extends Drawer {
                     let peakIndexRange = Math.floor(peakIndex * scale) * peakIndexScale; // start index
                     const peakIndexEnd = Math.floor((peakIndex + step) * scale) * peakIndexScale;
                     do { // do..while makes sure at least one peak is always evaluated
-                        const newPeak = Math.abs(peaks[peakIndexRange]);
+                        const newPeak = Math.abs(peaks[peakIndexRange]); // for arrays starting with negative values
                         if (newPeak > peak) {
                             peak = newPeak; // higher
                         }

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -313,7 +313,7 @@ export default class MultiCanvas extends Drawer {
                     let peakIndexRange = Math.floor(peakIndex * scale) * peakIndexScale; // start index
                     const peakIndexEnd = Math.floor((peakIndex + step) * scale) * peakIndexScale;
                     do { // do..while makes sure at least one peak is always evaluated
-                        const newPeak = peaks[peakIndexRange];
+                        const newPeak = Math.abs(peaks[peakIndexRange]);
                         if (newPeak > peak) {
                             peak = newPeak; // higher
                         }


### PR DESCRIPTION
Fixes #2439, an "unmasked" regression introduced with #2428. That regression broke bars rendering in the case a given pre-computed array of peaks alternates negative/positive values, instead of alternating positive/negative values (as wavesurfer itself generates).