### PR TITLE
Check for supported mimeType in RecordPlugin

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -2,8 +2,13 @@ async function fetchArrayBuffer(url: string): Promise<ArrayBuffer> {
   return fetch(url).then((response) => response.arrayBuffer())
 }
 
+async function fetchBlob(url: string): Promise<Blob> {
+  return fetch(url).then((response) => response.blob())
+}
+
 const Fetcher = {
   fetchArrayBuffer,
+  fetchBlob,
 }
 
 export default Fetcher

--- a/src/player.ts
+++ b/src/player.ts
@@ -50,11 +50,11 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     }
   }
 
-  protected setSrc(url: string, arrayBuffer?: ArrayBuffer) {
+  protected setSrc(url: string, blob?: Blob) {
     const src = this.media.currentSrc || this.media.src || ''
     if (src === url) return
     this.revokeSrc()
-    const newSrc = arrayBuffer ? URL.createObjectURL(new Blob([arrayBuffer], { type: 'audio/wav' })) : url
+    const newSrc = blob instanceof Blob ? URL.createObjectURL(blob) : url
     this.media.src = newSrc
   }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -298,9 +298,11 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       this.decodedData = Decoder.createBuffer(channelData, duration)
     } else {
       // Fetch and decode the audio of no pre-computed audio data is provided
-      const audio = await Fetcher.fetchArrayBuffer(url)
-      this.setSrc(url, audio)
-      this.decodedData = await Decoder.decode(audio, this.options.sampleRate)
+      const blob = await Fetcher.fetchBlob(url)
+      this.setSrc(url, blob)
+
+      const arrayBuffer = await blob.arrayBuffer()
+      this.decodedData = await Decoder.decode(arrayBuffer, this.options.sampleRate)
     }
 
     this.emit('decode', this.getDuration())


### PR DESCRIPTION
### Short description of changes:

This MR improves `RecordPlugin`:

- allows providing `mimeType` and `audioBitsPerSecond` params when creating a `MediaRecorder` instance;
- if `mimeType` was not provided, automatically detects currently supported type via `MediaRecorder.isTypeSupported()`;
- preserves recorded `mimeType` when loads audio for playback.

### Breaking in the external API:

None

### Breaking changes in the internal API:

- `Player#.setSrc()` for its second optional parameter now  instead of `ArrayBuffer` expects `Blob`, which preserves original audio mimeType within itself.

### Todos/Notes:

None

### Related Issues and other PRs:
Resolves #2836 