### PR TITLE
Fix: set initial playbackRate on canplay

### DIFF
--- a/examples/speed.js
+++ b/examples/speed.js
@@ -8,7 +8,7 @@
     </button>
 
     <label>
-      Playback rate: <span id="rate">1.00</span>x
+      Playback rate: <span id="rate">2.00</span>x
     </label>
 
     <label>
@@ -30,6 +30,7 @@ const wavesurfer = WaveSurfer.create({
   waveColor: 'rgb(200, 0, 200)',
   progressColor: 'rgb(100, 0, 100)',
   url: '/examples/audio/librivox.mp3',
+  audioRate: 2, // set the initial playback rate
 })
 
 let preservePitch = true

--- a/src/player.ts
+++ b/src/player.ts
@@ -29,7 +29,11 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     }
     // Speed
     if (options.playbackRate != null) {
-      this.media.playbackRate = options.playbackRate
+      this.onceMediaEvent('canplay', () => {
+        if (options.playbackRate != null) {
+          this.media.playbackRate = options.playbackRate
+        }
+      })
     }
   }
 


### PR DESCRIPTION
## Short description
Resolves #3058

## Implementation details
Playback rate works unreliably if set before the audio has been sufficiently loaded.
This PR sets the initial playback rate when the `canplay` event is emitted on the media element.