### PR TITLE
Fix: webpack config for plugins

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -1,4 +1,4 @@
-describe('WaveSurfer', () => {
+describe('WaveSurfer basic tests', () => {
   beforeEach((done) => {
     cy.visit('cypress/e2e/index.html')
 

--- a/cypress/e2e/options.cy.js
+++ b/cypress/e2e/options.cy.js
@@ -1,6 +1,6 @@
 const id = '#waveform'
 
-describe('WaveSurfer', () => {
+describe('WaveSurfer options tests', () => {
   beforeEach(() => {
     cy.visit('cypress/e2e/index.html')
 

--- a/cypress/e2e/regions.cy.js
+++ b/cypress/e2e/regions.cy.js
@@ -1,4 +1,4 @@
-describe('WaveSurfer plugins', () => {
+describe('WaveSurfer Regions plugin tests', () => {
   beforeEach((done) => {
     cy.visit('cypress/e2e/index.html')
 

--- a/cypress/e2e/umd.cy.js
+++ b/cypress/e2e/umd.cy.js
@@ -1,0 +1,22 @@
+describe('WaveSurfer UMD module tests', () => {
+  beforeEach((done) => {
+    cy.visit('cypress/e2e/umd.html')
+
+    cy.window().its('WaveSurfer').should('exist')
+    cy.window().its('WaveSurfer.Regions').should('exist')
+    cy.window().its('WaveSurfer.Timeline').should('exist')
+  })
+
+  it('should instantiate WaveSurfer with two plugins', () => {
+    cy.window().then((win) => {
+      return new Promise((resolve) => {
+        const { WaveSurfer } = win
+        win.wavesurfer = win.WaveSurfer.create({
+          container: '#waveform',
+          url: '../../examples/audio/demo.wav',
+          plugins: [WaveSurfer.Regions.create(), WaveSurfer.Timeline.create()],
+        })
+      })
+    })
+  })
+})

--- a/cypress/e2e/umd.cy.js
+++ b/cypress/e2e/umd.cy.js
@@ -1,10 +1,7 @@
 describe('WaveSurfer UMD module tests', () => {
-  beforeEach((done) => {
+  beforeEach(() => {
     cy.visit('cypress/e2e/umd.html')
-
     cy.window().its('WaveSurfer').should('exist')
-    cy.window().its('WaveSurfer.Regions').should('exist')
-    cy.window().its('WaveSurfer.Timeline').should('exist')
   })
 
   it('should instantiate WaveSurfer with two plugins', () => {
@@ -16,6 +13,7 @@ describe('WaveSurfer UMD module tests', () => {
           url: '../../examples/audio/demo.wav',
           plugins: [WaveSurfer.Regions.create(), WaveSurfer.Timeline.create()],
         })
+        resolve()
       })
     })
   })

--- a/cypress/e2e/umd.html
+++ b/cypress/e2e/umd.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WaveSurfer CommonJS Test</title>
-  </head>
-  <body>
-    <div id="waveform" style="width: 600px"></div>
 
     <script type="text/javascript" src="../../dist/wavesurfer.min.cjs"></script>
     <script type="text/javascript" src="../../dist/plugins/regions.min.cjs"></script>
     <script type="text/javascript" src="../../dist/plugins/timeline.min.cjs"></script>
+  </head>
+  <body>
+    <div id="waveform" style="width: 600px"></div>
   </body>
 </html>

--- a/cypress/e2e/umd.html
+++ b/cypress/e2e/umd.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WaveSurfer CommonJS Test</title>
+  </head>
+  <body>
+    <div id="waveform" style="width: 600px"></div>
+
+    <script type="text/javascript" src="../../dist/wavesurfer.min.cjs"></script>
+    <script type="text/javascript" src="../../dist/plugins/regions.min.cjs"></script>
+    <script type="text/javascript" src="../../dist/plugins/timeline.min.cjs"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "7.0.0-beta.11",
+  "version": "7.0.0-beta.12",
   "license": "BSD-3-Clause",
   "author": "katspaugh",
   "description": "Navigable audio waveform player",

--- a/webpack.config.plugins.js
+++ b/webpack.config.plugins.js
@@ -14,7 +14,7 @@ export default {
   },
 
   output: {
-    globalObject: 'WaveSurfer',
+    globalObject: `typeof WaveSurfer !== 'undefined' ? WaveSurfer : this`,
     library: '[name]',
     libraryTarget: 'umd',
     libraryExport: 'default',


### PR DESCRIPTION
## Short description
Resolves #2953

## Implementation details
When importing a UMD module in Node.js, it's interpreted as a CommonJS module and should not assume any global variables.
So I've added a check to export into a global WaveSurfer object if it's available (browser), or export to the global `this` (Node.js).
