### PR TITLE
Fix: fall back to rect if roundRect is not supported (old FF)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,22 +1,25 @@
 name: AI code review
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
-    types: [ready_for_review]
-  # pull_request_target:
-  #   types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
 
 jobs:
-  build:
+  review:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Robin AI Reviewer
-        uses: Integral-Healthcare/robin-ai-reviewer@latest
-        with:
+      - uses: fluxninja/openai-pr-reviewer@latest
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPEN_AI_API_KEY: ${{ secrets.OPEN_AI_API_KEY }}
-          files_to_ignore: |
-            "yarn.lock
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        with:
+          debug: false
+          review_simple_changes: false
+          review_comment_lgtm: false
+          disable_review: true
+          disable_release_notes: true

--- a/examples/all-options.js
+++ b/examples/all-options.js
@@ -106,6 +106,12 @@ const schema = {
     max: 30,
     step: 1,
   },
+  barRadius: {
+    value: 0,
+    min: 1,
+    max: 30,
+    step: 1,
+  },
   peaks: {
     type: 'json',
   },

--- a/examples/predecoded.js
+++ b/examples/predecoded.js
@@ -7,7 +7,7 @@ const wavesurfer = WaveSurfer.create({
   waveColor: 'rgb(200, 0, 200)',
   progressColor: 'rgb(100, 0, 100)',
   barWidth: 10,
-  barRadius: 4,
+  barRadius: 10,
   barGap: 2,
   url: '/examples/audio/demo.wav',
   peaks: [

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -262,6 +262,8 @@ class Renderer extends EventEmitter<RendererEvents> {
     }
     const vScale = (halfHeight / max) * barHeight
 
+    const rectFn = barRadius && 'roundRect' in ctx ? 'roundRect' : 'rect'
+
     ctx.beginPath()
 
     let prevX = 0
@@ -280,7 +282,7 @@ class Renderer extends EventEmitter<RendererEvents> {
         if (options.barAlign === 'top') y = 0
         else if (options.barAlign === 'bottom') y = height - barHeight
 
-        ctx.roundRect(prevX * (barWidth + barGap), y, barWidth, barHeight, barRadius)
+        ctx[rectFn](prevX * (barWidth + barGap), y, barWidth, barHeight, barRadius)
 
         prevX = x
         maxTop = 0


### PR DESCRIPTION
## Short description
Resolves #2979

## Implementation details
Older versions of Firefox didn't have `roundRect` so it should fall back to an unrounded rectangle.

## Screenshots
<img width="1200" alt="Screenshot 2023-07-05 at 22 13 13" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/68be4073-c826-4e78-bc3f-5dd76cf3e2cf">