### PR TITLE
Fix: keep external media on destroy

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -148,9 +148,9 @@ describe('WaveSurfer basic tests', () => {
       })
       expect(peaks.length).to.equal(1) // the file is mono
       expect(peaks[0].length).to.equal(1000)
-      expect(peaks[0][0]).to.equal(0)
-      expect(peaks[0][99]).to.equal(0.07)
-      expect(peaks[0][100]).to.equal(-0.15)
+      expect(peaks[0][0]).to.equal(0.01)
+      expect(peaks[0][99]).to.equal(0.3)
+      expect(peaks[0][100]).to.equal(0.31)
 
       const peaksB = win.wavesurfer.exportPeaks({
         maxLength: 1000,
@@ -158,16 +158,16 @@ describe('WaveSurfer basic tests', () => {
       })
       expect(peaksB.length).to.equal(1)
       expect(peaksB[0].length).to.equal(1000)
-      expect(peaksB[0][0]).to.equal(0)
-      expect(peaksB[0][99]).to.equal(0.072)
-      expect(peaksB[0][100]).to.equal(-0.151)
+      expect(peaksB[0][0]).to.equal(0.015)
+      expect(peaksB[0][99]).to.equal(0.296)
+      expect(peaksB[0][100]).to.equal(0.308)
 
       const peaksC = win.wavesurfer.exportPeaks()
       expect(peaksC.length).to.equal(1)
       expect(peaksC[0].length).to.equal(8000)
-      expect(peaksC[0][0]).to.equal(0)
-      expect(peaksC[0][99]).to.equal(-0.0024)
-      expect(peaksC[0][100]).to.equal(0.0048)
+      expect(peaksC[0][0]).to.equal(0.0117)
+      expect(peaksC[0][99]).to.equal(0.01)
+      expect(peaksC[0][100]).to.equal(0.0161)
     })
   })
 

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -180,9 +180,9 @@ describe('WaveSurfer basic tests', () => {
   it('should set media without errors', () => {
     cy.window().then((win) => {
       const media = document.createElement('audio')
-      media.id = "new-media"
+      media.id = 'new-media'
       win.wavesurfer.setMediaElement(media)
-      expect(win.wavesurfer.getMediaElement().id).to.equal("new-media")
+      expect(win.wavesurfer.getMediaElement().id).to.equal('new-media')
     })
   })
 })

--- a/examples/react-global-player.js
+++ b/examples/react-global-player.js
@@ -1,0 +1,143 @@
+// React example
+
+/*
+  <html>
+    <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </html>
+*/
+
+// Import React hooks
+const { useRef, useState, useEffect, useCallback, memo } = React
+
+// Import WaveSurfer
+import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
+
+// WaveSurfer hook
+const useWavesurfer = (containerRef, options) => {
+  const [wavesurfer, setWavesurfer] = useState(null)
+
+  // Initialize wavesurfer when the container mounts
+  // or any of the props change
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const ws = WaveSurfer.create({
+      ...options,
+      container: containerRef.current,
+    })
+
+    setWavesurfer(ws)
+
+    return () => {
+      ws.destroy()
+    }
+  }, [options, containerRef])
+
+  return wavesurfer
+}
+
+// Create a React component that will render wavesurfer.
+// Props are wavesurfer options.
+const WaveSurferPlayer = memo((props) => {
+  const containerRef = useRef()
+  const [isPlaying, setIsPlaying] = useState(false)
+  const wavesurfer = useWavesurfer(containerRef, props)
+  const { onPlay, onReady } = props
+
+  // On play button click
+  const onPlayClick = useCallback(() => {
+    wavesurfer.playPause()
+  }, [wavesurfer])
+
+  // Initialize wavesurfer when the container mounts
+  // or any of the props change
+  useEffect(() => {
+    if (!wavesurfer) return
+
+    const getPlayerParams = () => ({
+      media: wavesurfer.getMediaElement(),
+      peaks: wavesurfer.exportPeaks(),
+    })
+
+    const subscriptions = [
+      wavesurfer.on('ready', () => {
+        onReady && onReady(getPlayerParams())
+
+        setIsPlaying(wavesurfer.isPlaying())
+      }),
+      wavesurfer.on('play', () => {
+        onPlay &&
+          onPlay((prev) => {
+            const newParams = getPlayerParams()
+            if (!prev || prev.media !== newParams.media) {
+              if (prev) {
+                prev.media.pause()
+                prev.media.currentTime = 0
+              }
+              return newParams
+            }
+            return prev
+          })
+
+        setIsPlaying(true)
+      }),
+      wavesurfer.on('pause', () => setIsPlaying(false)),
+    ]
+
+    return () => {
+      subscriptions.forEach((unsub) => unsub())
+    }
+  }, [wavesurfer, onPlay, onReady])
+
+  return (
+    <div style={{ display: 'flex', gap: '1em', marginBottom: '1em' }}>
+      <button onClick={onPlayClick}>{isPlaying ? '⏸️' : '▶️'}</button>
+
+      <div ref={containerRef} style={{ minWidth: '200px' }} />
+    </div>
+  )
+})
+
+const Playlist = memo(({ urls, setCurrentPlayer }) => {
+  return urls.map((url, index) => (
+    <WaveSurferPlayer
+      key={url}
+      height={100}
+      waveColor="rgb(200, 0, 200)"
+      progressColor="rgb(100, 0, 100)"
+      url={url}
+      onPlay={setCurrentPlayer}
+      onReady={index === 0 ? setCurrentPlayer : undefined}
+    />
+  ))
+})
+
+const audioUrls = ['/examples/audio/audio.wav', '/examples/audio/demo.wav', '/examples/audio/stereo.mp3']
+
+const App = () => {
+  const [currentPlayer, setCurrentPlayer] = useState()
+
+  return (
+    <>
+      <p>Playlist</p>
+      <Playlist urls={audioUrls} setCurrentPlayer={setCurrentPlayer} />
+
+      <p>Global player</p>
+      {currentPlayer && (
+        <WaveSurferPlayer
+          height={50}
+          waveColor="blue"
+          progressColor="purple"
+          media={currentPlayer.media}
+          peaks={currentPlayer.peaks}
+        />
+      )}
+    </>
+  )
+}
+
+// Create a React root and render the app
+const root = ReactDOM.createRoot(document.body)
+root.render(<App />)

--- a/src/player.ts
+++ b/src/player.ts
@@ -9,12 +9,14 @@ type PlayerOptions = {
 
 class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   protected media: HTMLMediaElement
+  private isExternalMedia: boolean = false
 
   constructor(options: PlayerOptions) {
     super()
 
     if (options.media) {
       this.media = options.media
+      this.isExternalMedia = true
     } else {
       this.media = document.createElement('audio')
     }
@@ -50,7 +52,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     return this.onMediaEvent(event, callback, { once: true })
   }
 
-  private getSrc() {
+  protected getSrc() {
     return this.media.currentSrc || this.media.src || ''
   }
 
@@ -72,6 +74,9 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
 
   protected destroy() {
     this.media.pause()
+
+    if (this.isExternalMedia) return
+    this.media.remove()
     this.revokeSrc()
     this.media.src = ''
     // Load resets the media element to its initial state

--- a/src/player.ts
+++ b/src/player.ts
@@ -9,7 +9,7 @@ type PlayerOptions = {
 
 class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   protected media: HTMLMediaElement
-  private isExternalMedia: boolean = false
+  private isExternalMedia = false
 
   constructor(options: PlayerOptions) {
     super()

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -389,9 +389,9 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       const channel = this.decodedData.getChannelData(i)
       const data = []
       const sampleSize = Math.round(channel.length / maxLength)
-      for (let i = 0; i < channel.length; i += sampleSize) {
-        const sample = channel.slice(i, i + sampleSize)
-        const max = Math.max.apply(Math, Array.from(sample))
+      for (let i = 0; i < maxLength; i++) {
+        const sample = channel.slice(i * sampleSize, (i + 1) * sampleSize)
+        const max = Math.max(...sample)
         data.push(Math.round(max * precision) / precision)
       }
       peaks.push(data)


### PR DESCRIPTION
Media src shouldn't be reset if an external media element is passed in the options.
Also, I've made the exportPeaks algorythm the same as when rendering the waveform.