### PR TITLE
Fix: use bounding box for width calculation in dragToSeek

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -92,7 +92,7 @@ class Renderer extends EventEmitter<RendererEvents> {
       this.wrapper,
       // On drag
       (_, __, x) => {
-        this.emit('drag', Math.max(0, Math.min(1, x / this.wrapper.clientWidth)))
+        this.emit('drag', Math.max(0, Math.min(1, x / this.wrapper.getBoundingClientRect().width)))
       },
       // On start drag
       () => (this.isDragging = true),


### PR DESCRIPTION
## Short description
Resolves #3167

## Implementation details

Use `getBoundingClientRect().width` instead of `clientWidth` to take CSS scaling into account.