### PR TITLE
Fix: ignore right button clicks when dragging

### DIFF
--- a/src/draggable.ts
+++ b/src/draggable.ts
@@ -12,6 +12,9 @@ export function makeDraggable(
   if (!element) return unsub
 
   const down = (e: PointerEvent) => {
+    // Ignore the right mouse button
+    if (e.button === 2) return
+
     e.preventDefault()
     e.stopPropagation()
 


### PR DESCRIPTION
## Short description
Resolves #2963

## Implementation details
Right mouse clicks won't trigger dragging anymore.