### PR TITLE
Fix: [Regions] setOptions with markers

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -274,8 +274,9 @@ class SingleRegion extends EventEmitter<RegionEvents> {
       })
     }
     if (options.start !== undefined || options.end !== undefined) {
+      const isMarker = this.start === this.end
       this.start = options.start ?? this.start
-      this.end = options.end ?? this.end
+      this.end = options.end ?? (isMarker ? this.start : this.end)
       this.renderPosition()
     }
   }


### PR DESCRIPTION
## Short description
Resolves #3050

When calling `region.setOptions({ start: N })`, markers (regions w/o an end) could freeze because their end position wasn't updated.

## Implementation details
It will now always sync the end position of a marker with its start position, unless an explicit new end position is passed.

## How to test it
Can be tested with this example: https://wavesurfer-js.org/examples/#b2eebd63f32ff5ef60d9b13aced55151