### PR TITLE
Fix: [Envelope] ignore audio volume changes (revert #3003)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "license": "BSD-3-Clause",
   "author": "katspaugh",
   "description": "Navigable audio waveform player",

--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -210,14 +210,7 @@ class EnvelopePlugin extends BasePlugin<EnvelopePluginEvents, EnvelopePluginOpti
     this.initSvg()
     this.initFadeEffects()
 
-    // Sync the plugin's volume with the media element volume
-    const media = this.wavesurfer.getMediaElement()
-    const onMediaVolumeChange = () => this.setVolume(media.volume)
-    media.addEventListener('volumechange', onMediaVolumeChange)
-
     this.subscriptions.push(
-      () => media.removeEventListener('volumechange', onMediaVolumeChange),
-
       this.wavesurfer.on('redraw', () => {
         const duration = this.wavesurfer?.getDuration()
         if (!duration) return


### PR DESCRIPTION
Listening to audio element volume changes in the Envelope plugin breaks some use cases. Envelope volume should be set and controlled exclusively by Envelope. Users should call `envelope.setVolume()`.