### PR TITLE
Fixes minHeight on `.canvases` div

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -344,6 +344,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     const canvasContainer = document.createElement('div')
     const height = this.getHeight()
     canvasContainer.style.height = `${height}px`
+    this.canvasWrapper.style.minHeight = `${height}px`
     this.canvasWrapper.appendChild(canvasContainer)
 
     // A container for progress canvases


### PR DESCRIPTION
If you set a height, the `.canvases` div (`canvasWrapper`) still ends up with `defaultHeight` (128px) because that is set prior to rendering. ie: the value returned from `getHeight()` is different when its set for `.canvases` and its child div.

I'm not sure if this is the best fix. Feels a bit hacky but I didn't have the time to look at it more closely. Figured I'd make the PR to give you a heads up. :)