### PR TITLE
Fix: restore loadBlob

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ Most options, events, and methods are similar to those in previous versions.
  * `getFilters`, `setFilter` – as there's no Web Audio "backend"
  * `drawBuffer` – to redraw the waveform, use `setOptions` instead and pass new rendering options
  * `cancelAjax` – you can pass an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) in `fetchParams`
- * `loadBlob` – use `URL.createObjectURL()` to convert a blob to a URL and call `load(url)` instead
  * `skipForward`, `skipBackward`, `setPlayEnd` – can be implemented using `setTime(time)`
  * `exportPCM` is replaced with `exportPeaks` that returns arrays of floats
  * `toggleMute` is now called `setMuted(true | false)`

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -296,19 +296,20 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     return this.plugins
   }
 
-  /** Load an audio file by URL, with optional pre-decoded audio data */
-  public async load(url: string, channelData?: WaveSurferOptions['peaks'], duration?: number) {
+  public async loadAudio(url: string, blob?: Blob, channelData?: WaveSurferOptions['peaks'], duration?: number) {
+    this.emit('load', url)
+
     if (this.isPlaying()) this.pause()
 
     this.decodedData = null
     this.duration = null
 
-    this.emit('load', url)
-
     // Fetch the entire audio as a blob if pre-decoded data is not provided
-    const blob = channelData ? undefined : await Fetcher.fetchBlob(url, this.options.fetchParams)
+    if (!blob && !channelData) {
+      blob = await Fetcher.fetchBlob(url, this.options.fetchParams)
+    }
 
-    // Set the mediaelement source to the URL
+    // Set the mediaelement source
     this.setSrc(url, blob)
 
     // Wait for the audio duration
@@ -341,6 +342,16 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     }
 
     this.emit('ready', this.duration)
+  }
+
+  /** Load an audio file by URL, with optional pre-decoded audio data */
+  public async load(url: string, channelData?: WaveSurferOptions['peaks'], duration?: number) {
+    this.loadAudio(url, undefined, channelData, duration)
+  }
+
+  /** Load an audio blob */
+  public async loadBlob(blob: Blob, channelData?: WaveSurferOptions['peaks'], duration?: number) {
+    this.loadAudio('blob', blob, channelData, duration)
   }
 
   /** Zoom the waveform by a given pixels-per-second factor */


### PR DESCRIPTION
## Short description
Resolves #3059

Restores the `wavesurfer.loadBlob` method from v6.

## Implementation details

Allow passing a Blob directly instead of a URL.