### PR TITLE
Fix: export .min.js as main from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ wavesurfer.js v7 is a TypeScript rewrite of wavesurfer.js that brings several im
 
 ---
 
-Try it out:
+## Getting started
+
+Install and import the package:
 
 ```bash
 npm install --save wavesurfer.js
@@ -27,11 +29,11 @@ npm install --save wavesurfer.js
 import WaveSurfer from 'wavesurfer.js'
 ```
 
-Alternatively, import it from a CDN as a ES6 module:
+Alternatively, import it from a CDN as an ES6 module:
 
 ```html
 <script type="module">
-  import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+  import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
   const wavesurfer = WaveSurfer.create({
     container: '#waveform',
@@ -44,20 +46,20 @@ Alternatively, import it from a CDN as a ES6 module:
 
 Or, as a UMD script tag which exports the library as a global `WaveSurfer` variable:
 ```html
-<script type="text/javascript" src="https://unpkg.com/wavesurfer.js/dist/wavesurfer.min.js"></script>
+<script src="https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.min.js"></script>
 ```
 
 To import one of the plugins, e.g. the Timeline plugin:
 ```js
 import Timeline from 'wavesurfer.js/dist/plugins/timeline.js'
 
-// or with a CDN:
+// or from a CDN:
 
-import Timeline from 'https://unpkg.com/wavesurfer.js/dist/plugins/timeline.js'
+import Timeline from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/timeline.esm.js'
 
 // or as a script tag
 
-<script type="text/javascript" src="https://unpkg.com/wavesurfer.js/dist/plugins/timeline.min.js"></script>
+<script src="https://unpkg.com/wavesurfer.js@7/dist/plugins/timeline.min.js"></script>
 ```
 
 TypeScript types are included in the package, so there's no need to install `@types/wavesurfer.js`.

--- a/examples/_preview.js
+++ b/examples/_preview.js
@@ -4,6 +4,8 @@ const textarea = document.querySelector('textarea')
 const loadPreview = (code) => {
   const html = code.replace(/\n/g, '').match(/<html>(.+?)<\/html>/gm) || []
   const script = code.replace(/<\/script>/g, '')
+        .replace(/https:\/\/unpkg\.com\/wavesurfer.js@7/g, '..')
+        .replace(/\.esm\.js/g, '.js')
   const isBabel = script.includes('@babel')
 
   // Start of iframe template
@@ -35,14 +37,6 @@ const loadPreview = (code) => {
         vertical-align: middle;
       }
     </style>
-    <script type="importmap">
-      {
-        "imports": {
-          "https://unpkg.com/wavesurfer.js": "../dist/wavesurfer.js",
-          "https://unpkg.com/wavesurfer.js/dist/": "../dist/"
-        }
-      }
-    </script>
   </head>
 
   <body>

--- a/examples/all-options.js
+++ b/examples/all-options.js
@@ -1,6 +1,6 @@
 // All wavesurfer options in one place
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const audio = new Audio()
 audio.controls = true

--- a/examples/bars.js
+++ b/examples/bars.js
@@ -1,6 +1,6 @@
 // SoundCloud-style bars
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,6 +1,6 @@
 // A super-basic example
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/custom-render.js
+++ b/examples/custom-render.js
@@ -1,6 +1,6 @@
 // Custom rendering function
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/envelope.js
+++ b/examples/envelope.js
@@ -12,8 +12,8 @@
 </html>
 */
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import EnvelopePlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/envelope.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import EnvelopePlugin from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/envelope.esm.js'
 
 // Create an instance of WaveSurfer
 const wavesurfer = WaveSurfer.create({

--- a/examples/fm-synth.js
+++ b/examples/fm-synth.js
@@ -1,6 +1,6 @@
 // A two-operator FM synth with a real-time waveform
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const wavesurfer = WaveSurfer.create({
   container: '#waveform',

--- a/examples/gradient.js
+++ b/examples/gradient.js
@@ -1,6 +1,6 @@
 // Fancy gradients
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 // Create a canvas gradient
 const ctx = document.createElement('canvas').getContext('2d')

--- a/examples/hover.js
+++ b/examples/hover.js
@@ -1,7 +1,7 @@
 // Hover plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import Hover from 'https://unpkg.com/wavesurfer.js/dist/plugins/hover.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import Hover from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/hover.esm.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/minimap.js
+++ b/examples/minimap.js
@@ -1,7 +1,7 @@
 // Minimap plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import Minimap from 'https://unpkg.com/wavesurfer.js/dist/plugins/minimap.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import Minimap from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/minimap.esm.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/pitch.js
+++ b/examples/pitch.js
@@ -1,4 +1,4 @@
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const pitchWorker = new Worker('/examples/pitch-worker.js', { type: 'module' })
 

--- a/examples/predecoded.js
+++ b/examples/predecoded.js
@@ -1,6 +1,6 @@
 // With pre-decoded audio data
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/react.js
+++ b/examples/react.js
@@ -12,8 +12,8 @@
 const { useRef, useState, useEffect, useCallback } = React
 
 // Import WaveSurfer
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import Timeline from 'https://unpkg.com/wavesurfer.js/dist/plugins/timeline.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import Timeline from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/timeline.esm.js'
 
 // WaveSurfer hook
 const useWavesurfer = (containerRef, options) => {

--- a/examples/record.js
+++ b/examples/record.js
@@ -1,7 +1,7 @@
 // Record plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import RecordPlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/record.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import RecordPlugin from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/record.esm.js'
 
 // Create an instance of WaveSurfer
 const wavesurfer = WaveSurfer.create({

--- a/examples/regions.js
+++ b/examples/regions.js
@@ -1,7 +1,7 @@
 // Regions plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import RegionsPlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/regions.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import RegionsPlugin from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/regions.esm.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/silence.js
+++ b/examples/silence.js
@@ -1,7 +1,7 @@
 // Silence detection example
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import RegionsPlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/regions.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import RegionsPlugin from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/regions.esm.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/soundcloud.js
+++ b/examples/soundcloud.js
@@ -1,6 +1,6 @@
 // Soundcloud-style player
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const canvas = document.createElement('canvas')
 const ctx = canvas.getContext('2d')

--- a/examples/spectrogram.js
+++ b/examples/spectrogram.js
@@ -1,7 +1,7 @@
 // Spectrogram plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import Spectrogram from 'https://unpkg.com/wavesurfer.js/dist/plugins/spectrogram.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import Spectrogram from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/spectrogram.esm.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/speed.js
+++ b/examples/speed.js
@@ -23,7 +23,7 @@
 </html>
 */
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/split-channels.js
+++ b/examples/split-channels.js
@@ -1,6 +1,6 @@
 // Split channels
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/examples/styling.js
+++ b/examples/styling.js
@@ -48,8 +48,8 @@
   </html>
 */
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import RegionsPlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/regions.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import RegionsPlugin from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/regions.esm.js'
 
 // Create a Regions plugin instance
 const wsRegions = RegionsPlugin.create()

--- a/examples/timeline-custom.js
+++ b/examples/timeline-custom.js
@@ -1,7 +1,7 @@
 // Customized Timeline plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import TimelinePlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/timeline.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import TimelinePlugin from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/timeline.esm.js'
 
 // Create a timeline plugin instance with custom options
 const topTimeline = TimelinePlugin.create({

--- a/examples/timeline.js
+++ b/examples/timeline.js
@@ -1,7 +1,7 @@
 // Timeline plugin
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import TimelinePlugin from 'https://unpkg.com/wavesurfer.js/dist/plugins/timeline.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import TimelinePlugin from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/timeline.esm.js'
 
 // Create an instance of WaveSurfer
 const ws = WaveSurfer.create({

--- a/examples/video.js
+++ b/examples/video.js
@@ -12,7 +12,7 @@
 </html>
 */
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 // Initialize wavesurfer.js
 const ws = WaveSurfer.create({

--- a/examples/vowels.js
+++ b/examples/vowels.js
@@ -1,7 +1,7 @@
 // American English vowels
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
-import Spectrogram from 'https://unpkg.com/wavesurfer.js/dist/plugins/spectrogram.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+import Spectrogram from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/spectrogram.esm.js'
 
 // Sounds generated with `say -v 'Reed (English (US))' word`
 const vowels = ['i', 'ɪ', 'ɛ', 'æ', 'ɑ', 'ɔ', 'o', 'ʊ', 'u', 'ʌ', 'ə', 'ɝ']

--- a/examples/webaudio.js
+++ b/examples/webaudio.js
@@ -1,6 +1,6 @@
 // Web Audio example
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 // Create your own media element
 const audio = new Audio()

--- a/examples/zoom.js
+++ b/examples/zoom.js
@@ -1,6 +1,6 @@
 // Zooming the waveform
 
-import WaveSurfer from 'https://unpkg.com/wavesurfer.js'
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
 const wavesurfer = WaveSurfer.create({
   container: document.body,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "license": "BSD-3-Clause",
   "author": "katspaugh",
   "description": "Navigable audio waveform player",
@@ -21,7 +21,7 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/wavesurfer.esm.js",
+  "main": "./dist/wavesurfer.min.js",
   "module": "./dist/wavesurfer.esm.js",
   "browser": "./dist/wavesurfer.esm.js",
   "types": "./dist/wavesurfer.d.ts",


### PR DESCRIPTION
In v6, `https://unpkg.com/wavesurfer.js` was loading a UMD script, and now it's loading an ES6 module.

This breaks it for people who are importing an unversioned script, so I'm restoring the previous behavior where the `main` field in `package.json` points to a UMD script (`.min.js`).