### PR TITLE
Provide a new time when emitting `interaction` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Have a question about integrating wavesurfer.js on your website? Feel free to as
 ### FAQ
 
 * **Q**: Does wavesurfer support large files?
-* **A**: Since wavesurfer decodes audio entirely in the browser, large files may fail to decode due to memory constrains. We recommend using pre-decoded peaks for large files (see [this example](https://wavesurfer-js.org/examples/#predecoded.js)). You can use a tool like [bbc/audiowaveform](https://github.com/bbc/audiowaveform) to generate peaks.
+* **A**: Since wavesurfer decodes audio entirely in the browser, large files may fail to decode due to memory constraints. We recommend using pre-decoded peaks for large files (see [this example](https://wavesurfer-js.org/examples/#predecoded.js)). You can use a tool like [bbc/audiowaveform](https://github.com/bbc/audiowaveform) to generate peaks.
 
 ## Development
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -100,7 +100,7 @@ export type WaveSurferEvents = {
   /** When the user seeks to a new position */
   seeking: [currentTime: number]
   /** When the user interacts with the waveform (i.g. clicks or drags on it) */
-  interaction: []
+  interaction: [newTime: number]
   /** When the user clicks on the waveform */
   click: [relativeX: number]
   /** When the user drags the cursor */
@@ -194,7 +194,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       this.renderer.on('click', (relativeX) => {
         if (this.options.interact) {
           this.seekTo(relativeX)
-          this.emit('interaction')
+          this.emit('interaction', this.getCurrentTime())
           this.emit('click', relativeX)
         }
       }),
@@ -230,7 +230,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
             this.isPlaying() ? 0 : 200,
           )
 
-          this.emit('interaction')
+          this.emit('interaction', relativeX * this.getDuration())
           this.emit('drag', relativeX)
         }),
       )


### PR DESCRIPTION
### Short description of changes:
We now provide a new time when emitting the `interaction` event. This provides consumers with realtime information about drag events. Before, consumers would need to wait for the debounce. Tested behavior locally.

### Breaking in the external API:
Additional parameter to `interaction` event handlers, but should be non-breaking.

### Breaking changes in the internal API:
None

### Todos/Notes:
None

### Related Issues and other PRs:
https://github.com/katspaugh/wavesurfer.js/issues/2844