### PR TITLE
timeline plugin: restores formatTimeCallback

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -27,7 +27,17 @@ export type TimelinePluginOptions = {
 
 const defaultOptions = {
   height: 20,
-  formatTimeCallback: Function(),
+  formatTimeCallback: (seconds: number) => {
+    if (seconds / 60 > 1) {
+      // calculate minutes and seconds from seconds count
+      const minutes = Math.floor(seconds / 60)
+      seconds = Math.round(seconds % 60)
+      const paddedSeconds = `${seconds < 10 ? '0' : ''}${seconds}`
+      return `${minutes}:${paddedSeconds}`
+    }
+    const rounded = Math.round(seconds * 1000) / 1000
+    return `${rounded}`
+  },
 }
 
 export type TimelinePluginEvents = BasePluginEvents & {
@@ -40,7 +50,6 @@ export class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePlu
 
   constructor(options?: TimelinePluginOptions) {
     super(options || {})
-    defaultOptions.formatTimeCallback = this.defaultFormatTime
 
     this.options = Object.assign({}, defaultOptions, options)
     this.timelineWrapper = this.initTimelineWrapper()
@@ -87,18 +96,6 @@ export class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePlu
     const div = document.createElement('div')
     div.setAttribute('part', 'timeline')
     return div
-  }
-
-  private defaultFormatTime(seconds: number): string {
-    if (seconds / 60 > 1) {
-      // calculate minutes and seconds from seconds count
-      const minutes = Math.floor(seconds / 60)
-      seconds = Math.round(seconds % 60)
-      const paddedSeconds = `${seconds < 10 ? '0' : ''}${seconds}`
-      return `${minutes}:${paddedSeconds}`
-    }
-    const rounded = Math.round(seconds * 1000) / 1000
-    return `${rounded}`
   }
 
   // Return how many seconds should be between each notch

--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -21,10 +21,13 @@ export type TimelinePluginOptions = {
   secondaryLabelInterval?: number
   /** Custom inline style to apply to the container */
   style?: Partial<CSSStyleDeclaration> | string
+  /** Turn the time into a suitable label for the time. */
+  formatTimeCallback?: (seconds: number) => string
 }
 
 const defaultOptions = {
   height: 20,
+  formatTimeCallback: Function(),
 }
 
 export type TimelinePluginEvents = BasePluginEvents & {
@@ -37,6 +40,7 @@ export class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePlu
 
   constructor(options?: TimelinePluginOptions) {
     super(options || {})
+    defaultOptions.formatTimeCallback = this.defaultFormatTime
 
     this.options = Object.assign({}, defaultOptions, options)
     this.timelineWrapper = this.initTimelineWrapper()
@@ -85,7 +89,7 @@ export class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePlu
     return div
   }
 
-  private formatTime(seconds: number): string {
+  private defaultFormatTime(seconds: number): string {
     if (seconds / 60 > 1) {
       // calculate minutes and seconds from seconds count
       const minutes = Math.floor(seconds / 60)
@@ -194,7 +198,7 @@ export class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePlu
       if (isPrimary || isSecondary) {
         notch.style.height = '100%'
         notch.style.textIndent = '3px'
-        notch.textContent = this.formatTime(i)
+        notch.textContent = this.options.formatTimeCallback(i)
         if (isPrimary) notch.style.opacity = '1'
       }
 


### PR DESCRIPTION
## Short description
Restores the timeline plugin formatTimeCallback function from v6.

## Implementation details
copied over from v6

## How to test it


## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
