### PR TITLE
Regions plugin: Only add resize handles if resize prop is true

### DIFF
--- a/cypress/e2e/regions.cy.js
+++ b/cypress/e2e/regions.cy.js
@@ -308,4 +308,23 @@ describe('WaveSurfer Regions plugin tests', () => {
       win.wavesurfer.destroy()
     })
   })
+
+  it('should not add resize handles if resize is set to false', () => {
+    cy.window().then((win) => {
+      const regionsPlugin = win.wavesurfer.getActivePlugins()[0]
+
+      const region = regionsPlugin.addRegion({
+        id: 'no-resize-region',
+        start: 1,
+        end: 5,
+        resize: false,
+      })
+
+      expect(region).to.be.an('object')
+      expect(region.element).to.be.an('HTMLDivElement')
+      expect(region.element.children).to.have.length(0)
+
+      win.wavesurfer.destroy()
+    })
+  })
 })

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -115,7 +115,7 @@ class SingleRegion extends EventEmitter<RegionEvents> {
     )
 
     // Add resize handles
-    if (!isMarker) {
+    if (!isMarker && this.resize) {
       const leftHandle = document.createElement('div')
       leftHandle.setAttribute('data-resize', 'left')
       leftHandle.setAttribute(


### PR DESCRIPTION
## Short description
Currently, adding a new region also creates left and right resize handles regardless of the resize param being set. For small regions, the resize handles makes it so you can't see the actual background color.

## Implementation details
Add the resize param to the resize handle creation conditional.

## How to test it
```
regionsPlugin.addRegion({
...,
resize: false
});
```
Added an e2e test as well

## Screenshots
Before: ![Before](https://github.com/katspaugh/wavesurfer.js/assets/32553602/f49887ff-7b8a-45f9-ac6c-b8b9202565f3)
After: ![After](https://github.com/katspaugh/wavesurfer.js/assets/32553602/90391291-7ba5-4e0f-aab0-2b685e12e221)

## Checklist
* [✅] This PR is covered by e2e tests
* [✅] It introduces no breaking API changes
