### PR TITLE
Fix: stop timer on "emptied"

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -188,6 +188,10 @@ class WaveSurfer extends Player<WaveSurferEvents> {
         this.timer.stop()
       }),
 
+      this.onMediaEvent('emptied', () => {
+        this.timer.stop()
+      }),
+
       this.onMediaEvent('ended', () => {
         this.emit('finish')
       }),


### PR DESCRIPTION
## Short description
Resolves #3097

## Implementation details

The `pause` event isn't emitted as expected when the src is changed right after calling `pause()` which resulted in the timer being run after a new audio is loaded but not played yet.

I've added a new media event listener on `emptied` which is triggered when a new audio source is loaded.