### PR TITLE
Fix: [Envelope] handle 0 volume

### DIFF
--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -301,6 +301,7 @@ class EnvelopePlugin extends BasePlugin<EnvelopePluginEvents, EnvelopePluginOpti
   }
 
   private invertNaturalVolume(value: number): number {
+    if (value === 0) return value
     const minValue = 0.0001
     const maxValue = 1
     const interpolatedValue = Math.pow((value - minValue) / (maxValue - minValue), 1 / this.naturalVolumeExponent)


### PR DESCRIPTION
## Short description
Resolves #3032

## Implementation details
Setting the volume to 0 resulted in a NaN value in `invertNaturalVolume`. It will now return 0 immediately.