### PR TITLE
Allow timeline label intervals to be specified in notch count as well as seconds

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -15,10 +15,14 @@ export type TimelinePluginOptions = {
   duration?: number
   /** Interval between ticks in seconds */
   timeInterval?: number
-  /** Interval between numeric labels */
+  /** Interval between numeric labels in seconds */
   primaryLabelInterval?: number
-  /** Interval between secondary numeric labels */
+  /** Interval between secondary numeric labels in seconds */
   secondaryLabelInterval?: number
+  /** Interval between numeric labels in timeIntervals (i.e notch count) */
+  primaryLabelSpacing?: number
+  /** Interval between secondary numeric labels  in timeIntervals (i.e notch count) */
+  secondaryLabelSpacing?: number
   /** Custom inline style to apply to the container */
   style?: Partial<CSSStyleDeclaration> | string
   /** Turn the time into a suitable label for the time. */
@@ -138,7 +142,9 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     const pxPerSec = this.timelineWrapper.scrollWidth / duration
     const timeInterval = this.options.timeInterval ?? this.defaultTimeInterval(pxPerSec)
     const primaryLabelInterval = this.options.primaryLabelInterval ?? this.defaultPrimaryLabelInterval(pxPerSec)
+    const primaryLabelSpacing = this.options.primaryLabelSpacing
     const secondaryLabelInterval = this.options.secondaryLabelInterval ?? this.defaultSecondaryLabelInterval(pxPerSec)
+    const secondaryLabelSpacing = this.options.secondaryLabelSpacing
     const isTop = this.options.insertPosition === 'beforebegin'
 
     const timeline = document.createElement('div')
@@ -189,10 +195,14 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     `,
     )
 
-    for (let i = 0; i < duration; i += timeInterval) {
+    for (let i = 0, notches = 0; i < duration; i += timeInterval, notches++) {
       const notch = notchEl.cloneNode() as HTMLElement
-      const isPrimary = (Math.round(i * 100) / 100) % primaryLabelInterval === 0
-      const isSecondary = (Math.round(i * 100) / 100) % secondaryLabelInterval === 0
+      const isPrimary =
+        (Math.round(i * 100) / 100) % primaryLabelInterval === 0 ||
+        (primaryLabelSpacing && notches % primaryLabelSpacing === 0)
+      const isSecondary =
+        (Math.round(i * 100) / 100) % secondaryLabelInterval === 0 ||
+        (secondaryLabelSpacing && notches % secondaryLabelSpacing === 0)
 
       if (isPrimary || isSecondary) {
         notch.style.height = '100%'


### PR DESCRIPTION
## Short description

If the timeline displays units other than seconds – such as beats, or video frame position – notch and label intervals are likely to be precise float when converted to seconds. Precision is especially important when zoomed in at a high minPxPerSec. 

Currently `primaryLabelInterval` and `secondaryLabelInterval` are specified in seconds, and the computation to assess whether a given notch position is a label rounds to 2 decimal places. This is presumably desirable in some cases but not in the aforementioned use case, where the loss of precision causes labels to be skipped altogether.

I'd therefore like to suggest an alternative way to specify when labels should occur, simply based on the number of notches. For example:
* `primaryLabelSpacing=10` means every 10th notch is a primary label.
* `secondaryLabelSpacing=5` means every 5th notch is a secondary label.


## Implementation details

Add `primaryLabelSpacing` and `secondaryLabelSpacing` as additional ways to specify the label interval. 


If these options are present alongside the original `primaryLabelInterval` and `secondaryLabelSpacing`, both are used to assess whether a given notch should be a label.

## How to test it

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes

(I can add tests if you agree this is useful)