### PR TITLE
V6: change the release branch and publish 6.6.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - v6
 
 permissions:
   contents: write

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "description": "Interactive navigable audio visualization using Web Audio and Canvas",
   "main": "dist/wavesurfer.js",
   "directories": {


### PR DESCRIPTION
V6 releases should be published from the v6 branch, not master.