### PR TITLE
Fix: duration can be already loaded

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -291,9 +291,11 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       if (!duration) {
         // Wait for the audio duration
         duration =
+          this.getDuration() ||
           (await new Promise((resolve) => {
             this.onceMediaEvent('loadedmetadata', () => resolve(this.getMediaElement().duration))
-          })) || 0
+          })) ||
+          0
       }
       this.decodedData = Decoder.createBuffer(channelData, duration)
     } else {


### PR DESCRIPTION
Resolves #2895.

Duration can be already loaded when an existing audio element is passed, in which case there's no need to wait for the `loadedmetadata` event, it will never be fired.