### PR TITLE
Feat: track the progress of fetch requests

### DIFF
--- a/examples/events.js
+++ b/examples/events.js
@@ -1,0 +1,113 @@
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+
+const wavesurfer = WaveSurfer.create({
+  container: document.body,
+  waveColor: 'rgb(200, 0, 200)',
+  progressColor: 'rgb(100, 0, 100)',
+})
+
+/** When audio starts loading */
+wavesurfer.on('load', (url) => {
+  console.log('Load', url)
+})
+
+/** During audio loading */
+wavesurfer.on('loading', (percent) => {
+  console.log('Loading', percent + '%')
+})
+
+/** When the audio has been decoded */
+wavesurfer.on('decode', (duration) => {
+  console.log('Decode', duration + 's')
+})
+
+/** When the audio is both decoded and can play */
+wavesurfer.on('ready', (duration) => {
+  console.log('Ready', duration + 's')
+})
+
+/** When a waveform is drawn */
+wavesurfer.on('redraw', () => {
+  console.log('Redraw')
+})
+
+/** When the audio starts playing */
+wavesurfer.on('play', () => {
+  console.log('Play')
+})
+
+/** When the audio pauses */
+wavesurfer.on('pause', () => {
+  console.log('Pause')
+})
+
+/** When the audio finishes playing */
+wavesurfer.on('finish', () => {
+  console.log('Finish')
+})
+
+/** On audio position change, fires continuously during playback */
+wavesurfer.on('timeupdate', (currentTime) => {
+  console.log('Time', currentTime + 's')
+})
+
+/** When the user seeks to a new position */
+wavesurfer.on('seeking', (currentTime) => {
+  console.log('Seeking', currentTime + 's')
+})
+
+/** When the user interacts with the waveform (i.g. clicks or drags on it) */
+wavesurfer.on('interaction', (newTime) => {
+  console.log('Interaction', newTime + 's')
+})
+
+/** When the user clicks on the waveform */
+wavesurfer.on('click', (relativeX) => {
+  console.log('Click', relativeX)
+})
+
+/** When the user drags the cursor */
+wavesurfer.on('drag', (relativeX) => {
+  console.log('Drag', relativeX)
+})
+
+/** When the waveform is scrolled (panned) */
+wavesurfer.on('scroll', (visibleStartTime, visibleEndTime) => {
+  console.log('Scroll', visibleStartTime + 's', visibleEndTime + 's')
+})
+
+/** When the zoom level changes */
+wavesurfer.on('zoom', (minPxPerSec) => {
+  console.log('Zoom', minPxPerSec + 'px/s')
+})
+
+/** Just before the waveform is destroyed so you can clean up your events */
+wavesurfer.on('destroy', () => {
+  console.log('Destroy')
+})
+
+wavesurfer.load('/examples/audio/audio.wav')
+
+/*
+<html>
+  <label>
+    Zoom: <input type="range" min="10" max="1000" value="100" />
+  </label>
+  <button>Play/pause</button>
+  <p>Open the console to see the event logs</p>
+</html>
+*/
+
+// Update the zoom level on slider change
+wavesurfer.once('decode', () => {
+  const slider = document.querySelector('input[type="range"]')
+
+  slider.addEventListener('input', (e) => {
+    const minPxPerSec = e.target.valueAsNumber
+    wavesurfer.zoom(minPxPerSec)
+  })
+
+  document.querySelector('button').addEventListener('click', () => {
+    wavesurfer.playPause()
+  })
+})

--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
         <ul>
           <li><a href="#basic.js">Basic</a></li>
           <li><a href="#all-options.js">Options</a></li>
+          <li><a href="#events.js">Events</a></li>
           <li><a href="#zoom.js">Zoom</a></li>
           <li><a href="#regions.js">Regions</a></li>
           <li><a href="#hover.js">Hover</a></li>

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -8,8 +8,8 @@ async function fetchBlob(
 
   // Read the data to track progress
   {
-    const reader = response.clone().body!.getReader()
-    const contentLength = +response.headers.get('Content-Length')!
+    const reader = response.clone().body?.getReader()
+    const contentLength = Number(response.headers?.get('Content-Length'))
     let receivedLength = 0
 
     // Process the data
@@ -23,10 +23,10 @@ async function fetchBlob(
       progressCallback(percentage)
 
       // Continue reading data
-      return reader.read().then(({ done, value }) => processChunk(done, value))
+      return reader?.read().then(({ done, value }) => processChunk(done, value))
     }
 
-    reader.read().then(({ done, value }) => processChunk(done, value))
+    reader?.read().then(({ done, value }) => processChunk(done, value))
   }
 
   return response.blob()

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,5 +1,35 @@
-async function fetchBlob(url: string, init?: RequestInit): Promise<Blob> {
-  return fetch(url, init).then((response) => response.blob())
+async function fetchBlob(
+  url: string,
+  progressCallback: (percentage: number) => void,
+  requestInit?: RequestInit,
+): Promise<Blob> {
+  // Fetch the resource
+  const response = await fetch(url, requestInit)
+
+  // Read the data to track progress
+  {
+    const reader = response.clone().body!.getReader()
+    const contentLength = +response.headers.get('Content-Length')!
+    let receivedLength = 0
+
+    // Process the data
+    const processChunk = async (done: boolean | undefined, value: Uint8Array | undefined): Promise<void> => {
+      if (done) return
+
+      // Add to the received length
+      receivedLength += value?.length || 0
+
+      const percentage = Math.round((receivedLength / contentLength) * 100)
+      progressCallback(percentage)
+
+      // Continue reading data
+      return reader.read().then(({ done, value }) => processChunk(done, value))
+    }
+
+    reader.read().then(({ done, value }) => processChunk(done, value))
+  }
+
+  return response.blob()
 }
 
 const Fetcher = {

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -83,6 +83,8 @@ const defaultOptions = {
 export type WaveSurferEvents = {
   /** When audio starts loading */
   load: [url: string]
+  /** During audio loading */
+  loading: [percent: number]
   /** When the audio has been decoded */
   decode: [duration: number]
   /** When the audio is both decoded and can play */
@@ -306,7 +308,15 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.emit('load', url)
 
     // Fetch the entire audio as a blob if pre-decoded data is not provided
-    const blob = channelData ? undefined : await Fetcher.fetchBlob(url, this.options.fetchParams)
+    const blob = channelData
+      ? undefined
+      : await Fetcher.fetchBlob(
+          url,
+          (percentage) => {
+            this.emit('loading', percentage)
+          },
+          this.options.fetchParams,
+        )
 
     // Set the mediaelement source to the URL
     this.setSrc(url, blob)


### PR DESCRIPTION
## Short description
Resolves #3056

## Implementation details
This PR augments the fetcher with a reader that tracks the progress of a fetch request and adds a `loading` event.

## How to test it
A new example is added for testing all wavesurfer events.