### PR TITLE
Fix: [Regions] resizing when start is 0

### DIFF
--- a/examples/_preview.js
+++ b/examples/_preview.js
@@ -16,16 +16,19 @@ const loadPreview = (code) => {
     <title>wavesurfer.js examples</title>
     <style>
       html {
-        padding: 1rem;
         font-family: sans-serif;
       }
       body {
         margin: 0;
+        padding: 1rem;
       }
       @media (prefers-color-scheme: dark) {
         body {
           background: #333;
           color: #eee;
+        }
+        a {
+          color: #fff;
         }
       }
       input {

--- a/examples/regions.js
+++ b/examples/regions.js
@@ -22,12 +22,12 @@ const randomColor = () => `rgba(${random(0, 255)}, ${random(0, 255)}, ${random(0
 ws.on('decode', () => {
   // Regions
   wsRegions.addRegion({
-    start: 4,
+    start: 0,
     end: 8,
-    content: 'Immovable',
+    content: 'Resize me',
     color: randomColor(),
     drag: false,
-    resize: false,
+    resize: true,
   })
   wsRegions.addRegion({
     start: 9,
@@ -40,7 +40,7 @@ ws.on('decode', () => {
   wsRegions.addRegion({
     start: 12,
     end: 17,
-    content: 'Fixed-size region',
+    content: 'Drag me',
     color: randomColor(),
     resize: false,
   })

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
           color: #eee;
         }
         body a {
-          color: #fafafa;
+          color: #fff;
         }
         iframe {
           border-color: #444;

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -57,7 +57,7 @@ export type RegionParams = {
   maxLength?: number
 }
 
-export class Region extends EventEmitter<RegionEvents> {
+class SingleRegion extends EventEmitter<RegionEvents> {
   public element: HTMLElement
   public id: string
   public start: number
@@ -397,7 +397,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     }
 
     const duration = this.wavesurfer.getDuration()
-    const region = new Region(options, duration)
+    const region = new SingleRegion(options, duration)
 
     if (!duration) {
       this.subscriptions.push(
@@ -449,7 +449,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         const end = ((x + initialSize) / width) * duration
 
         // Create a region but don't save it until the drag ends
-        region = new Region(
+        region = new SingleRegion(
           {
             ...options,
             start,
@@ -484,3 +484,4 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
 }
 
 export default RegionsPlugin
+export type Region = SingleRegion

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -57,7 +57,7 @@ export type RegionParams = {
   maxLength?: number
 }
 
-class Region extends EventEmitter<RegionEvents> {
+export class Region extends EventEmitter<RegionEvents> {
   public element: HTMLElement
   public id: string
   public start: number
@@ -216,8 +216,8 @@ class Region extends EventEmitter<RegionEvents> {
     const length = newEnd - newStart
 
     if (
-      newStart > 0 &&
-      newEnd < this.totalDuration &&
+      newStart >= 0 &&
+      newEnd <= this.totalDuration &&
       newStart <= newEnd &&
       length >= this.minLength &&
       length <= this.maxLength


### PR DESCRIPTION
## Short description
Resolves #2998

## Implementation details
Resizing had a `start > 0` condition that should be `>=`.

## How to test it
Can be tested with the first region in the regions example.

## Screenshots
<img width="561" alt="Screenshot 2023-07-11 at 08 47 42" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/88425262-8b2b-4624-b453-9abdaf5561dd">