### PR TITLE
Feat: [Record] decouple real-time waveform and recorded audio

### DIFF
--- a/examples/record.js
+++ b/examples/record.js
@@ -11,9 +11,7 @@ const wavesurfer = WaveSurfer.create({
 })
 
 // Initialize the Record plugin
-const record = wavesurfer.registerPlugin(RecordPlugin.create({
-  mimeType: 'audio/mp4',
-}))
+const record = wavesurfer.registerPlugin(RecordPlugin.create())
 
 // Render recorded audio
 record.on('record-end', (blob) => {
@@ -31,7 +29,7 @@ record.on('record-end', (blob) => {
   const link = container.appendChild(document.createElement('a'))
   Object.assign(link, {
     href: recordedUrl,
-    download: 'recording.mp4',
+    download: 'recording.' + blob.type.split(';')[0].split('/')[1] || 'webm',
     textContent: 'Download recording',
     style: 'display: block; margin: 1rem 0 2rem',
   })

--- a/examples/record.js
+++ b/examples/record.js
@@ -11,7 +11,9 @@ const wavesurfer = WaveSurfer.create({
 })
 
 // Initialize the Record plugin
-const record = wavesurfer.registerPlugin(RecordPlugin.create())
+const record = wavesurfer.registerPlugin(RecordPlugin.create({
+  mimeType: 'audio/mp4',
+}))
 
 // Render recorded audio
 record.on('record-end', (blob) => {
@@ -29,7 +31,7 @@ record.on('record-end', (blob) => {
   const link = container.appendChild(document.createElement('a'))
   Object.assign(link, {
     href: recordedUrl,
-    download: 'recording.wav',
+    download: 'recording.mp4',
     textContent: 'Download recording',
     style: 'display: block; margin: 1rem 0 2rem',
   })

--- a/examples/record.js
+++ b/examples/record.js
@@ -14,7 +14,7 @@ const wavesurfer = WaveSurfer.create({
 const record = wavesurfer.registerPlugin(RecordPlugin.create())
 
 // Render recorded audio
-record.on('stopRecording', (blob) => {
+record.on('record-end', (blob) => {
   const recordedUrl = URL.createObjectURL(blob)
   const container = document.querySelector('#recordings')
 

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -31,7 +31,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   }
 
   private renderMicStream(stream: MediaStream): () => void {
-    const audioContext = new AudioContext({ sampleRate: 8000 })
+    const audioContext = new AudioContext()
     const source = audioContext.createMediaStreamSource(stream)
     const analyser = audioContext.createAnalyser()
     source.connect(analyser)

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -14,8 +14,8 @@ export type RecordPluginOptions = {
 }
 
 export type RecordPluginEvents = BasePluginEvents & {
-  startRecording: []
-  stopRecording: [blob: Blob]
+  'record-start': []
+  'record-end': [blob: Blob]
 }
 
 const MIME_TYPES = ['audio/webm', 'audio/wav', 'audio/mpeg', 'audio/mp4', 'audio/mp3']
@@ -110,7 +110,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     mediaRecorder.onstop = () => {
       const blob = new Blob(recordedChunks, { type: mediaRecorder.mimeType })
 
-      this.emit('stopRecording', blob)
+      this.emit('record-end', blob)
 
       if (this.options.renderRecordedAudio !== false) {
         this.wavesurfer?.load(URL.createObjectURL(blob))
@@ -119,7 +119,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
 
     mediaRecorder.start()
 
-    this.emit('startRecording')
+    this.emit('record-start')
   }
 
   /** Check if the audio is being recorded */


### PR DESCRIPTION
## Short description
Resolves #3017

## Implementation details
This PR refactors and introduces breaking changes in the Record plugin API. It will be released in 7.1.0.

The Record plugin will now continuously monitor microphone audio and render a real-time waveform for it.
It can be stopped by calling the `stopMic()` method.

Events renamed:
* `startRecording` -> `record-start`
* `stopRecording` -> `record-end`

Recorded audio will *not* be rendered in the same wavesurfer instance anymore. Instead, the `record-end` event will return a blob that can be rendered in another wavesurfer instance.

## Screenshots
<img width="667" alt="Screenshot 2023-07-14 at 10 38 07" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/f0fcec1c-ec5e-4815-a451-0a42e4269e4b">
