### PR TITLE
Chore: simplify plugin import syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
       "types": "./dist/wavesurfer.d.ts",
       "require": "./dist/wavesurfer.cjs"
     },
+    "./dist/plugins/*.js": {
+      "import": "./dist/plugins/*.esm.js",
+      "types": "./dist/plugins/*.d.ts",
+      "require": "./dist/plugins/*.cjs"
+    },
     "./plugins/*": {
       "import": "./dist/plugins/*.esm.js",
       "types": "./dist/plugins/*.d.ts",
@@ -40,7 +45,7 @@
     "./dist/*": {
       "import": "./dist/*"
     }
-  },  
+  },
   "scripts": {
     "build:dev": "tsc -w --target ESNext",
     "build": "rm -rf dist && tsc && rollup -c",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
       "types": "./dist/wavesurfer.d.ts",
       "require": "./dist/wavesurfer.cjs"
     },
-    "./dist/plugins/*.js": {
+    "./plugins/*": {
       "import": "./dist/plugins/*.esm.js",
       "types": "./dist/plugins/*.d.ts",
       "require": "./dist/plugins/*.cjs"
@@ -40,7 +40,7 @@
     "./dist/*": {
       "import": "./dist/*"
     }
-  },
+  },  
   "scripts": {
     "build:dev": "tsc -w --target ESNext",
     "build": "rm -rf dist && tsc && rollup -c",


### PR DESCRIPTION
## Short description

~~TypeScript was complaining about not being able to find the declarations, so I fixed the exports map and tested it. Now I get full TS + autocompletion for plugin constructors.~~

This might've been an issue with VS Code misbehaving, so this PR is now just a bit of polish rather than a fix. I added a shorter way to import plugins, e.g.: `import SomePlugin from 'wavesurfer.js/plugins/some-plugin'`

## Checklist
* [X] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
