### PR TITLE
Fix: resume AudioContext if suspended

### DIFF
--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,6 +1,7 @@
 /** Decode an array buffer into an audio buffer */
 async function decode(audioData: ArrayBuffer, sampleRate: number): Promise<AudioBuffer> {
   const audioCtx = new AudioContext({ sampleRate })
+  if (audioCtx.state === 'suspended') await audioCtx.resume()
   const decode = audioCtx.decodeAudioData(audioData)
   decode.finally(() => audioCtx.close())
   return decode


### PR DESCRIPTION
## Short description
Resolves #3057

## Implementation details
Resume AudioContext if it's suspended upon creation.

This might still not work in some browsers unless `load` is called on user action (e.g. on click).
