### PR TITLE
Fix: dragging zero-lengths regions (i.e. markers)

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -66,7 +66,7 @@ export class Region extends EventEmitter<RegionEvents> {
   public resize: boolean
   public color: string
   public content?: HTMLElement
-  public minLength = 0.01
+  public minLength = 0
   public maxLength = Infinity
 
   constructor(params: RegionParams, private totalDuration: number) {
@@ -218,7 +218,7 @@ export class Region extends EventEmitter<RegionEvents> {
     if (
       newStart > 0 &&
       newEnd < this.totalDuration &&
-      newStart < newEnd &&
+      newStart <= newEnd &&
       length >= this.minLength &&
       length <= this.maxLength
     ) {


### PR DESCRIPTION
## Short description
Resolves #2978

## Implementation details
Regions can be zero-length, in which case they become markers, but this wasn't taken into account in the dragging restrictions which assumed a certain minimum length.

## How to test it
Drag one of the markers in the regions example.