### PR TITLE
Fix: events in load should always be async

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -312,13 +312,13 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.setSrc(url, blob)
 
     // Wait for the audio duration
+    // It should be a promise to allow event listeners to subscribe to the ready and decode events
     this.duration =
-      duration ||
-      this.getDuration() ||
+      (await Promise.resolve(duration || this.getDuration())) ||
       (await new Promise((resolve) => {
         this.onceMediaEvent('loadedmetadata', () => resolve(this.getDuration()))
       })) ||
-      0
+      (await Promise.resolve(0))
 
     // Decode the audio data or use user-provided peaks
     if (channelData) {


### PR DESCRIPTION
## Short description
Resolves #3034

## Implementation details
If an externally passed media element already has a duration when wavesurfer is initialized, the load function would return synchronously before any event listeners have a chance to subscribe to the ready event.

It's now always asynchronous even if duration is available synchronously. This makes the ready event emit _after_ event handlers are set.