### PR TITLE
Feat: update the container via setOptions

### DIFF
--- a/cypress/e2e/index.html
+++ b/cypress/e2e/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="waveform" style="width: 600px"></div>
+    <div id="otherWaveform" style="width: 600px"></div>
 
     <script type="module">
       import WaveSurfer from '../../dist/wavesurfer.js'

--- a/cypress/e2e/options.cy.js
+++ b/cypress/e2e/options.cy.js
@@ -1,4 +1,5 @@
 const id = '#waveform'
+const otherId = `#otherWaveform`
 
 describe('WaveSurfer options tests', () => {
   beforeEach(() => {
@@ -518,6 +519,28 @@ describe('WaveSurfer options tests', () => {
 
         win.wavesurfer.once('ready', () => {
           cy.get(id).matchImageSnapshot('fetch-options')
+          resolve()
+        })
+      })
+    })
+  })
+
+  it('should remount the container when set via setOptions', () => {
+    cy.window().then((win) => {
+      return new Promise((resolve, reject) => {
+        win.wavesurfer = win.WaveSurfer.create({
+          container: id,
+          url: '../../examples/audio/demo.wav',
+          barWidth: 4,
+          barGap: 3,
+          barRadius: 4,
+        })
+
+        win.wavesurfer.once('ready', () => {
+          win.wavesurfer.setOptions({ container: otherId })
+          cy.get(id).children().should('have.length', 0)
+          cy.get(otherId).children().should('have.length', 1)
+          cy.get(otherId).matchImageSnapshot('bars')
           resolve()
         })
       })

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -31,15 +31,7 @@ class Renderer extends EventEmitter<RendererEvents> {
 
     this.options = options
 
-    let parent
-    if (typeof options.container === 'string') {
-      parent = document.querySelector(options.container) as HTMLElement | null
-    } else if (options.container instanceof HTMLElement) {
-      parent = options.container
-    }
-    if (!parent) {
-      throw new Error('Container not found')
-    }
+    const parent = this.parentFromOptionsContainer(options.container)
     this.parent = parent
 
     const [div, shadow] = this.initHtml()
@@ -56,6 +48,21 @@ class Renderer extends EventEmitter<RendererEvents> {
     }
 
     this.initEvents()
+  }
+
+  private parentFromOptionsContainer(container: WaveSurferOptions['container']) {
+    let parent
+    if (typeof container === 'string') {
+      parent = document.querySelector(container) satisfies HTMLElement | null
+    } else if (container instanceof HTMLElement) {
+      parent = container
+    }
+
+    if (!parent) {
+      throw new Error('Container not found')
+    }
+
+    return parent
   }
 
   private initEvents() {
@@ -204,8 +211,17 @@ class Renderer extends EventEmitter<RendererEvents> {
     return [div, shadow]
   }
 
+  /** Wavesurfer itself calls this method. Do not call it manually. */
   setOptions(options: WaveSurferOptions) {
+    if (this.options.container !== options.container) {
+      const newParent = this.parentFromOptionsContainer(options.container)
+      newParent.appendChild(this.container)
+
+      this.parent = newParent
+    }
+
     this.options = options
+
     // Re-render the waveform
     this.reRender()
   }


### PR DESCRIPTION
## Short description
Allows the user of the library to remount the wavesurfer instance to a new container.

Resolves #3197

## Implementation details
This feature allows changing the container via setOptions and adds a new event type 'containerRemount' which is only emitted when the container is remounted i.e. updated via setOptions.

If only the container is updated, it wont try to rerender the waveform.

In the change we introduced a new file `equals.ts` which has common utility functions for comparing 
Perhaps the `equals.ts` needs it's own unit testing or to be changed to `lodash`'s utility functions but from my experience it has some quirkiness in some scenarios.

## How to test it
As usual you can test the via the `yarn test` command.

You can also test the feature via the new example `remounting-container.js`.

## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes