### PR TITLE
Fix: restore mediaControls

### DIFF
--- a/examples/all-options.js
+++ b/examples/all-options.js
@@ -2,11 +2,6 @@
 
 import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 
-const audio = new Audio()
-audio.controls = true
-audio.style.width = '100%'
-document.body.appendChild(audio)
-
 const options = {
   /** HTML element or CSS selector (required) */
   container: 'body',
@@ -40,12 +35,8 @@ const options = {
   fillParent: true,
   /** Audio URL */
   url: '/examples/audio/audio.wav',
-  /** Pre-computed audio data */
-  peaks: undefined,
-  /** Pre-computed duration */
-  duration: undefined,
-  /** Use an existing media element instead of creating one */
-  media: audio,
+  /** Whether to show default audio element controls */
+  mediaControls: true,
   /** Play the audio on load */
   autoplay: false,
   /** Pass false to disable clicks on the waveform */

--- a/src/player.ts
+++ b/src/player.ts
@@ -2,6 +2,7 @@ import EventEmitter, { type GeneralEventTypes } from './event-emitter.js'
 
 type PlayerOptions = {
   media?: HTMLMediaElement
+  mediaControls?: boolean
   autoplay?: boolean
   playbackRate?: number
 }
@@ -18,6 +19,10 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
       this.media = document.createElement('audio')
     }
 
+    // Controls
+    if (options.mediaControls) {
+      this.media.controls = true
+    }
     // Autoplay
     if (options.autoplay) {
       this.media.autoplay = true

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -25,7 +25,7 @@ class Renderer extends EventEmitter<RendererEvents> {
   private resizeObserver: ResizeObserver | null = null
   private isDragging = false
 
-  constructor(options: WaveSurferOptions) {
+  constructor(options: WaveSurferOptions, audioElement?: HTMLElement) {
     super()
 
     this.options = options
@@ -49,6 +49,10 @@ class Renderer extends EventEmitter<RendererEvents> {
     this.canvasWrapper = shadow.querySelector('.canvases') as HTMLElement
     this.progressWrapper = shadow.querySelector('.progress') as HTMLElement
     this.cursor = shadow.querySelector('.cursor') as HTMLElement
+
+    if (audioElement) {
+      shadow.appendChild(audioElement)
+    }
 
     this.initEvents()
   }
@@ -111,6 +115,10 @@ class Renderer extends EventEmitter<RendererEvents> {
       <style>
         :host {
           user-select: none;
+        }
+        :host audio {
+          display: block;
+          width: 100%;
         }
         :host .scroll {
           overflow-x: auto;

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -40,6 +40,8 @@ export type WaveSurferOptions = {
   duration?: number
   /** Use an existing media element instead of creating one */
   media?: HTMLMediaElement
+  /** Whether to show default audio element controls */
+  mediaControls?: boolean
   /** Play the audio on load */
   autoplay?: boolean
   /** Pass false to disable clicks on the waveform */
@@ -131,33 +133,26 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   constructor(options: WaveSurferOptions) {
     super({
       media: options.media,
+      mediaControls: options.mediaControls,
       autoplay: options.autoplay,
       playbackRate: options.audioRate,
     })
 
     this.options = Object.assign({}, defaultOptions, options)
-
     this.timer = new Timer()
 
-    this.renderer = new Renderer(this.options)
+    const audioElement = !options.media ? this.getMediaElement() : undefined
+    this.renderer = new Renderer(this.options, audioElement)
 
     this.initPlayerEvents()
     this.initRendererEvents()
     this.initTimerEvents()
     this.initPlugins()
 
+    // Load audio if URL is passed or an external media with an src
     const url = this.options.url || this.options.media?.currentSrc || this.options.media?.src
     if (url) {
       this.load(url, this.options.peaks, this.options.duration)
-    }
-  }
-
-  public setOptions(options: Partial<WaveSurferOptions>) {
-    this.options = Object.assign({}, this.options, options)
-    this.renderer.setOptions(this.options)
-
-    if (options.audioRate) {
-      this.setPlaybackRate(options.audioRate)
     }
   }
 
@@ -256,6 +251,19 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.options.plugins.forEach((plugin) => {
       this.registerPlugin(plugin)
     })
+  }
+
+  /** Set new wavesurfer options and re-render it */
+  public setOptions(options: Partial<WaveSurferOptions>) {
+    this.options = Object.assign({}, this.options, options)
+    this.renderer.setOptions(this.options)
+
+    if (options.audioRate) {
+      this.setPlaybackRate(options.audioRate)
+    }
+    if (options.mediaControls != null) {
+      this.getMediaElement().controls = options.mediaControls
+    }
   }
 
   /** Register a wavesurfer.js plugin */


### PR DESCRIPTION
## Short description
Resolves #3025

## Implementation details
An internally created audio element is now added to the shadow DOM. If mediaControls is set, controls=true will be added to the element.

## Screenshots
<img width="650" alt="Screenshot 2023-07-19 at 09 23 29" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/3f8448b1-2871-4d84-9879-1b847ac823fd">