### PR TITLE
Regions: fix enableDragSelection when container has padding

### DIFF
--- a/src/draggable.ts
+++ b/src/draggable.ts
@@ -27,12 +27,13 @@ export function makeDraggable(
       const y = e.clientY
 
       if (isDragging || Math.abs(x - startX) >= threshold || Math.abs(y - startY) >= threshold) {
+        const { left, top } = element.getBoundingClientRect()
+
         if (!isDragging) {
           isDragging = true
-          onStart?.(startX, startY)
+          onStart?.(startX - left, startY - top)
         }
 
-        const { left, top } = element.getBoundingClientRect()
         onDrag(x - startX, y - startY, x - left, y - top)
         startX = x
         startY = y


### PR DESCRIPTION
## Short description
Resolves #2919.

Fixes drag selection in the Regions plugin when the container has a padding.

## Implementation details
The draggable function now takes into account the container bbox's left and top in the onDragStart callback.
I also refactored and cleaned up the enableDragSelection function a bit.

## How to test it
Open the Regions example and drag on the waveform to create a region.