### PR TITLE
cursor plugin: fix typeError if displayTime: null

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ wavesurfer.js changelog
 6.2.0 (unreleased)
 ------------------
 - Fix `clientWidth` error in responsive mode (#2498)
+- Fix `TypeError` when `showTime: undefined` in cursor plugin (#2501)
 
 6.1.0 (31.03.2022)
 ------------------

--- a/src/plugin/cursor/index.js
+++ b/src/plugin/cursor/index.js
@@ -90,7 +90,8 @@ export default class CursorPlugin {
         const bbox = this.wrapper.getBoundingClientRect();
         let y = 0;
         let x = this.wrapper.scrollLeft + event.clientX - bbox.left;
-        let flip = bbox.right < event.clientX + this.displayTime.getBoundingClientRect().width;
+        const displayTimeWidth = this.displayTime ? this.displayTime.getBoundingClientRect().width : 0;
+        let flip = bbox.right < event.clientX + displayTimeWidth;
 
         if (this.params.showTime && this.params.followCursorY) {
             // follow y-position of the mouse


### PR DESCRIPTION
**Title:** Fix typeError if `displayTime: null` in Cursor plugin

## Please make sure you provide the information below:

### Short description of changes:
Adding a simple check for `this.displayTime` before getting its `getBoundingClientRect()`. Previously it was giving an error:
```
Cannot read properties of null (reading 'getBoundingClientRect')
```

### Breaking in the external API:
None

### Breaking changes in the internal API:
None

### Todos/Notes:
None

### Related Issues and other PRs:
fixes #2501