### PR TITLE
spectrogram plugin: Add `frequencyMin`, `frequencyMax` scaling option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ wavesurfer.js changelog
 
 6.0.4 (unreleased)
 ------------------
+- Spectrogram plugin:
+  - Add `frequencyMin`, `frequencyMax` option to scale frequency axis. 
+    And set default 12kHz range to draw spectrogram like 5.x (#2455)
 - Timeline plugin:
   - Fix rendering issue for negative `offset` values (#2463)
 

--- a/example/spectrogram/index.html
+++ b/example/spectrogram/index.html
@@ -96,6 +96,9 @@ wavesurfer.load('../media/demo.wav');</code></pre>
                       <li><code>wavesurfer</code> - <em>required</em> - a WaveSurfer instance.</li>
                       <li><code>container</code> - <em>required</em> - the element in which to place the spectrogram, or a CSS selector to find it.</li>
                       <li><code>fftSamples</code> - number of FFT samples (<code>512</code> by default). Number of spectral lines and height of the spectrogram will be a half of this parameter.</li>
+                      <li><code>frequencyMin</code> - Min frequency to scale spectrogram(<code>0</code> by default).</li>
+                      <li><code>frequencyMax</code> - Max frequency to scale spectrogram(<code>12000</code> by default). Set this to samplerate/2 to draw whole range of spectrogram.</li>
+                      <li><code>splitChannels</code> - Render with separate spectrograms for the channels of the audio</li>
                       <li><code>frequenciesDataUrl</code> - URL to load spectral data from.</li>
                       <li><code>labels</code> - Whether or not to display frequency labels.</li>
                       <li><code>colorMap</code> - Specifies the colormap to be used when rendering the spectrogram.</li>

--- a/src/plugin/spectrogram/index.js
+++ b/src/plugin/spectrogram/index.js
@@ -135,7 +135,7 @@ export default class SpectrogramPlugin {
             this.splitChannels = params.splitChannels;
             this.channels = this.splitChannels ? ws.backend.buffer.numberOfChannels : 1;
 
-            // Getting file's original samplerate is difficult(#1248). 
+            // Getting file's original samplerate is difficult(#1248).
             // So set 12kHz default to render like 5.x.
             this.frequencyMin = params.frequencyMin || 0;
             this.frequencyMax = params.frequencyMax || 12000;
@@ -279,7 +279,7 @@ export default class SpectrogramPlugin {
 
         for (let c = 0; c < frequenciesData.length; c++) { // for each channel
             const pixels = my.resample(frequenciesData[c]);
-            var imageData = new ImageData(new Uint8ClampedArray(width * height * 4), width, height);
+            const imageData = new ImageData(width, height);
 
             for (let i = 0; i < pixels.length; i++) {
                 for (let j = 0; j < pixels[i].length; j++) {
@@ -293,14 +293,14 @@ export default class SpectrogramPlugin {
             }
 
             // scale and stack spectrograms
-            createImageBitmap(imageData).then(renderer => 
+            createImageBitmap(imageData).then(renderer =>
                 spectrCc.drawImage(renderer,
-                    0, height * (1 - freqMax / freqFrom),           // source x, y
+                    0, height * (1 - freqMax / freqFrom), // source x, y
                     width, height * (freqMax - freqMin) / freqFrom, // source width, height
-                    0, height * c,                                  // destination x, y
-                    width, height                                   // destination width, height
+                    0, height * c, // destination x, y
+                    width, height // destination width, height
                 )
-            )
+            );
         }
     }
 

--- a/src/plugin/spectrogram/index.js
+++ b/src/plugin/spectrogram/index.js
@@ -136,7 +136,7 @@ export default class SpectrogramPlugin {
             this.channels = this.splitChannels ? ws.backend.buffer.numberOfChannels : 1;
 
             // Getting file's original samplerate is difficult(#1248).
-            // So set 12kHz default to render like 5.x.
+            // So set 12kHz default to render like wavesurfer.js 5.x.
             this.frequencyMin = params.frequencyMin || 0;
             this.frequencyMax = params.frequencyMax || 12000;
 

--- a/src/plugin/spectrogram/index.js
+++ b/src/plugin/spectrogram/index.js
@@ -21,6 +21,9 @@ import FFT from './fft';
  * @property {number} pixelRatio=wavesurfer.params.pixelRatio to control the
  * size of the spectrogram in relation with its canvas. 1 = Draw on the whole
  * canvas. 2 = Draw on a quarter (1/2 the length and 1/2 the width)
+ * @property {number} frequencyMin=0 Min frequency to scale spectrogram.
+ * @property {number} frequencyMax=12000 Max frequency to scale spectrogram.
+ * Set this to samplerate/2 to draw whole range of spectrogram.
  * @property {?boolean} deferInit Set to true to manually call
  * `initPlugin('spectrogram')`
  * @property {?number[][]} colorMap A 256 long array of 4-element arrays.
@@ -131,6 +134,11 @@ export default class SpectrogramPlugin {
             this.alpha = params.alpha;
             this.splitChannels = params.splitChannels;
             this.channels = this.splitChannels ? ws.backend.buffer.numberOfChannels : 1;
+
+            // Getting file's original samplerate is difficult(#1248). 
+            // So set 12kHz default to render like 5.x.
+            this.frequencyMin = params.frequencyMin || 0;
+            this.frequencyMax = params.frequencyMax || 12000;
 
             this.createWrapper();
             this.createCanvas();
@@ -261,6 +269,9 @@ export default class SpectrogramPlugin {
         const spectrCc = my.spectrCc;
         const height = my.height;
         const width = my.width;
+        const freqFrom = my.buffer.sampleRate / 2;
+        const freqMin = my.frequencyMin;
+        const freqMax = my.frequencyMax;
 
         if (!spectrCc) {
             return;
@@ -268,7 +279,7 @@ export default class SpectrogramPlugin {
 
         for (let c = 0; c < frequenciesData.length; c++) { // for each channel
             const pixels = my.resample(frequenciesData[c]);
-            const imageData = spectrCc.createImageData(width, height);
+            var imageData = new ImageData(new Uint8ClampedArray(width * height * 4), width, height);
 
             for (let i = 0; i < pixels.length; i++) {
                 for (let j = 0; j < pixels[i].length; j++) {
@@ -281,8 +292,15 @@ export default class SpectrogramPlugin {
                 }
             }
 
-            // stack spectrograms
-            spectrCc.putImageData(imageData, 0, height * c);
+            // scale and stack spectrograms
+            createImageBitmap(imageData).then(renderer => 
+                spectrCc.drawImage(renderer,
+                    0, height * (1 - freqMax / freqFrom),           // source x, y
+                    width, height * (freqMax - freqMin) / freqFrom, // source width, height
+                    0, height * c,                                  // destination x, y
+                    width, height                                   // destination width, height
+                )
+            )
         }
     }
 
@@ -381,10 +399,8 @@ export default class SpectrogramPlugin {
         const bgWidth = 55;
         const getMaxY = frequenciesHeight || 512;
         const labelIndex = 5 * (getMaxY / 256);
-        const freqStart = 0;
-        const step =
-            (this.wavesurfer.backend.ac.sampleRate / 2 - freqStart) /
-            labelIndex;
+        const freqStart = this.frequencyMin;
+        const step = (this.frequencyMax - freqStart) / labelIndex;
 
         // prepare canvas element for labels
         const ctx = this.labelsEl.getContext('2d');
@@ -408,9 +424,6 @@ export default class SpectrogramPlugin {
                 ctx.textBaseline = 'middle';
 
                 const freq = freqStart + step * i;
-                const index = Math.round(
-                    (freq / (this.sampleRate / 2)) * this.fftSamples
-                );
                 const label = this.freqType(freq);
                 const units = this.unitType(freq);
                 const yLabelOffset = 2;


### PR DESCRIPTION
### Short description of changes:
Spectrogram plugin:
- Add `frequencyMin`, `frequencyMax` option to scale frequency axis.
- Set default 12kHz range to draw spectrogram like 5.x (#2455)

![image](https://user-images.githubusercontent.com/8174871/156881192-1462cd88-7ce2-4621-af84-c1ad73e221c5.png)


### Breaking in the external API:
None.

### Breaking changes in the internal API:
None.

### Todos/Notes:
None.

### Related Issues and other PRs:
#2424
fixes #2455
