### PR TITLE
Fix: [Envelope] react to media element volume changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "license": "BSD-3-Clause",
   "author": "katspaugh",
   "description": "Navigable audio waveform player",

--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -210,7 +210,14 @@ class EnvelopePlugin extends BasePlugin<EnvelopePluginEvents, EnvelopePluginOpti
     this.initSvg()
     this.initFadeEffects()
 
+    // Sync the plugin's volume with the media element volume
+    const media = this.wavesurfer.getMediaElement()
+    const onMediaVolumeChange = () => this.setVolume(media.volume)
+    media.addEventListener('volumechange', onMediaVolumeChange)
+
     this.subscriptions.push(
+      () => media.removeEventListener('volumechange', onMediaVolumeChange),
+
       this.wavesurfer.on('redraw', () => {
         const duration = this.wavesurfer?.getDuration()
         if (!duration) return


### PR DESCRIPTION
## Short description
Resolves #2995

## Implementation details
The Envelope plugin now listens to media element volume changes and sets its GainNode volume to the same value.
This allows setting the audio volume via `wavesurfer.setVolume()` and not just `envelope.setVolume()`.
