### PR TITLE
Fix: pause audio on load

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -282,6 +282,8 @@ export class WaveSurfer extends Player<WaveSurferEvents> {
 
   /** Load an audio file by URL, with optional pre-decoded audio data */
   public async load(url: string, channelData?: WaveSurferOptions['peaks'], duration?: number) {
+    if (this.isPlaying()) this.pause()
+
     this.decodedData = null
     this.duration = null
 


### PR DESCRIPTION
## Short description
Resolves #2958

## Implementation details
If a previous audio is playing when `load()` is called, pause it before starting to fetch a new one.

## How to test it
In the React example, press the Play button and then press Change audio.