### PR TITLE
Correct type of maxRegions property of RegionsPlugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 wavesurfer.js changelog
 =======================
 
+6.1.0
+------------------
+- Fixed the type annotation of `maxRegions` in the regions plugin.
+
 6.0.1 (13.02.2022)
 ------------------
 - Fixed a regression that broke bars rendering when using a certain format for the peaks array (#2439)

--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -10,7 +10,7 @@
  * @property {?number} snapToGridInterval Snap the regions to a grid of the specified multiples in seconds
  * @property {?number} snapToGridOffset Shift the snap-to-grid by the specified seconds. May also be negative.
  * @property {?boolean} deferInit Set to true to manually call
- * @property {number[]} maxRegions Maximum number of regions that may be created by the user at one time.
+ * @property {number} maxRegions Maximum number of regions that may be created by the user at one time.
  * `initPlugin('regions')`
  * @property {function} formatTimeCallback Allows custom formating for region tooltip.
  * @property {?number} edgeScrollWidth='5% from container edges' Optional width for edgeScroll to start


### PR DESCRIPTION
Changed the type of `maxRegions` from `number[]` to `number`.

