### PR TITLE
Fix: [Regions] support overlapping regions for region-in / region-out events

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -320,13 +320,13 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         const nowActiveRegions = this.regions.filter(region => region.start <= currentTime && region.end >= currentTime)
 
         for (const newRegion of prevActiveRegions.filter(region => !nowActiveRegions.includes(region))) {
-            this.emit('region-out', newRegion)
-            prevActiveRegions = prevActiveRegions.filter(region => region != newRegion)
+          this.emit('region-out', newRegion)
+          prevActiveRegions = prevActiveRegions.filter(region => region != newRegion)
         }
 
         for (const newRegion of nowActiveRegions.filter(region => !prevActiveRegions.includes(region))) {
-            this.emit('region-in', newRegion)
-            prevActiveRegions.push(newRegion)
+          this.emit('region-in', newRegion)
+          prevActiveRegions.push(newRegion)
         }
       }),
     )

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -313,20 +313,20 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     this.wavesurfer.getWrapper().appendChild(this.regionsContainer)
 
     // Detect when a region is being played
-    let activeRegion: Region | null = null
+    let prevActiveRegions: Region[] = []
 
     this.subscriptions.push(
       this.wavesurfer.on('timeupdate', (currentTime) => {
-        const playedRegion = this.regions.find((region) => region.start <= currentTime && region.end >= currentTime)
+        const nowActiveRegions = this.regions.filter(region => region.start <= currentTime && region.end >= currentTime)
 
-        if (activeRegion && activeRegion !== playedRegion) {
-          this.emit('region-out', activeRegion)
-          activeRegion = null
+        for (const newRegion of prevActiveRegions.filter(region => !nowActiveRegions.includes(region))) {
+            this.emit('region-out', newRegion)
+            prevActiveRegions = prevActiveRegions.filter(region => region != newRegion)
         }
 
-        if (playedRegion && playedRegion !== activeRegion) {
-          activeRegion = playedRegion
-          this.emit('region-in', playedRegion)
+        for (const newRegion of nowActiveRegions.filter(region => !prevActiveRegions.includes(region))) {
+            this.emit('region-in', newRegion)
+            prevActiveRegions.push(newRegion)
         }
       }),
     )


### PR DESCRIPTION
## Short description
This PR enables overlapping regions to receive in/out events

## Implementation details
A region array tracks diffs going in and out, emitting appropriate events as they mutate

## How to test it
Overlap two regions and monitor for region-in / region-out events

## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
