### PR TITLE
Spectrogram: same font size for unit labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install --save wavesurfer.js@beta
 import WaveSurfer from 'wavesurfer.js'
 ```
 
-Alternatively, import it from a CDN as a ES6 module directly in the browser:
+Alternatively, import it from a CDN as a ES6 module:
 
 ```html
 <script type="module">
@@ -42,8 +42,12 @@ Or, as a UMD script tag which exports the library as a global `WaveSurfer` varia
 <script src="https://unpkg.com/wavesurfer.js@beta/dist/wavesurfer.min.cjs"></script>
 ```
 
-To import a plugin, e.g. the Timeline plugin:
+To import one of the plugins, e.g. the Timeline plugin:
 ```js
+import Timeline from 'wavesurfer.js/dist/plugins/timeline.js'
+
+// or, with a CDN:
+
 import Timeline from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/timeline.js'
 ```
 
@@ -64,12 +68,12 @@ The "official" plugins have been completely rewritten and enhanced:
  * [Minimap](https://wavesurfer-js.org/examples/#minimap.js) – a small waveform that serves as a scrollbar for the main waveform
  * [Envelope](https://wavesurfer-js.org/examples/#envelope.js) – a graphical interface to add fade-in and -out effects and control volume
  * [Record](https://wavesurfer-js.org/examples/#record.js) – records audio from the microphone and renders a waveform
- * [Spectrogram](https://wavesurfer-js.org/examples/#spectrogram.js) – visualization of an audio frequency spectrum
+ * [Spectrogram](https://wavesurfer-js.org/examples/#spectrogram.js) – visualization of an audio frequency spectrum (written by @akreal)
 
 ## CSS styling
 
 wavesurfer.js v7 is rendered into a Shadow DOM tree. This isolates its CSS from the rest of the web page.
-However, it's still possible to style various wavesurfer.js elements via CSS using the `::part()` pseudo-selector.
+However, it's still possible to style various wavesurfer.js elements with CSS via the `::part()` pseudo-selector.
 For example:
 
 ```css
@@ -127,7 +131,12 @@ Have a question about integrating wavesurfer.js on your website? Feel free to as
 ### FAQ
 
 * **Q**: Does wavesurfer support large files?
-* **A**: Since wavesurfer decodes audio entirely in the browser, large files may fail to decode due to memory constraints. We recommend using pre-decoded peaks for large files (see [this example](https://wavesurfer-js.org/examples/#predecoded.js)). You can use a tool like [bbc/audiowaveform](https://github.com/bbc/audiowaveform) to generate peaks.
+* **A**: Since wavesurfer decodes audio entirely in the browser using Web Audio, large clips may result in an innacurately timed waveform or fail to decode at all due to memory constraints. We recommend using pre-decoded peaks for large files (see [this example](https://wavesurfer-js.org/examples/#predecoded.js)). You can use a tool like [bbc/audiowaveform](https://github.com/bbc/audiowaveform) to generate peaks.
+
+---
+
+* **Q**: What about streaming audio?
+* **A**: Streaming isn't supported because wavesurfer needs to download the entire audio file to decode and render it.
 
 ## Development
 

--- a/examples/vowels.js
+++ b/examples/vowels.js
@@ -22,7 +22,7 @@ containers.forEach((vowelDiv, idx) => {
     waveColor: 'rgb(200, 0, 200)',
     progressColor: 'rgb(100, 0, 100)',
     url: `/examples/audio/${files[idx]}.mp4`,
-    sampleRate: 15e3,
+    sampleRate: 14600,
     interact: false,
     plugins: [
       Spectrogram.create({
@@ -49,14 +49,14 @@ containers.forEach((vowelDiv, idx) => {
   .grid {
     display: flex;
     flex-flow: row wrap;
-    border: 1px solid #333;
+    gap: 2px;
   }
   .grid > div {
-    flex: 1;
     min-width: 120px;
     padding: 0.5rem;
     text-align: center;
     border: 1px solid #333;
+    border-radius: 4px;
     cursor: pointer;
   }
   ::part(spec-labels) {

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -211,12 +211,12 @@ export default class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvent
     }
 
     this.loadLabels(
-      this.options.labelsBackground || 'rgba(68,68,68,0.5)',
+      this.options.labelsBackground,
       '12px',
-      '10px',
+      '12px',
       '',
-      this.options.labelsColor || '#fff',
-      this.options.labelsHzColor || this.options.labelsColor || '#f7f7f7',
+      this.options.labelsColor,
+      this.options.labelsHzColor || this.options.labelsColor,
       'center',
       '#specLabels',
     )
@@ -341,7 +341,7 @@ export default class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvent
     const frequenciesHeight = this.height
     bgFill = bgFill || 'rgba(68,68,68,0)'
     fontSizeFreq = fontSizeFreq || '12px'
-    fontSizeUnit = fontSizeUnit || '10px'
+    fontSizeUnit = fontSizeUnit || '12px'
     fontType = fontType || 'Helvetica'
     textColorFreq = textColorFreq || '#fff'
     textColorUnit = textColorUnit || '#fff'
@@ -386,25 +386,17 @@ export default class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvent
 
         if (i == 0) {
           y = (1 + c) * getMaxY + i - 10
-          // unit label
-          ctx.fillStyle = textColorUnit
-          ctx.font = fontSizeUnit + ' ' + fontType
-          ctx.fillText(units, x + 24, y)
-          // freq label
-          ctx.fillStyle = textColorFreq
-          ctx.font = fontSizeFreq + ' ' + fontType
-          ctx.fillText(label, x, y)
         } else {
           y = (1 + c) * getMaxY - i * 50 + yLabelOffset
-          // unit label
-          ctx.fillStyle = textColorUnit
-          ctx.font = fontSizeUnit + ' ' + fontType
-          ctx.fillText(units, x + 24, y)
-          // freq label
-          ctx.fillStyle = textColorFreq
-          ctx.font = fontSizeFreq + ' ' + fontType
-          ctx.fillText(label, x, y)
         }
+        // unit label
+        ctx.fillStyle = textColorUnit
+        ctx.font = fontSizeUnit + ' ' + fontType
+        ctx.fillText(units, x + 24, y)
+        // freq label
+        ctx.fillStyle = textColorFreq
+        ctx.font = fontSizeFreq + ' ' + fontType
+        ctx.fillText(label, x, y)
       }
     }
   }


### PR DESCRIPTION
## Short description
Align the numeric and unit parts of Spectrogram labels a little bit better.

## Implementation details
Originally, the unit font size was 10px and the numeric value size was 12px. Now they are both 12px and neatly aligned.

I've also updated the readme.

## Screenshots
<img width="130" alt="Screenshot 2023-06-20 at 21 25 57" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/071d5d66-1ab0-47a8-b848-57a109583886">
