### PR TITLE
Fix: height x2

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -311,7 +311,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     const canvas = document.createElement('canvas')
     const length = channelData[0].length
     canvas.width = Math.round((width * (end - start)) / length)
-    canvas.height = height
+    canvas.height = height * pixelRatio
     canvas.style.width = `${Math.floor(canvas.width / pixelRatio)}px`
     canvas.style.height = `${height}px`
     canvas.style.left = `${Math.floor((start * width) / pixelRatio / length)}px`


### PR DESCRIPTION
Fixes #2807

The width was already x2 for high-DPI screens but not the height which resulted in slight distortions when using rounded bars.