### PR TITLE
Multitrack+ allows separate containers to be defined for each track :)

### DIFF
--- a/examples/multitrack.js
+++ b/examples/multitrack.js
@@ -20,9 +20,11 @@ const multitrack = Multitrack.create(
   [
     {
       id: 0,
+      container: document.querySelector('#track0'),
     },
     {
       id: 1,
+      container: document.querySelector('#track1'),
       draggable: false,
       startPosition: 14, // start time relative to the entire multitrack
       url: '/examples/audio/librivox.mp3',
@@ -64,6 +66,7 @@ const multitrack = Multitrack.create(
     },
     {
       id: 2,
+      container: document.querySelector('#track2'),
       draggable: true,
       startPosition: 1,
       startCue: 2.1,
@@ -79,7 +82,6 @@ const multitrack = Multitrack.create(
     },
   ],
   {
-    container: document.body, // required!
     minPxPerSec: 10, // zoom level
     rightButtonDrag: true, // drag tracks with the right mouse button
     cursorWidth: 2,
@@ -140,6 +142,9 @@ document.body.style.color = '#fff'
   <label>
     Zoom: <input type="range" min="10" max="100" value="10" />
   </label>
+  <div id="track0"></div>
+  <div id="track1"></div>
+  <div id="track2"></div>
 
   <div style="margin: 1em 0 2em;">
     <button id="play">Play</button>

--- a/examples/multitrack.js
+++ b/examples/multitrack.js
@@ -20,12 +20,14 @@ const multitrack = Multitrack.create(
   [
     {
       id: 0,
+      hideScrollbar: true,
       container: document.querySelector('#track0'),
     },
     {
       id: 1,
       container: document.querySelector('#track1'),
       draggable: false,
+      hideScrollbar: true,
       startPosition: 14, // start time relative to the entire multitrack
       url: '/examples/audio/librivox.mp3',
       fadeInEnd: 5,
@@ -67,6 +69,7 @@ const multitrack = Multitrack.create(
     {
       id: 2,
       container: document.querySelector('#track2'),
+      hideScrollbar: true,
       draggable: true,
       startPosition: 1,
       startCue: 2.1,

--- a/src/plugins/multitrack.ts
+++ b/src/plugins/multitrack.ts
@@ -163,7 +163,8 @@ class MultiTrack extends EventEmitter<MultitrackEvents> {
       peaks: track.peaks,
       cursorColor: 'transparent',
       cursorWidth: 0,
-      interact: false
+      interact: false,
+      hideScrollbar: true,
     })
 
     // Regions and markers


### PR DESCRIPTION
### Short description of changes:

The current multitrack feature requires a single container for all tracks. This change allows each track to specify a container and will sync audio operations across them, or if a single container is specified, it will use the current functionality of combining them into a single container.

### Breaking in the external API:

None

### Breaking changes in the internal API:

I don't think there are any, although drag 'n drop isn't working (but this is consistent with main)

### Todos/Notes:

The iniital cursor shows up at zero time for each track, then adjusts when played. That's probably an easy fix, I haven't looked into it. I'm a few beers in at this point :)

### Related Issues and other PRs:
