### PR TITLE
Add barMinHeight to list of removed options in v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Most options, events, and methods are similar to those in previous versions.
  * `skipLength` – there's no `skipForward` and `skipBackward` methods anymore
  * `splitChannelsOptions` – you should now use `splitChannels` to pass the channel options. Pass `height: 0` to hide a channel. See [this example](https://wavesurfer-js.org/examples/#split-channels.js).
  * `xhr`, `drawingContextAttributes`, `maxCanvasWidth`, `forceDecode` – removed to reduce code complexity
+ * `barMinHeight` - the minimum bar height is now 1 pixel by default
 
 ### Removed methods
  * `getFilters`, `setFilter` – as there's no Web Audio "backend"


### PR DESCRIPTION
## Short description
Just adds a note in the README that the `barMinHeight` property is removed in v7. I went searching for how to achieve this in v7 and found the details in this [discussion](https://github.com/katspaugh/wavesurfer.js/discussions/2815).

## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
