### PR TITLE
docs: brief notes on NPM/CommonJS/ES6 usage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,17 @@ layout: default
 });</code></pre>
   </p>
 
+  <p>
+    If you are using Webpack or another bundler, you can install it wit hNPM:
+    <pre style="white-space: normal">
+      npm install wavesurfer.js
+    </pre>
+    Then you will need to include it in your code using CommonJS:
+    <pre><code class="javascript">const WaveSurfer = require("wavesurfer.js");</code></pre>
+    Or ES6 syntax:
+    <pre><code class="javascript">import WaveSurfer from "wavesurfer.js";</code></pre>
+  </p>
+
   <h2>Parameters</h2>
 
   <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,12 +27,12 @@ layout: default
   </p>
 
   <p>
-    If you are using Webpack or another bundler, you can install it with NPM:
+    If you are using Webpack or another bundler, you can install <b>wavesurfer.js</b> with NPM:
     <pre style="white-space: normal">
       npm install wavesurfer.js
     </pre>
-    Then you will need to include it in your code using CommonJS:
-    <pre><code class="javascript">const WaveSurfer = require("wavesurfer.js");</code></pre>
+    To use the library, you will need to include it from your code using CommonJS:
+    <pre><code class="javascript">var WaveSurfer = require("wavesurfer.js");</code></pre>
     Or ES6 syntax:
     <pre><code class="javascript">import WaveSurfer from "wavesurfer.js";</code></pre>
   </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@ layout: default
   </p>
 
   <p>
-    If you are using Webpack or another bundler, you can install it wit hNPM:
+    If you are using Webpack or another bundler, you can install it with NPM:
     <pre style="white-space: normal">
       npm install wavesurfer.js
     </pre>

--- a/plugins/index.html
+++ b/plugins/index.html
@@ -6,7 +6,7 @@ layout: default
 
   <h2>How to configure a plugin</h2>
 
-  <p>To start using a plugin, you need to insert the plugin library into your HTML page, alongside <code>wavesurfur.js</code>, like this:</p>
+  <p>To start using a plugin, you need to insert the plugin library into your HTML page, alongside <code>wavesurfer.js</code>, like this:</p>
   <pre><code>&lt;script src=&quot;https://unpkg.com/wavesurfer.js&quot;&gt;&lt;/script&gt;
 &lt;script src=&quot;https://unpkg.com/wavesurfer.js/dist/plugin/wavesurfer.regions.min.js&quot;&gt;&lt;/script&gt;</code></pre>
   <p>You need to include the plugin's configuration when creating an instance of <code>WaveSurfer</code>:</p>
@@ -17,6 +17,19 @@ layout: default
     ]
 });</code></pre>
 
+  <p>When using NPM, the plugins are installed
+  in <code>node_modules</code> with the package but must be imported or required
+  locally in order to use them:
+    <pre><code class="javascript">
+# ES6: import RegionsPlugin from "wavesurfer.js/dist/plugin/wavesurfer.regions.min.js";
+const RegionsPlugin = require("wavesurfer.js/dist/plugin/wavesurfer.regions.min.js");
+var wavesurfer = WaveSurfer.create({
+    container: '#waveform',
+    plugins: [
+        RegionsPlugin.create({})
+    ]
+});</code></pre>
+  </p>
 
   <h2>Plugins</h2>
   <ul>

--- a/plugins/index.html
+++ b/plugins/index.html
@@ -17,12 +17,13 @@ layout: default
     ]
 });</code></pre>
 
-  <p>When using NPM, the plugins are installed
-  in <code>node_modules</code> with the package but must be imported or required
-  locally in order to use them:
+  <p>If you are using the NPM package with Webpack or another bundler,
+    the plugins are installed in <code>node_modules</code> with
+    the <b>wavesurfer.js</b> package, but they must first be imported
+    or required locally in order to use them:
     <pre><code class="javascript">
-# ES6: import RegionsPlugin from "wavesurfer.js/dist/plugin/wavesurfer.regions.min.js";
-const RegionsPlugin = require("wavesurfer.js/dist/plugin/wavesurfer.regions.min.js");
+// ES6: import RegionsPlugin from "wavesurfer.js/dist/plugin/wavesurfer.regions.min.js";
+var RegionsPlugin = require("wavesurfer.js/dist/plugin/wavesurfer.regions.min.js");
 var wavesurfer = WaveSurfer.create({
     container: '#waveform',
     plugins: [


### PR DESCRIPTION
### Short description of changes:

Add basic documentation about using `wavesurfer.js` with NPM and CommonJS/ES6 modules 

### Breaking in the external API:

nothing

### Breaking changes in the internal API:

nothing

### Todos/Notes:

nothing

### Related Issues and other PRs:

https://github.com/katspaugh/wavesurfer.js/issues/1077
https://github.com/katspaugh/wavesurfer.js/issues/2427
