### PR TITLE
Feat: add public method to set media element

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -176,4 +176,13 @@ describe('WaveSurfer basic tests', () => {
       win.wavesurfer.destroy()
     })
   })
+
+  it('should set media without errors', () => {
+    cy.window().then((win) => {
+      const media = document.createElement('audio')
+      media.id = "new-media"
+      win.wavesurfer.setMediaElement(media)
+      expect(win.wavesurfer.getMediaElement().id).to.equal("new-media")
+    })
+  })
 })

--- a/src/player.ts
+++ b/src/player.ts
@@ -147,6 +147,11 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     return this.media
   }
 
+  /** Set HTML media element */
+  public setMediaElement(element: HTMLMediaElement) {
+    this.media = element
+  }
+
   /** Set a sink id to change the audio output device */
   public setSinkId(sinkId: string): Promise<void> {
     // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId


### PR DESCRIPTION
## Short description
Allow user to set `media` after creation of Wavesurfer instance.

Resolves #3190

## Implementation details
Currently, we can specify a `media` element only during creation of Wavesurfer instance. In some advanced use cases where there are multiple players on a screen and we want to sync play/pause/seek between two players having the ability to share the `media` element during runtime would be advantageous, especially if one player is always persistent and survives screen navigation.

To enable this feature we added a public `setMediaElement` method to `Player` class.

## How to test it
As usual you can test with the `yarn cypress` command.

## Checklist
* [x] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
