### PR TITLE
Fix: [Regions] fire region-created after subscribing to region events

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -387,7 +387,6 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     this.regionsContainer.appendChild(region.element)
     this.avoidOverlapping(region)
     this.regions.push(region)
-    this.emit('region-created', region)
 
     const regionSubscriptions = [
       region.on('update-end', () => {
@@ -416,6 +415,8 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     ]
 
     this.subscriptions.push(...regionSubscriptions)
+
+    this.emit('region-created', region)
   }
 
   /** Create a region with given parameters */


### PR DESCRIPTION
## Short description
Resolves #3085

## Implementation details

If a region is removed inside a region-created handler, it wouldn't be properly removed from the region list because other events haven't been subscribed to yet. I've moved the region-created call to the very end of the function to allow event listeners to be created before it.