### PR TITLE
Feat: [Spectrogram] option to split channels

### DIFF
--- a/examples/spectrogram.js
+++ b/examples/spectrogram.js
@@ -8,7 +8,7 @@ const ws = WaveSurfer.create({
   container: '#waveform',
   waveColor: 'rgb(200, 0, 200)',
   progressColor: 'rgb(100, 0, 100)',
-  url: '/examples/audio/demo.wav',
+  url: '/examples/audio/audio.wav',
   sampleRate: 22050,
 })
 
@@ -16,7 +16,8 @@ const ws = WaveSurfer.create({
 ws.registerPlugin(
   Spectrogram.create({
     labels: true,
-    height: 256,
+    height: 200,
+    splitChannels: true,
   }),
 )
 


### PR DESCRIPTION
## Short description
Resolves #3038

## Implementation details
The Spectrogram plugin now takes a parameter to split the channels. If this option isn't specified, it will inherit it from the wavesurfer options.

## Screenshots
<img width="631" alt="Screenshot 2023-07-21 at 20 33 40" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/740082c9-ed8c-48ab-a566-6dcb1c3d5153">