### PR TITLE
deps: remove unused babel-plugin-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "babel-loader": "^8.2.5",
     "babel-plugin-add-module-exports": "^1.0.4",
     "babel-plugin-istanbul": "^6.1.1",
-    "babel-plugin-proxy": "^1.1.0",
     "date-fns": "^2.29.1",
     "debounce": "^1.2.1",
     "esdoc": "^1.1.0",


### PR DESCRIPTION
#2195 introduced the usage of Proxy in wavesurfer.js and enabled the [babel-plugin-proxy](https://www.npmjs.com/package/babel-plugin-proxy). That plugin has this disclaimer though: `It is not suitable for production environments because performance impact is huge.` Ouch.

I removed it and everything still seems to work fine, so it was either not used or harmless (or impacting performance, guess we'll see..)