### PR TITLE
responsive debounce optimizing: don't fire redraw if waveform is invisible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 wavesurfer.js changelog
 =======================
 
+6.0.5 (unreleased)
+------------------
+- Optimize responsive resize to avoid unnecessarily firing redraw on unpainted waveforms (#2485)
+
 6.0.4 (09.03.2022)
 ------------------
 - Spectrogram plugin:

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -505,7 +505,9 @@ export default class WaveSurfer extends util.Observer {
                     !this.params.scrollParent
                 ) {
                     prevWidth = this.drawer.wrapper.clientWidth;
-                    this.drawer.fireEvent('redraw');
+                    if (prevWidth) {
+                        this.drawer.fireEvent('redraw');
+                    }
                 }
             },
             typeof this.params.responsive === 'number'

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -506,6 +506,7 @@ export default class WaveSurfer extends util.Observer {
                 ) {
                     prevWidth = this.drawer.wrapper.clientWidth;
                     if (prevWidth) {
+                        // redraw only if waveform container is rendered and has a width
                         this.drawer.fireEvent('redraw');
                     }
                 }


### PR DESCRIPTION
### Short description of changes:
Avoid unnecessary calculations when performing the responsive debounced resize check.

Background: In my app I use many simultaneous Wavesurfer instances and toggle showing/hiding different waveforms at different times. I noticed that on window resize each instance was firing `redraw` from the debounce function even if the waveform container was unpainted/had 0 width, leading to unneeded calculations. So I propose adding a check for a nonzero width value before incurring the expense of calling `redraw`.

This is a bit of a microoptimization that won't noticeably affect users with only a single Wavesurfer instance but for those using dozens or hundreds of instances the benefit compounds and this will reduce cpu use during resizes.

### Breaking in the external API:
nothing

### Breaking changes in the internal API:
nothing
