### PR TITLE
Use relative paths for dist exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
   "browser": "dist/wavesurfer.js",
   "exports": {
     ".": {
-      "import": "dist/wavesurfer.js",
-      "require": "dist/wavesurfer.min.js"
+      "import": "./dist/wavesurfer.js",
+      "require": "./dist/wavesurfer.min.js"
     },
     "./dist/plugins/*": {
-      "import": "dist/plugins/*.js",
-      "require": "dist/plugins/*.min.js"
+      "import": "./dist/plugins/*.js",
+      "require": "./dist/plugins/*.min.js"
     },
     "./dist/plugins/*.js": {
-      "import": "dist/plugins/*.js",
-      "require": "dist/plugins/*.min.js"
+      "import": "./dist/plugins/*.js",
+      "require": "./dist/plugins/*.min.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
fixes #2792 

This fixed the issue I was having. As soon as I opened in my code editor I was prompted with the error

```
String does not match the pattern of "^\./".
```

This change resolved it and the error I was getting in my app
