### PR TITLE
regions plugin: restore support for one drag selection for all channels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@ wavesurfer.js changelog
 =======================
 
 6.3.0 (unreleased)
-- Regions plugin: restore support for one drag selection for all channels (#2551)
+------------------
+- Regions plugin: restore support for one drag selection for all channels (#2529)
 
 6.2.0 (16.05.2022)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 wavesurfer.js changelog
 =======================
 
+6.3.0 (unreleased)
+- Regions plugin: restore support for one drag selection for all channels (#2551)
+
 6.2.0 (16.05.2022)
 ------------------
 - Fix `clientWidth` error in responsive mode (#2498)

--- a/src/plugin/regions/index.js
+++ b/src/plugin/regions/index.js
@@ -299,7 +299,7 @@ export default class RegionsPlugin {
             );
 
             // set the region channel index based on the clicked area
-            if (this.wavesurfer.params.splitChannels) {
+            if (this.wavesurfer.params.splitChannels && this.wavesurfer.params.splitChannelsOptions.splitDragSelection) {
                 const y = (e.touches ? e.touches[0].clientY : e.clientY) - wrapperRect.top;
                 const channelCount = this.wavesurfer.backend.buffer != null ? this.wavesurfer.backend.buffer.numberOfChannels : 1;
                 const channelHeight = this.wrapper.clientHeight / channelCount;

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -174,6 +174,7 @@ import MediaElementWebAudio from './mediaelement-webaudio';
  * @property {boolean} relativeNormalization=false determines whether
  * normalization is done per channel or maintains proportionality between
  * channels. Only applied when normalize and splitChannels are both true.
+ * @property {boolean} splitDragSelection=false determines if drag selection in regions plugin works separately on each channel or only one selection for all channels
  * @since 4.3.0
  */
 
@@ -298,7 +299,8 @@ export default class WaveSurfer extends util.Observer {
             overlay: false,
             channelColors: {},
             filterChannels: [],
-            relativeNormalization: false
+            relativeNormalization: false,
+            splitDragSelection: false
         },
         vertical: false,
         waveColor: '#999',

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -174,7 +174,8 @@ import MediaElementWebAudio from './mediaelement-webaudio';
  * @property {boolean} relativeNormalization=false determines whether
  * normalization is done per channel or maintains proportionality between
  * channels. Only applied when normalize and splitChannels are both true.
- * @property {boolean} splitDragSelection=false determines if drag selection in regions plugin works separately on each channel or only one selection for all channels
+ * @property {boolean} splitDragSelection=false determines if drag selection in regions
+ * plugin works separately on each channel or only one selection for all channels
  * @since 4.3.0
  */
 


### PR DESCRIPTION
### Short description of changes:
add `splitDragSelection` (default false) in `splitChannelsOptions` and check on it when splitting the drag selection
### Todos/Notes:
maybe update annotation example to include this

### Related Issues and other PRs:
fixes #2529
refs #2380