### PR TITLE
Fix: reset media on destroy

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -8,14 +8,12 @@ type PlayerOptions = {
 
 class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   protected media: HTMLMediaElement
-  private isExternalMedia = false
 
   constructor(options: PlayerOptions) {
     super()
 
     if (options.media) {
       this.media = options.media
-      this.isExternalMedia = true
     } else {
       this.media = document.createElement('audio')
     }
@@ -56,15 +54,15 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     this.revokeSrc()
     const newSrc = blob instanceof Blob ? URL.createObjectURL(blob) : url
     this.media.src = newSrc
+    this.media.load()
   }
 
   public destroy() {
     this.media.pause()
     this.revokeSrc()
-
-    if (!this.isExternalMedia) {
-      this.media.remove()
-    }
+    this.media.src = ''
+    // Load resets the media element to its initial state
+    this.media.load()
   }
 
   /** Start playing the audio */

--- a/src/player.ts
+++ b/src/player.ts
@@ -41,15 +41,19 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     return this.onMediaEvent(event, callback, { once: true })
   }
 
+  private getSrc() {
+    return this.media.currentSrc || this.media.src || ''
+  }
+
   private revokeSrc() {
-    const src = this.media.currentSrc || this.media.src || ''
+    const src = this.getSrc()
     if (src.startsWith('blob:')) {
-      URL.revokeObjectURL(this.media.currentSrc)
+      URL.revokeObjectURL(src)
     }
   }
 
   protected setSrc(url: string, blob?: Blob) {
-    const src = this.media.currentSrc || this.media.src || ''
+    const src = this.getSrc()
     if (src === url) return
     this.revokeSrc()
     const newSrc = blob instanceof Blob ? URL.createObjectURL(blob) : url
@@ -57,7 +61,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     this.media.load()
   }
 
-  public destroy() {
+  protected destroy() {
     this.media.pause()
     this.revokeSrc()
     this.media.src = ''


### PR DESCRIPTION
## Short description
Resolves #2940

## Implementation details
The media element's src needs to be cleared on destroy.

## How to test it
Destroy an already playing wavesurfer instance, observe that the sound should stop.