### PR TITLE
Update README.md with correct link to methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See more [examples](https://wavesurfer-js.org/examples).
 
 See the wavesurfer.js documentation on our website:
 
- * [methods](http://wavesurfer-js.org/docs/methods)
+ * [methods](https://wavesurfer-js.org/docs/classes/wavesurfer.default)
  * [options](http://wavesurfer-js.org/docs/options)
  * [events](http://wavesurfer-js.org/docs/events)
 


### PR DESCRIPTION
Looks like the redirect from `https://wavesurfer-js.org/docs/methods` is no longer valid

## Short description
Resolves #

## Implementation details


## How to test it


## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
