### PR TITLE
feat: add pause/resume functionality to RecordPlugin

### DIFF
--- a/examples/record.js
+++ b/examples/record.js
@@ -41,7 +41,17 @@ record.on('record-end', (blob) => {
     textContent: 'Download recording',
   })
 })
+const pauseButton = document.querySelector('#pause');
+pauseButton.onclick = () => {
+  if (record.isPaused()) {
+    record.resumeRecording()
+    pauseButton.textContent = 'Pause'
+    return
+  }
 
+  record.pauseRecording();
+  pauseButton.textContent = 'Resume'
+}
 {
   // Record button
   const recButton = document.querySelector('#record')
@@ -50,6 +60,7 @@ record.on('record-end', (blob) => {
     if (record.isRecording()) {
       record.stopRecording()
       recButton.textContent = 'Record'
+      pauseButton.style.display = 'none';
       return
     }
 
@@ -58,6 +69,7 @@ record.on('record-end', (blob) => {
     record.startRecording().then(() => {
       recButton.textContent = 'Stop'
       recButton.disabled = false
+      pauseButton.style.display = 'inline';
     })
   }
 }
@@ -71,6 +83,7 @@ record.on('record-end', (blob) => {
   </p>
 
   <button id="record">Record</button>
+  <button id="pause" style="display: none;">Pause</button>
 
   <div id="mic" style="border: 1px solid #ddd; border-radius: 4px; margin-top: 1rem"></div>
 

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -147,6 +147,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   public stopRecording() {
     if (this.isRecording()) {
       this.mediaRecorder?.stop()
+      this.stream?.getTracks().forEach((track) => track.stop())
     }
   }
 

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -15,6 +15,8 @@ export type RecordPluginOptions = {
 
 export type RecordPluginEvents = BasePluginEvents & {
   'record-start': []
+  'record-pause': []
+  'record-resume': []
   'record-end': [blob: Blob]
 }
 
@@ -137,10 +139,30 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     return this.mediaRecorder?.state === 'recording'
   }
 
+  public isPaused(): boolean {
+    return this.mediaRecorder?.state === 'paused'
+  }
+
   /** Stop the recording */
   public stopRecording() {
     if (this.isRecording()) {
       this.mediaRecorder?.stop()
+    }
+  }
+
+  /** Pause the recording */
+  public pauseRecording() {
+    if (this.isRecording()) {
+      this.mediaRecorder?.pause()
+      this.emit('record-pause')
+    }
+  }
+
+  /** Resume the recording */
+  public resumeRecording() {
+    if (this.isPaused()) {
+      this.mediaRecorder?.resume()
+      this.emit('record-resume')
     }
   }
 


### PR DESCRIPTION
## Fixes
https://github.com/katspaugh/wavesurfer.js/discussions/3248

## Short description
Adds pause/resume functionality to RecordPlugin so users can pause and resume the recording instead of only being able to start and stop the recording.

## Implementation details
It uses [MediaRecorder.pause](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/pause) and [MediaRecorder.resume](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/resume)

## How to test it

The record.js example has been updated to include this functionality.

## Screenshots

<img width="829" alt="image" src="https://github.com/katspaugh/wavesurfer.js/assets/5158554/bd840802-a4bc-494c-8794-18e8264612c9">


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
