### PR TITLE
Fix: [Regions] prevent resizing when moving over edge

### DIFF
--- a/examples/regions.js
+++ b/examples/regions.js
@@ -23,21 +23,24 @@ ws.on('decode', () => {
   // Regions
   wsRegions.addRegion({
     start: 4,
-    end: 7,
-    content: 'First region',
+    end: 8,
+    content: 'Immovable',
     color: randomColor(),
+    drag: false,
+    resize: false,
   })
   wsRegions.addRegion({
     start: 9,
     end: 10,
-    content: 'Middle region',
+    content: 'Cramped region',
     color: randomColor(),
   })
   wsRegions.addRegion({
     start: 12,
     end: 17,
-    content: 'Last region',
+    content: 'Fixed-size region',
     color: randomColor(),
+    resize: false,
   })
 
   // Markers (zero-length regions)

--- a/examples/regions.js
+++ b/examples/regions.js
@@ -34,6 +34,8 @@ ws.on('decode', () => {
     end: 10,
     content: 'Cramped region',
     color: randomColor(),
+    minLength: 1,
+    maxLength: 10,
   })
   wsRegions.addRegion({
     start: 12,

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -94,7 +94,6 @@ export class Region extends EventEmitter<RegionEvents> {
       transition: background-color 0.2s ease;
       cursor: ${this.drag ? 'grab' : 'default'};
       pointer-events: all;
-      pointer-events: all;
     `,
     )
 


### PR DESCRIPTION
## Short description

Resolves #2946

## Implementation details
Regions will now not resize when dragging past the edges of a waveform.

## How to test it
It can be tested on the updated Regions example by dragging the "fixed-size" region.

## Screenshots
<img width="673" alt="Screenshot 2023-07-02 at 22 10 03" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/19a88eac-ab16-473a-8472-ba168d77155e">
