### PR TITLE
Fix: [Regions] Overlpaeed Regions region-out event error

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -322,7 +322,6 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         // Trigger region-in when activeRegions doesn't include a played regions
         playedRegions.forEach((region) => {
           if (!activeRegions.includes(region)) {
-            activeRegions = [...activeRegions, region]
             this.emit('region-in', region)
           }
         })
@@ -335,7 +334,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         })
 
         // Update activeRegions only played regions
-        activeRegions = playedRegions.filter((region) => playedRegions.includes(region))
+        activeRegions = playedRegions
       }),
     )
   }


### PR DESCRIPTION
- When regions are overlapped, region-out event triggered strangely

## Short description
Previously, there was only one active Region.

However, if there are multiple regions, there can be multiple active regions.

I have improved the logic for this case.

## Implementation details

- change activeRegion to actionRegions(array)
- find all played regions
- trigger event by  activeRegion & played regions
- update activeRegions

## How to test it
Check the triggered event(region-out) after overlapping different regions


## Screenshots
```
//reg region
{
    "listeners": {
        "update-end": {},
        "play": {},
        "click": {},
        "dblclick": {},
        "remove": {}
    },
    "totalDuration": 103.944,
    "minLength": 0,
    "maxLength": null,
    "id": "red",
    "start": 26.9,
    "end": 40.6,
    "drag": true,
    "resize": false,
    "color": "rgba(242, 85, 75, 0.3)",
    "element": null
}

// green region
{
    "listeners": {
        "update-end": {},
        "play": {},
        "click": {},
        "dblclick": {},
        "remove": {}
    },
    "totalDuration": 103.944,
    "minLength": 0,
    "maxLength": null,
    "id": "green",
    "start": 29.6,
    "end": 43.3,
    "drag": false,
    "resize": false,
    "color": "rgba(0, 179, 130, 0.3)",
    "element": null
}
```
![image](https://github.com/katspaugh/wavesurfer.js/assets/61446585/bce7759a-8c54-4d73-87f8-0a8141c8e598)

before
![image](https://github.com/katspaugh/wavesurfer.js/assets/61446585/6f35eafa-58fa-4841-a671-5cbec7a53f98)
after
![image](https://github.com/katspaugh/wavesurfer.js/assets/61446585/0d1c9951-4ee2-4168-8f80-18d780392b49)


