### PR TITLE
Fix Failed to execute 'createMediaElementSource' on 'AudioContext'

### DIFF
--- a/src/mediaelement-webaudio.js
+++ b/src/mediaelement-webaudio.js
@@ -1,5 +1,7 @@
 import MediaElement from './mediaelement';
 
+const MediaElementMap = new WeakMap();
+
 /**
  * MediaElementWebAudio backend: load audio via an HTML5 audio tag, but playback with the WebAudio API.
  * The advantage here is that the html5 <audio> tag can perform range requests on the server and not
@@ -54,9 +56,14 @@ export default class MediaElementWebAudio extends MediaElement {
      * @param {HTMLMediaElement} mediaElement HTML5 Audio to load
      */
     createMediaElementSource(mediaElement) {
-        this.sourceMediaElement = this.ac.createMediaElementSource(
-            mediaElement
-        );
+        if (MediaElementMap.has(mediaElement)) {
+            this.sourceMediaElement = MediaElementMap.get(mediaElement);
+        } else {
+            this.sourceMediaElement = this.ac.createMediaElementSource(
+                mediaElement
+            );
+            MediaElementMap.set(mediaElement, this.sourceMediaElement);
+        }
         this.sourceMediaElement.connect(this.analyser);
     }
 


### PR DESCRIPTION
### Short description of changes:
It works fine the first time I create the wavesurfer with MediaElementWebAudio backend, but when the component is unmounted and then recreated at a later point, I get the following error message:

> Uncaught InvalidStateError: Failed to execute 'createMediaElementSource' on 'AudioContext': HTMLMediaElement already connected previously to a different MediaElementSourceNode.

It's possible to workaround this issue using WeakMap to remember MediaElementSourceNode:
```
 createMediaElementSource(mediaElement) {
        if (MediaElementMap.has(mediaElement)) {
            this.sourceMediaElement = MediaElementMap.get(mediaElement);
        } else {
            this.sourceMediaElement = this.ac.createMediaElementSource(
                mediaElement
            );
            MediaElementMap.set(mediaElement, this.sourceMediaElement);
        }
        this.sourceMediaElement.connect(this.analyser);
    }
```

### Breaking in the external API:
none 

### Breaking changes in the internal API:
none 
