### PR TITLE
Build: set compile target to ES6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - beta
+      - main
 
 permissions:
   contents: write

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "7.0.0-beta.13",
+  "version": "7.0.0-beta.14",
   "license": "BSD-3-Clause",
   "author": "katspaugh",
   "description": "Navigable audio waveform player",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES6",
     "lib": [
       "ESNext",
       "DOM"
     ],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "nodenext",
     "allowUmdGlobalAccess": false,
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
## Short description
Resolves #2969

## Implementation details
Target ES6 instead of ES2021, so that it works on more platforms.

Syntax like this:
```js
        this.wavesurfer?.load(this.recordedUrl)
```
will now be compiled to
```js
        (_a = this.wavesurfer) === null || _a === void 0 ? void 0 : _a.load(this.recordedUrl);
```

This increases the minified bundle from 16 Kb to 17 Kb which is fine.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- Chore: Updated the branch name for triggering releases from "beta" to "main" in the `.github/workflows/release.yml` configuration file.

> "From beta to main, a change so plain,
> A chore to update, with no code to gain.
> Branching strategy aligned, unintended consequences declined,
> Review this change, and peace of mind we'll find."
<!-- end of auto-generated comment: release notes by openai -->