### PR TITLE
regions plugin: improved delta calculation (resize end)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 wavesurfer.js changelog
 =======================
 
-6.4.1 (12.01.2023)
+6.5.0 (unreleased) (12.01.2023)
 ------------------
 - Regions plugin:
   - Improved delta calculation (resize end) (#2641)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 wavesurfer.js changelog
 =======================
 
+6.4.1 (12.01.2023)
+------------------
+- Regions plugin:
+  - Improved delta calculation (resize end) (#2641)
+
 6.4.0 (05.11.2022)
 ------------------
 - Markers plugin:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 wavesurfer.js changelog
 =======================
 
-6.5.0 (unreleased) (12.01.2023)
+6.5.0 (unreleased)
 ------------------
 - Regions plugin:
   - Improved delta calculation (resize end) (#2641)

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -586,6 +586,8 @@ export class Region {
         const onMove = (event) => {
             const duration = this.wavesurfer.getDuration();
             let orientedEvent = this.util.withOrientation(event, this.vertical);
+            
+            let delta = null
 
             if (event.touches && event.touches.length > 1) {
                 return;
@@ -632,7 +634,10 @@ export class Region {
                     }
                 } else if (resize === 'end') {
                     if (time < this.start + minLength) {
+                        // Calculate the end time based on the min length of the region.
                         time = this.start + minLength;
+                    
+                        delta = time - (this.end + (time - startTime));
                     }
 
                     if (time > duration) {
@@ -641,8 +646,9 @@ export class Region {
                 }
             }
 
-            let delta = time - startTime;
+             if (!delta) delta = time - startTime;
             startTime = time;
+
 
             // Drag
             if (this.drag && drag) {

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -586,8 +586,7 @@ export class Region {
         const onMove = (event) => {
             const duration = this.wavesurfer.getDuration();
             let orientedEvent = this.util.withOrientation(event, this.vertical);
-            
-            let delta = null
+            let delta = null;
 
             if (event.touches && event.touches.length > 1) {
                 return;
@@ -636,7 +635,6 @@ export class Region {
                     if (time < this.start + minLength) {
                         // Calculate the end time based on the min length of the region.
                         time = this.start + minLength;
-                    
                         delta = time - (this.end + (time - startTime));
                     }
 
@@ -646,9 +644,11 @@ export class Region {
                 }
             }
 
-             if (!delta) delta = time - startTime;
-            startTime = time;
+            if (!delta) {
+                delta = time - startTime;
+            }
 
+            startTime = time;
 
             // Drag
             if (this.drag && drag) {


### PR DESCRIPTION
### Short description of changes:
With the use case that I use this library for, users need to be able to resize the regions. When a region was resized and afterward set back to the min length (f.e. 3.1 sec or in HMSM, which is how we show it, 00:00:03:10) it would stay at 3.12sec (00:00:03:12) or 3.14sec (00:00:03:14) or something, but never go back down all the way to 3.1 (00:00:03:10). With these changes, the length of the region can be set back to 3.10 exactly

