### PR TITLE
Feat: Record Plugin - Choose Mic

### DIFF
--- a/examples/record.js
+++ b/examples/record.js
@@ -41,7 +41,7 @@ record.on('record-end', (blob) => {
     textContent: 'Download recording',
   })
 })
-const pauseButton = document.querySelector('#pause');
+const pauseButton = document.querySelector('#pause')
 pauseButton.onclick = () => {
   if (record.isPaused()) {
     record.resumeRecording()
@@ -49,8 +49,21 @@ pauseButton.onclick = () => {
     return
   }
 
-  record.pauseRecording();
+  record.pauseRecording()
   pauseButton.textContent = 'Resume'
+}
+
+const micSelect = document.querySelector('#mic-select')
+{
+  // Mic selection
+  record.getAvailableAudioDevices().then((devices) => {
+    devices.forEach((device) => {
+      const option = document.createElement('option')
+      option.value = device.deviceId
+      option.text = device.label || device.deviceId
+      micSelect.appendChild(option)
+    })
+  })
 }
 {
   // Record button
@@ -60,16 +73,17 @@ pauseButton.onclick = () => {
     if (record.isRecording()) {
       record.stopRecording()
       recButton.textContent = 'Record'
-      pauseButton.style.display = 'none';
+      pauseButton.style.display = 'none'
       return
     }
 
     recButton.disabled = true
-
-    record.startRecording().then(() => {
+    // get selected device
+    const deviceId = micSelect.value
+    record.startRecording({ deviceId }).then(() => {
       recButton.textContent = 'Stop'
       recButton.disabled = false
-      pauseButton.style.display = 'inline';
+      pauseButton.style.display = 'inline'
     })
   }
 }
@@ -85,6 +99,9 @@ pauseButton.onclick = () => {
   <button id="record">Record</button>
   <button id="pause" style="display: none;">Pause</button>
 
+  <select id="mic-select">
+    <option value="" hidden>Select mic</option>
+  </select>
   <div id="mic" style="border: 1px solid #ddd; border-radius: 4px; margin-top: 1rem"></div>
 
   <div id="recordings" style="margin: 1rem 0"></div>

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -174,6 +174,25 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     }
   }
 
+  /** Get a list of available audio devices */
+  public async getAvailableAudioDevices() {
+    // Request access to the microphone before enumerating devices, otherwise
+    // the browser will not return any device IDs
+    let stream: MediaStream
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+      })
+    } catch (err) {
+      throw new Error('Error getting audio devices: ' + (err as Error).message)
+    }
+    this.stream = stream
+    this.stopMic()
+    return navigator.mediaDevices
+      .enumerateDevices()
+      .then((devices) => devices.filter((device) => device.kind === 'audioinput'))
+  }
+
   /** Destroy the plugin */
   public destroy() {
     super.destroy()

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -175,19 +175,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   }
 
   /** Get a list of available audio devices */
-  public async getAvailableAudioDevices() {
-    // Request access to the microphone before enumerating devices, otherwise
-    // the browser will not return any device IDs
-    let stream: MediaStream
-    try {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: true,
-      })
-    } catch (err) {
-      throw new Error('Error getting audio devices: ' + (err as Error).message)
-    }
-    this.stream = stream
-    this.stopMic()
+  public static async getAvailableAudioDevices() {
     return navigator.mediaDevices
       .enumerateDevices()
       .then((devices) => devices.filter((device) => device.kind === 'audioinput'))

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -174,7 +174,11 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     }
   }
 
-  /** Get a list of available audio devices */
+  /** Get a list of available audio devices
+   * You can use this to get the device ID of the microphone to use with the startMic and startRecording methods
+   * Will return an empty array if the browser doesn't support the MediaDevices API or if the user has not granted access to the microphone
+   * You can ask for permission to the microphone by calling startMic
+   */
   public static async getAvailableAudioDevices() {
     return navigator.mediaDevices
       .enumerateDevices()

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -13,6 +13,11 @@ export type RecordPluginOptions = {
   renderRecordedAudio?: boolean
 }
 
+export type RecordPluginDeviceOptions = {
+  /** The device ID of the microphone to use */
+  deviceId?: string | { exact: string }
+}
+
 export type RecordPluginEvents = BasePluginEvents & {
   'record-start': []
   'record-pause': []
@@ -74,10 +79,12 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   }
 
   /** Request access to the microphone and start monitoring incoming audio */
-  public async startMic(): Promise<MediaStream> {
+  public async startMic(options?: RecordPluginDeviceOptions): Promise<MediaStream> {
     let stream: MediaStream
     try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: options?.deviceId ? { deviceId: options.deviceId } : true,
+      })
     } catch (err) {
       throw new Error('Error accessing the microphone: ' + (err as Error).message)
     }
@@ -99,8 +106,8 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   }
 
   /** Start recording audio from the microphone */
-  public async startRecording() {
-    const stream = this.stream || (await this.startMic())
+  public async startRecording(options?: RecordPluginDeviceOptions) {
+    const stream = this.stream || (await this.startMic(options))
 
     const mediaRecorder =
       this.mediaRecorder ||


### PR DESCRIPTION
## Short description
Resolves #3245
Open to feedback!

## Implementation details
- Adds options to `startMic` and `startRecording` to use a specific mic (via deviceId)
- Add function to get a list of available audio devices `getAvailableAudioDevices`

## How to test it
1. Open the Record example. 
1. If you haven't allowed mic permissions on the site before, for this example you will need to hit the record button first, allow permissions and refresh the page for the list to be updated.
1. You should be able to select a mic from the list.
1. Hit record and test the mic.

In Chrome, you can reset the "Allow Mic" permissions by going to Settings > Privacy and Security > Site settings > Microphone > Click trash icon on `wavesurfer.xyz` or `localhost:9090`.

## Screenshots
<img width="710" alt="000219 - 2023-10-13_01 34 23" src="https://github.com/katspaugh/wavesurfer.js/assets/11529600/2b9b0f35-e85a-460d-b27a-0e4db7645337">


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes