### PR TITLE
Fix: remove plugins on destroy

### DIFF
--- a/scripts/plugin.ts.template
+++ b/scripts/plugin.ts.template
@@ -2,7 +2,7 @@
  * The PluginName plugin
  */
 
-import BasePlugin from '../base-plugin.js'
+import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
 
 export type PluginNamePluginOptions = {
 }
@@ -10,7 +10,7 @@ export type PluginNamePluginOptions = {
 const defaultOptions = {
 }
 
-export type PluginNamePluginEvents = {
+export type PluginNamePluginEvents = BasePluginEvents & {
 }
 
 export class PluginNamePlugin extends BasePlugin<PluginNamePluginEvents, PluginNamePluginOptions> {

--- a/src/base-plugin.ts
+++ b/src/base-plugin.ts
@@ -1,7 +1,7 @@
 import EventEmitter, { type GeneralEventTypes } from './event-emitter.js'
 import type WaveSurfer from './wavesurfer.js'
 
-type BasePluginEvents = GeneralEventTypes & {
+export type BasePluginEvents = GeneralEventTypes & {
   destroy: []
 }
 

--- a/src/base-plugin.ts
+++ b/src/base-plugin.ts
@@ -1,9 +1,9 @@
 import EventEmitter, { type GeneralEventTypes } from './event-emitter.js'
 import type WaveSurfer from './wavesurfer.js'
 
-export type BasePluginEvents = GeneralEventTypes & {
+export type BasePluginEvents = {
   destroy: []
-}
+} & GeneralEventTypes
 
 export type GenericPlugin = BasePlugin<BasePluginEvents, unknown>
 

--- a/src/base-plugin.ts
+++ b/src/base-plugin.ts
@@ -1,9 +1,13 @@
 import EventEmitter, { type GeneralEventTypes } from './event-emitter.js'
 import type WaveSurfer from './wavesurfer.js'
 
-export type GenericPlugin = BasePlugin<GeneralEventTypes, unknown>
+type BasePluginEvents = GeneralEventTypes & {
+  destroy: []
+}
 
-export class BasePlugin<EventTypes extends GeneralEventTypes, Options> extends EventEmitter<EventTypes> {
+export type GenericPlugin = BasePlugin<BasePluginEvents, unknown>
+
+export class BasePlugin<EventTypes extends BasePluginEvents, Options> extends EventEmitter<EventTypes> {
   protected wavesurfer?: WaveSurfer
   protected subscriptions: (() => void)[] = []
   protected options: Options
@@ -24,6 +28,7 @@ export class BasePlugin<EventTypes extends GeneralEventTypes, Options> extends E
   }
 
   destroy() {
+    this.emit('destroy')
     this.subscriptions.forEach((unsubscribe) => unsubscribe())
   }
 }

--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -2,7 +2,7 @@
  * Envelope is a visual UI for controlling the audio volume and add fade-in and fade-out effects.
  */
 
-import BasePlugin from '../base-plugin.js'
+import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
 import { makeDraggable } from '../draggable.js'
 import EventEmitter from '../event-emitter.js'
 
@@ -33,7 +33,7 @@ const defaultOptions = {
 
 type Options = EnvelopePluginOptions & typeof defaultOptions
 
-export type EnvelopePluginEvents = {
+export type EnvelopePluginEvents = BasePluginEvents & {
   'fade-in-change': [time: number]
   'fade-out-change': [time: number]
   'volume-change': [volume: number]

--- a/src/plugins/hover.ts
+++ b/src/plugins/hover.ts
@@ -2,7 +2,7 @@
  * The Hover plugin follows the mouse and shows a timestamp
  */
 
-import BasePlugin from '../base-plugin.js'
+import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
 
 export type HoverPluginOptions = {
   lineColor?: string
@@ -17,7 +17,7 @@ const defaultOptions = {
   labelSize: 11,
 }
 
-export type HoverPluginEvents = {
+export type HoverPluginEvents = BasePluginEvents & {
   hover: [relX: number]
 }
 

--- a/src/plugins/minimap.ts
+++ b/src/plugins/minimap.ts
@@ -2,7 +2,7 @@
  * Minimap is a tiny copy of the main waveform serving as a navigation tool.
  */
 
-import BasePlugin from '../base-plugin.js'
+import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
 import WaveSurfer, { type WaveSurferOptions } from '../wavesurfer.js'
 
 export type MinimapPluginOptions = {
@@ -16,7 +16,7 @@ const defaultOptions = {
   insertPosition: 'afterend',
 }
 
-export type MinimapPluginEvents = {
+export type MinimapPluginEvents = BasePluginEvents & {
   ready: []
   interaction: []
 }

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -2,7 +2,7 @@
  * Record audio from the microphone, render a waveform and download the audio.
  */
 
-import BasePlugin from '../base-plugin.js'
+import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
 
 export type RecordPluginOptions = {
   realtimeWaveColor?: string
@@ -11,7 +11,7 @@ export type RecordPluginOptions = {
   audioBitsPerSecond?: MediaRecorderOptions['audioBitsPerSecond']
 }
 
-export type RecordPluginEvents = {
+export type RecordPluginEvents = BasePluginEvents & {
   startRecording: []
   stopRecording: []
 }

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -10,14 +10,14 @@ import EventEmitter from '../event-emitter.js'
 
 export type RegionsPluginOptions = undefined
 
-export type RegionsPluginEvents = {
+export type RegionsPluginEvents = BasePluginEvents & {
   'region-created': [region: Region]
   'region-updated': [region: Region]
   'region-clicked': [region: Region, e: MouseEvent]
   'region-double-clicked': [region: Region, e: MouseEvent]
 }
 
-export type RegionEvents = BasePluginEvents & {
+export type RegionEvents = {
   /** Before the region is removed */
   remove: []
   /** When the region's parameters are being updated */

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -4,7 +4,7 @@
  * You can set the color and content of each region, as well as their HTML content.
  */
 
-import BasePlugin from '../base-plugin.js'
+import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
 import { makeDraggable } from '../draggable.js'
 import EventEmitter from '../event-emitter.js'
 
@@ -17,7 +17,7 @@ export type RegionsPluginEvents = {
   'region-double-clicked': [region: Region, e: MouseEvent]
 }
 
-export type RegionEvents = {
+export type RegionEvents = BasePluginEvents & {
   /** Before the region is removed */
   remove: []
   /** When the region's parameters are being updated */

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -344,6 +344,7 @@ export class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, Spect
       this.wrapper.remove()
       this.wrapper = null
     }
+    super.destroy()
   }
 
   createWrapper() {

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -219,7 +219,7 @@ function FFT(bufferSize, sampleRate, windowFunc, alpha) {
 /**
  * Spectrogram plugin for wavesurfer.
  */
-import BasePlugin from '../base-plugin.js'
+import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
 
 export type SpectrogramPluginOptions = {
   /** Selector of element or element in which to render */
@@ -260,7 +260,7 @@ export type SpectrogramPluginOptions = {
   colorMap?: number[][]
 }
 
-export type SpectrogramPluginEvents = {
+export type SpectrogramPluginEvents = BasePluginEvents & {
   ready: []
   click: [relativeX: number]
 }

--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -2,7 +2,7 @@
  * The Timeline plugin adds timestamps and notches under the waveform.
  */
 
-import BasePlugin from '../base-plugin.js'
+import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
 
 export type TimelinePluginOptions = {
   /** The height of the timeline in pixels, defaults to 20 */
@@ -27,7 +27,7 @@ const defaultOptions = {
   height: 20,
 }
 
-export type TimelinePluginEvents = {
+export type TimelinePluginEvents = BasePluginEvents & {
   ready: []
 }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -262,6 +262,14 @@ export class WaveSurfer extends Player<WaveSurferEvents> {
   public registerPlugin<T extends GenericPlugin>(plugin: T): T {
     plugin.init(this)
     this.plugins.push(plugin)
+
+    // Unregister plugin on destroy
+    this.subscriptions.push(
+      plugin.once('destroy', () => {
+        this.plugins = this.plugins.filter((p) => p !== plugin)
+      }),
+    )
+
     return plugin
   }
 
@@ -382,8 +390,8 @@ export class WaveSurfer extends Player<WaveSurferEvents> {
   /** Unmount wavesurfer */
   public destroy() {
     this.emit('destroy')
-    this.subscriptions.forEach((unsubscribe) => unsubscribe())
     this.plugins.forEach((plugin) => plugin.destroy())
+    this.subscriptions.forEach((unsubscribe) => unsubscribe())
     this.timer.destroy()
     this.renderer.destroy()
     super.destroy()


### PR DESCRIPTION
## Short description
As pointed out by @nidhiwebsolutions [here](https://github.com/katspaugh/wavesurfer.js/discussions/2962#discussion-5363339), one might want to destroy a plugin while a wavesurfer instance is still intact. In this case, the plugin should be removed from the list of registered plugins.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Introduced a new event type `destroy` in the `BasePluginEvents` type and emitted the `destroy` event when the `destroy()` method is called in the `BasePlugin` class.
- Bug fix: Modified the `destroy` method of the `SpectrogramPlugin` class to remove the plugin from the list of registered plugins before calling the superclass's `destroy` method.
- Refactor: Updated import statements and extended event types in various plugin classes to include `BasePluginEvents`.

> "Code changes dance,
> Plugins sing in harmony,
> Bugs fade, features shine."
<!-- end of auto-generated comment: release notes by openai -->