### PR TITLE
Fix: [Hover] fix converting seconds method in formatTime

### DIFF
--- a/src/plugins/hover.ts
+++ b/src/plugins/hover.ts
@@ -95,7 +95,7 @@ class HoverPlugin extends BasePlugin<HoverPluginEvents, HoverPluginOptions> {
 
   private formatTime(seconds: number): string {
     const minutes = Math.floor(seconds / 60)
-    const secondsRemainder = Math.round(seconds) % 60
+    const secondsRemainder = Math.floor(seconds) % 60
     const paddedSeconds = `0${secondsRemainder}`.slice(-2)
     return `${minutes}:${paddedSeconds}`
   }


### PR DESCRIPTION
## Implementation details
### before (using `Math.round`)
- 0.4sec -> `0:00`
- 0.5sec -> `0:01`
- 0.9sec -> `0:01`
- 1.0sec -> `0:01`
- 1.4sec -> `0:01`
- 1.5sec -> `0:02`

### after (using `Math.floor`)
- 0.4sec -> `0:00`
- 0.5sec -> `0:00`
- 0.9sec -> `0:00`
- 1.0sec -> `0:01`
- 1.4sec -> `0:01`
- 1.5sec -> `0:01`

## How to test it
Test with Timeline plugin by importing after modifying the package Hover plugin src code directly.

## Screenshots
Sorry for an environment where I can't upload screenshots.

## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
