### PR TITLE
Feat: add dblclick event

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -3,7 +3,8 @@ import EventEmitter from './event-emitter.js'
 import type { WaveSurferOptions } from './wavesurfer.js'
 
 type RendererEvents = {
-  click: [relativeX: number]
+  click: [relativeX: number, relativeY: number]
+  dblclick: [relativeX: number, relativeY: number]
   drag: [relativeX: number]
   scroll: [relativeStart: number, relativeEnd: number]
   render: []
@@ -58,12 +59,25 @@ class Renderer extends EventEmitter<RendererEvents> {
   }
 
   private initEvents() {
-    // Add a click listener
-    this.wrapper.addEventListener('click', (e) => {
+    const getClickPosition = (e: MouseEvent): [number, number] => {
       const rect = this.wrapper.getBoundingClientRect()
       const x = e.clientX - rect.left
+      const y = e.clientX - rect.left
       const relativeX = x / rect.width
-      this.emit('click', relativeX)
+      const relativeY = y / rect.height
+      return [relativeX, relativeY]
+    }
+
+    // Add a click listener
+    this.wrapper.addEventListener('click', (e) => {
+      const [x, y] = getClickPosition(e)
+      this.emit('click', x, y)
+    })
+
+    // Add a double click listener
+    this.wrapper.addEventListener('dblclick', (e) => {
+      const [x, y] = getClickPosition(e)
+      this.emit('dblclick', x, y)
     })
 
     // Drag

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -109,7 +109,9 @@ export type WaveSurferEvents = {
   /** When the user interacts with the waveform (i.g. clicks or drags on it) */
   interaction: [newTime: number]
   /** When the user clicks on the waveform */
-  click: [relativeX: number]
+  click: [relativeX: number, relativeY: number]
+  /** When the user double-clicks on the waveform */
+  dblclick: [relativeX: number, relativeY: number]
   /** When the user drags the cursor */
   drag: [relativeX: number]
   /** When the waveform is scrolled (panned) */
@@ -207,12 +209,17 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   private initRendererEvents() {
     this.subscriptions.push(
       // Seek on click
-      this.renderer.on('click', (relativeX) => {
+      this.renderer.on('click', (relativeX, relativeY) => {
         if (this.options.interact) {
           this.seekTo(relativeX)
           this.emit('interaction', relativeX * this.getDuration())
-          this.emit('click', relativeX)
+          this.emit('click', relativeX, relativeY)
         }
+      }),
+
+      // Double click
+      this.renderer.on('dblclick', (relativeX, relativeY) => {
+        this.emit('dblclick', relativeX, relativeY)
       }),
 
       // Scroll


### PR DESCRIPTION
## Short description
Resolves #2655

## Implementation details
I've added a double click event, and also added the Y mouse position to both click and dblclick.

It can be used like this:


```js
wavesurfer.on('dblclick, (x, y) => {
  console.log('Double-clicked at %d, %d', x, y) 
})
```

Please note that any double click will also trigger a regular click. This can be worked around by setting `wavesurfer.options.interact` to false, which would disable regular clicks.