### PR TITLE
timeline plugin: fix negative offset rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 wavesurfer.js changelog
 =======================
 
+6.0.4 (04.03.2022)
+------------------
+- Timline plugin:
+  - Fix rendering issue on negative offset values (#2463)
+
 6.0.3 (01.03.2022)
 ------------------
 - Cursor plugin:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
 wavesurfer.js changelog
 =======================
 
-6.0.4 (04.03.2022)
+6.0.4 (unreleased)
 ------------------
-- Timline plugin:
-  - Fix rendering issue on negative offset values (#2463)
+- Timeline plugin:
+  - Fix rendering issue for negative `offset` values (#2463)
 
 6.0.3 (01.03.2022)
 ------------------

--- a/src/plugin/timeline/index.js
+++ b/src/plugin/timeline/index.js
@@ -371,7 +371,13 @@ export default class TimelinePlugin {
         // build an array of position data with index, second and pixel data,
         // this is then used multiple times below
         const positioning = [];
-        for (i = 0; i < totalSeconds / timeInterval; i++) {
+
+        // render until end in case we have a negative offset
+        const renderSeconds = (this.params.offset < 0)
+            ? totalSeconds - this.params.offset
+            : totalSeconds;
+
+        for (i = 0; i < renderSeconds / timeInterval; i++) {
             positioning.push([i, curSeconds, curPixel]);
             curSeconds += timeInterval;
             curPixel += pixelsPerSecond * timeInterval;


### PR DESCRIPTION
### Short description of changes:
when using negative values as `timeline.options.offset` the timeline is now rendered from start to the very end.  
before that change the timeline for those seconds of negative offset had not been rendered at the end of the waveform

### Related Issues and other PRs:

fixes #2463
