### PR TITLE
Feat: [Envelope] getOptions and point ids +  dragToSeek option

### DIFF
--- a/examples/all-options.js
+++ b/examples/all-options.js
@@ -41,6 +41,8 @@ const options = {
   autoplay: false,
   /** Pass false to disable clicks on the waveform */
   interact: true,
+  /** Allow to drag the cursor to seek to a new position */
+  dragToSeek: false,
   /** Hide the scrollbar */
   hideScrollbar: false,
   /** Audio rate */

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -67,7 +67,9 @@ class Renderer extends EventEmitter<RendererEvents> {
     })
 
     // Drag
-    this.initDrag()
+    if (this.options.dragToSeek) {
+      this.initDrag()
+    }
 
     // Add a scroll listener
     this.scrollContainer.addEventListener('scroll', () => {

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -46,6 +46,8 @@ export type WaveSurferOptions = {
   autoplay?: boolean
   /** Pass false to disable clicks on the waveform */
   interact?: boolean
+  /** Allow to drag the cursor to seek to a new position */
+  dragToSeek?: boolean
   /** Hide the scrollbar */
   hideScrollbar?: boolean
   /** Audio rate, i.e. the playback speed */
@@ -75,6 +77,7 @@ const defaultOptions = {
   minPxPerSec: 0,
   fillParent: true,
   interact: true,
+  dragToSeek: false,
   autoScroll: true,
   autoCenter: true,
   sampleRate: 8000,


### PR DESCRIPTION
Envelope plugin:
* Add `getPoints`
* Allow giving points an id

Wavesurfer options:
* `dragToSeek` – dragging the playhead is now opt-in (a breaking API change ⚠️ )