### PR TITLE
Release v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - beta
+      - main
 
 permissions:
   contents: write
@@ -20,7 +20,7 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          OLD_VERSION=$(npm show wavesurfer.js@beta version)
+          OLD_VERSION=$(npm show wavesurfer.js version)
           NEW_VERSION=$(node -p 'require("./package.json").version')
           if [ $NEW_VERSION != $OLD_VERSION ]; then
             echo "New version $NEW_VERSION detected"
@@ -63,4 +63,4 @@ jobs:
         if: ${{ steps.version.outputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
-        run: npm publish --tag beta
+        run: npm publish

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # <img src="https://user-images.githubusercontent.com/381895/226091100-f5567a28-7736-4d37-8f84-e08f297b7e1a.png" alt="logo" height="60" valign="middle" /> wavesurfer.js
 
-[![npm](https://img.shields.io/npm/v/wavesurfer.js/beta)](https://www.npmjs.com/package/wavesurfer.js)
+[![npm](https://img.shields.io/npm/v/wavesurfer.js)](https://www.npmjs.com/package/wavesurfer.js)
 
 ## New TypeScript version
 
-wavesurfer.js v7 beta is a TypeScript rewrite of wavesurfer.js that brings several improvements:
+wavesurfer.js v7 is a TypeScript rewrite of wavesurfer.js that brings several improvements:
 
  * Typed API for better development experience
  * Enhanced decoding and rendering performance
@@ -21,7 +21,7 @@ wavesurfer.js v7 beta is a TypeScript rewrite of wavesurfer.js that brings sever
 Try it out:
 
 ```bash
-npm install --save wavesurfer.js@beta
+npm install --save wavesurfer.js
 ```
 ```js
 import WaveSurfer from 'wavesurfer.js'
@@ -31,7 +31,7 @@ Alternatively, import it from a CDN as a ES6 module:
 
 ```html
 <script type="module">
-  import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+  import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
   const wavesurfer = WaveSurfer.create({
     container: '#waveform',
@@ -44,7 +44,7 @@ Alternatively, import it from a CDN as a ES6 module:
 
 Or, as a UMD script tag which exports the library as a global `WaveSurfer` variable:
 ```html
-<script type="text/javascript" src="https://unpkg.com/wavesurfer.js@beta/dist/wavesurfer.min.cjs"></script>
+<script type="text/javascript" src="https://unpkg.com/wavesurfer.js/dist/wavesurfer.min.cjs"></script>
 ```
 
 To import one of the plugins, e.g. the Timeline plugin:
@@ -53,11 +53,11 @@ import Timeline from 'wavesurfer.js/dist/plugins/timeline.js'
 
 // or with a CDN:
 
-import Timeline from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/timeline.js'
+import Timeline from 'https://unpkg.com/wavesurfer.js/dist/plugins/timeline.js'
 
 // or as a script tag
 
-<script type="text/javascript" src="https://unpkg.com/wavesurfer.js@beta/dist/plugins/timeline.min.cjs"></script>
+<script type="text/javascript" src="https://unpkg.com/wavesurfer.js/dist/plugins/timeline.min.cjs"></script>
 ```
 
 TypeScript types are included in the package, so there's no need to install `@types/wavesurfer.js`.

--- a/examples/_preview.js
+++ b/examples/_preview.js
@@ -35,8 +35,8 @@ const loadPreview = (code) => {
     <script type="importmap">
       {
         "imports": {
-          "https://unpkg.com/wavesurfer.js@beta": "../dist/wavesurfer.js",
-          "https://unpkg.com/wavesurfer.js@beta/dist/": "../dist/"
+          "https://unpkg.com/wavesurfer.js": "../dist/wavesurfer.js",
+          "https://unpkg.com/wavesurfer.js/dist/": "../dist/"
         }
       }
     </script>

--- a/examples/all-options.js
+++ b/examples/all-options.js
@@ -1,6 +1,6 @@
 // All wavesurfer options in one place
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const audio = new Audio()
 audio.controls = true

--- a/examples/bars.js
+++ b/examples/bars.js
@@ -1,6 +1,6 @@
 // SoundCloud-style bars
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,6 +1,6 @@
 // A super-basic example
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/custom-render.js
+++ b/examples/custom-render.js
@@ -1,6 +1,6 @@
 // Custom rendering function
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/envelope.js
+++ b/examples/envelope.js
@@ -12,8 +12,8 @@
 </html>
 */
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import EnvelopePlugin from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/envelope.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import EnvelopePlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/envelope.js'
 
 // Create an instance of WaveSurfer
 const wavesurfer = WaveSurfer.create({

--- a/examples/fm-synth.js
+++ b/examples/fm-synth.js
@@ -1,6 +1,6 @@
 // A two-operator FM synth with a real-time waveform
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const wavesurfer = WaveSurfer.create({
   container: '#waveform',

--- a/examples/gradient.js
+++ b/examples/gradient.js
@@ -1,6 +1,6 @@
 // Fancy gradients
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 // Create a canvas gradient
 const ctx = document.createElement('canvas').getContext('2d')

--- a/examples/hover.js
+++ b/examples/hover.js
@@ -1,7 +1,7 @@
 // Hover plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import Hover from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/hover.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import Hover from 'https://unpkg.com/wavesurfer.js/dist/plugins/hover.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/minimap.js
+++ b/examples/minimap.js
@@ -1,7 +1,7 @@
 // Minimap plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import Minimap from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/minimap.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import Minimap from 'https://unpkg.com/wavesurfer.js/dist/plugins/minimap.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/pitch.js
+++ b/examples/pitch.js
@@ -1,4 +1,4 @@
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const pitchWorker = new Worker('/examples/pitch-worker.js', { type: 'module' })
 

--- a/examples/predecoded.js
+++ b/examples/predecoded.js
@@ -1,6 +1,6 @@
 // With pre-decoded audio data
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/react.js
+++ b/examples/react.js
@@ -12,8 +12,8 @@
 const { useRef, useState, useEffect, useCallback } = React
 
 // Import WaveSurfer
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import Timeline from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/timeline.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import Timeline from 'https://unpkg.com/wavesurfer.js/dist/plugins/timeline.js'
 
 // WaveSurfer hook
 const useWavesurfer = (containerRef, options) => {

--- a/examples/record.js
+++ b/examples/record.js
@@ -1,7 +1,7 @@
 // Record plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import RecordPlugin from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/record.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import RecordPlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/record.js'
 
 // Create an instance of WaveSurfer
 const wavesurfer = WaveSurfer.create({

--- a/examples/regions.js
+++ b/examples/regions.js
@@ -1,7 +1,7 @@
 // Regions plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import RegionsPlugin from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/regions.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import RegionsPlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/regions.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/silence.js
+++ b/examples/silence.js
@@ -1,7 +1,7 @@
 // Silence detection example
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import RegionsPlugin from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/regions.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import RegionsPlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/regions.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/soundcloud.js
+++ b/examples/soundcloud.js
@@ -1,6 +1,6 @@
 // Soundcloud-style player
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const canvas = document.createElement('canvas')
 const ctx = canvas.getContext('2d')

--- a/examples/spectrogram.js
+++ b/examples/spectrogram.js
@@ -1,7 +1,7 @@
 // Spectrogram plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import Spectrogram from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/spectrogram.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import Spectrogram from 'https://unpkg.com/wavesurfer.js/dist/plugins/spectrogram.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/speed.js
+++ b/examples/speed.js
@@ -23,7 +23,7 @@
 </html>
 */
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/split-channels.js
+++ b/examples/split-channels.js
@@ -1,6 +1,6 @@
 // Split channels
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/styling.js
+++ b/examples/styling.js
@@ -48,8 +48,8 @@
   </html>
 */
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import RegionsPlugin from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/regions.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import RegionsPlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/regions.js'
 
 // Create a Regions plugin instance
 const wsRegions = RegionsPlugin.create()

--- a/examples/timeline-custom.js
+++ b/examples/timeline-custom.js
@@ -1,7 +1,7 @@
 // Customized Timeline plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import TimelinePlugin from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/timeline.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import TimelinePlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/timeline.js'
 
 // Create a timeline plugin instance with custom options
 const topTimeline = TimelinePlugin.create({

--- a/examples/timeline.js
+++ b/examples/timeline.js
@@ -1,7 +1,7 @@
 // Timeline plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import TimelinePlugin from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/timeline.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import TimelinePlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/timeline.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/video.js
+++ b/examples/video.js
@@ -12,7 +12,7 @@
 </html>
 */
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 // Initialize wavesurfer.js
 const ws = WaveSurfer.create({

--- a/examples/vowels.js
+++ b/examples/vowels.js
@@ -1,7 +1,7 @@
 // American English vowels
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
-import Spectrogram from 'https://unpkg.com/wavesurfer.js@beta/dist/plugins/spectrogram.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import Spectrogram from 'https://unpkg.com/wavesurfer.js/dist/plugins/spectrogram.js'
 
 // Sounds generated with `say -v 'Reed (English (US))' word`
 const vowels = ['i', 'ɪ', 'ɛ', 'æ', 'ɑ', 'ɔ', 'o', 'ʊ', 'u', 'ʌ', 'ə', 'ɝ']

--- a/examples/webaudio.js
+++ b/examples/webaudio.js
@@ -1,6 +1,6 @@
 // Web Audio example
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 // Create your own media element
 const audio = new Audio()

--- a/examples/zoom.js
+++ b/examples/zoom.js
@@ -1,6 +1,6 @@
 // Zooming the waveform
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js@beta'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "7.0.0-beta.12",
+  "version": "7.0.0",
   "license": "BSD-3-Clause",
   "author": "katspaugh",
   "description": "Navigable audio waveform player",


### PR DESCRIPTION
It's been over a month since the beta was released. Since then, 32 pull requests fixing various issues have been merged thanks to the many people who tried out the beta and reported bugs. Kudos to everyone! ❤️ 

v7's original goals didn't include full backwards compatibility but we're now much closer to the previous major wavesurfer.js version in terms of options, methods and plugins.

At this point, I feel confident about publishing v7 as a stable package version. Since it's a major upgrade, most people will have to explicitly upgrade their NPM package or CDN script tag.

There will be a portion of CDN users with no version pinned at all. This release might affect their apps if they use some of the [removed/altered parts of the API](https://github.com/katspaugh/wavesurfer.js#upgrading-from-v6).

**Planned release date:** the 8th of July.