### PR TITLE
[DOCUMENTATION] change description of audioprocess event

### DIFF
--- a/docs/events.html
+++ b/docs/events.html
@@ -13,7 +13,7 @@ layout: default
   <p>Here's the list of available events:</p>
 
   <ul>
-    <li><code>audioprocess</code> – Fires continuously as the audio plays. Also fires on seeking.</li>
+    <li><code>audioprocess</code> – Fires continuously as the audio plays.</li>
     <li><code>dblclick</code> – When instance is double-clicked.</li>
     <li><code>destroy</code> – When instance is destroyed.</li>
     <li><code>error</code> – Occurs on error.  Callback will receive (string) error message.</li>


### PR DESCRIPTION
### Related Issues and other PRs:
fixes #2475 

### Short description of changes:
remove hint `Also fires on seeking.` of description of `audioprocess` event as it's not true during paused player
