### PR TITLE
cursor plugin: fix element removal in destroy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@ wavesurfer.js changelog
 =======================
 
 6.0.3 (unreleased)
+------------------
+
 - Cursor plugin:
+  - Fix type documentation for `followCursorY` and `opacity` options (#2459)
   - Fix destroying cursor and showTime dom nodes (#2460)
 
 6.0.2 (20.02.2022)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 wavesurfer.js changelog
 =======================
 
+6.0.3 (unreleased)
+- Cursor plugin:
+  - Fix destroying cursor and showTime dom nodes (#2460)
+
 6.0.2 (20.02.2022)
 ------------------
 - Fix regression and restore support for passing a `CanvasGradient` to

--- a/src/plugin/cursor/index.js
+++ b/src/plugin/cursor/index.js
@@ -237,9 +237,9 @@ export default class CursorPlugin {
      */
     destroy() {
         if (this.params.showTime) {
-            this.cursor.parentNode.removeChild(this.showTime);
+            this.showTime.remove();
         }
-        this.cursor.parentNode.removeChild(this.cursor);
+        this.cursor.remove();
         this.wrapper.removeEventListener('mousemove', this._onMousemove);
         if (this.params.hideOnBlur) {
             this.wrapper.removeEventListener('mouseenter', this._onMouseenter);


### PR DESCRIPTION
When the plugin `destroy(`) method get called, I got an error because `removeChild()` was called with something that wasn't a `Node`, for `this.showTime` and `this.cursor`. 

### Short description of changes:
It seems that `showTime` and `cursor` are `Proxy` objects, and the `removeChild()` doesn't swallow that. Changing from e.g. `removeChild(this.cursor)` to `this.cursor.remove()` on the Proxy objects seems to fix this.


### Breaking in the external API:
n/a

### Breaking changes in the internal API:
n/a

### Todos/Notes:
n/a

### Related Issues and other PRs:

fixes #2460 