### PR TITLE
Fix/multiple records

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "cypress:canary": "cypress open --e2e -b chrome:canary",
     "test": "cypress run",
     "serve": "npx live-server --port=9090 --no-browser",
-    "start": "npm run build:dev & npm run serve"
+    "start": "npm run build:dev & npm run serve",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "cypress:canary": "cypress open --e2e -b chrome:canary",
     "test": "cypress run",
     "serve": "npx live-server --port=9090 --no-browser",
-    "start": "npm run build:dev & npm run serve",
-    "prepare": "npm run build"
+    "start": "npm run build:dev & npm run serve"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -148,6 +148,8 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     if (this.isRecording()) {
       this.mediaRecorder?.stop()
       this.stream?.getTracks().forEach((track) => track.stop())
+      this.stream = null
+      this.mediaRecorder = null
     }
   }
 

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -96,6 +96,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     if (!this.stream) return
     this.stream.getTracks().forEach((track) => track.stop())
     this.stream = null
+    this.mediaRecorder = null
   }
 
   /** Start recording audio from the microphone */
@@ -147,9 +148,6 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   public stopRecording() {
     if (this.isRecording()) {
       this.mediaRecorder?.stop()
-      this.stream?.getTracks().forEach((track) => track.stop())
-      this.stream = null
-      this.mediaRecorder = null
     }
   }
 


### PR DESCRIPTION
## Short description
Resolves https://github.com/katspaugh/wavesurfer.js/issues/3252

## Implementation details
Since the tracks were discarded, I guess the old references to it won't work. So I have set both `stream` and `mediaRecorder` to `null` so they can be set afresh.

## How to test it

Try doing multiple recordings. It should work. And when you stop recording the recording indicator on the tab should also correctly disappear.

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
