### PR TITLE
Feat: custom render function

### DIFF
--- a/examples/custom-render.js
+++ b/examples/custom-render.js
@@ -1,0 +1,50 @@
+// Custom rendering function
+
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+
+const wavesurfer = WaveSurfer.create({
+  container: document.body,
+  waveColor: 'rgb(200, 0, 200)',
+  progressColor: 'rgb(100, 0, 100)',
+  url: '/examples/audio/demo.wav',
+
+  /**
+   * Render a waveform as a squiggly line
+   * @see https://css-tricks.com/making-an-audio-waveform-visualizer-with-vanilla-javascript/
+   */
+  renderFunction: (channels, ctx) => {
+    const { width, height } = ctx.canvas
+    const scale = channels[0].length / width
+    const step = 10
+
+    ctx.translate(0, height / 2)
+    ctx.strokeStyle = ctx.fillStyle
+    ctx.beginPath()
+
+    for (let i = 0; i < width; i += step * 2) {
+      const index = Math.floor(i * scale)
+      const value = Math.abs(channels[0][index])
+      let x = i
+      let y = value * height
+
+      ctx.moveTo(x, 0)
+      ctx.lineTo(x, y)
+      ctx.arc(x + step / 2, y, step / 2, Math.PI, 0, true)
+      ctx.lineTo(x + step, 0)
+
+      x = x + step
+      y = -y
+      ctx.moveTo(x, 0)
+      ctx.lineTo(x, y)
+      ctx.arc(x + step / 2, y, step / 2, Math.PI, 0, false)
+      ctx.lineTo(x + step, 0)
+    }
+
+    ctx.stroke()
+    ctx.closePath()
+  },
+})
+
+wavesurfer.on('interaction', () => {
+  wavesurfer.play()
+})

--- a/index.html
+++ b/index.html
@@ -164,6 +164,7 @@
           <li><a href="#silence.js">Silence</a></li>
           <li><a href="#pitch.js">Pitch</a></li>
           <li><a href="#split-channels.js">Split channels</a></li>
+          <li><a href="#custom-render.js">Custom render</a></li>
           <li><a href="#react.js">React</a></li>
           <li><a href="#predecoded.js">Pre-decoded</a></li>
           <li><a href="#multitrack.js">Multi-track</a></li>

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -7,7 +7,7 @@ async function decode(audioData: ArrayBuffer, sampleRate: number): Promise<Audio
 }
 
 /** Normalize peaks to -1..1 */
-function normalize<T extends Float32Array[] | Array<number[]>>(channelData: T): T {
+function normalize<T extends Array<Float32Array | number[]>>(channelData: T): T {
   const firstChannel = channelData[0]
   if (firstChannel.some((n) => n > 1 || n < -1)) {
     const length = firstChannel.length
@@ -26,7 +26,7 @@ function normalize<T extends Float32Array[] | Array<number[]>>(channelData: T): 
 }
 
 /** Create an audio buffer from pre-decoded audio data */
-function createBuffer(channelData: Float32Array[] | Array<number[]>, duration: number): AudioBuffer {
+function createBuffer(channelData: Array<Float32Array | number[]>, duration: number): AudioBuffer {
   // If a single array of numbers is passed, make it an array of arrays
   if (typeof channelData[0] === 'number') channelData = [channelData as unknown as number[]]
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -35,7 +35,7 @@ export type WaveSurferOptions = {
   /** Audio URL */
   url?: string
   /** Pre-computed audio data */
-  peaks?: Float32Array[] | Array<number[]>
+  peaks?: Array<Float32Array | number[]>
   /** Pre-computed duration */
   duration?: number
   /** Use an existing media element instead of creating one */
@@ -58,6 +58,8 @@ export type WaveSurferOptions = {
   splitChannels?: WaveSurferOptions[]
   /** The list of plugins to initialize on start */
   plugins?: GenericPlugin[]
+  /** Custom render function */
+  renderFunction?: (peaks: Array<Float32Array | number[]>, ctx: CanvasRenderingContext2D) => void
 }
 
 const defaultOptions = {


### PR DESCRIPTION
I've added a new option `renderFunction: (peaks, ctx) => void` which allows swapping out the default rendering function for a custom one.

<img width="585" alt="Screenshot 2023-06-01 at 08 58 12" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/26b91155-d341-4ec3-a71b-936238361c19">

Resolves https://github.com/katspaugh/wavesurfer.js/discussions/2811