### PR TITLE
Show the correct way to import with type definitions enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const wavesurfer = WaveSurfer.create({
 
 To import one of the plugins, e.g. the [Regions plugin](https://wavesurfer.xyz/examples/?regions.js):
 ```js
-import Regions from 'wavesurfer.js/plugins/regions'
+import Regions from 'wavesurfer.js/dist/plugins/regions.js'
 ```
 
 Or as a script tag that will export `WaveSurfer.Regions`:


### PR DESCRIPTION
## Short description
I tried the documentation in the existing README and that was not picking up the types and VSCode complained:

```
Cannot find module 'wavesurfer.js/plugins/record.js' or its corresponding type declarations
```

I then chanced upon https://github.com/katspaugh/wavesurfer.js/issues/2877#issuecomment-1606044454 and tried that and everything worked correctly, with types picked up. This PR updates the documentation.


## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
