### PR TITLE
Fix: rename UMD files to .min.cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Alternatively, import it from a CDN as a ES6 module directly in the browser:
 
 Or, as a UMD script tag which exports the library as a global `WaveSurfer` variable:
 ```html
-<script src="https://unpkg.com/wavesurfer.js@beta/dist/wavesurfer.min.js"></script>
+<script src="https://unpkg.com/wavesurfer.js@beta/dist/wavesurfer.min.cjs"></script>
 ```
 
 To import a plugin, e.g. the Timeline plugin:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "7.0.0-beta.8",
+  "version": "7.0.0-beta.9",
   "license": "BSD-3-Clause",
   "author": "katspaugh",
   "description": "Navigable audio waveform player",

--- a/package.json
+++ b/package.json
@@ -26,15 +26,15 @@
   "exports": {
     ".": {
       "import": "./dist/wavesurfer.js",
-      "require": "./dist/wavesurfer.min.js"
+      "require": "./dist/wavesurfer.min.cjs"
     },
     "./plugins/*.js": {
       "import": "./dist/plugins/*.js",
-      "require": "./dist/plugins/*.min.js"
+      "require": "./dist/plugins/*.min.cjs"
     },
     "./dist/plugins/*.js": {
       "import": "./dist/plugins/*.js",
-      "require": "./dist/plugins/*.min.js"
+      "require": "./dist/plugins/*.min.cjs"
     },
     "./dist/*": {
       "import": "./dist/*"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ export default {
     libraryTarget: 'umd',
     libraryExport: 'default',
     globalObject: 'this',
-    filename: '[name].min.js',
+    filename: '[name].min.cjs',
     path: path.resolve('./dist'),
   },
 }

--- a/webpack.config.plugins.js
+++ b/webpack.config.plugins.js
@@ -18,7 +18,7 @@ export default {
     library: '[name]',
     libraryTarget: 'umd',
     libraryExport: 'default',
-    filename: (entry) => `${entry.runtime.toLowerCase()}.min.js`,
+    filename: (entry) => `${entry.runtime.toLowerCase()}.min.cjs`,
     path: path.resolve('./dist/plugins'),
   },
 }


### PR DESCRIPTION
Resolves #2903.

UMD files are now exported as `*.min.cjs` instead of `.min.js` for Node.js to recognize them as CommonJS modules.