### PR TITLE
Fix: isPlaying() should return true directly after play()

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -185,4 +185,18 @@ describe('WaveSurfer basic tests', () => {
       expect(win.wavesurfer.getMediaElement().id).to.equal('new-media')
     })
   })
+
+  it('should return true when calling isPlaying() after play()', (done) => {
+    cy.window().then((win) => {
+      expect(win.wavesurfer.isPlaying()).to.be.false
+      win.wavesurfer.play()
+      expect(win.wavesurfer.isPlaying()).to.be.true
+      win.wavesurfer.once('play', () => {
+        expect(win.wavesurfer.isPlaying()).to.be.true
+        win.wavesurfer.pause()
+        expect(win.wavesurfer.isPlaying()).to.be.false
+        done()
+      })
+    })
+  })
 })

--- a/src/player.ts
+++ b/src/player.ts
@@ -95,7 +95,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
 
   /** Check if the audio is playing */
   public isPlaying(): boolean {
-    return this.media.currentTime > 0 && !this.media.paused && !this.media.ended
+    return !this.media.paused && !this.media.ended
   }
 
   /** Jumpt to a specific time in the audio (in seconds) */


### PR DESCRIPTION
## Short description
Resolves #3258

## Implementation details
The `currentTime > 0` check was returning false at the beginning of playback, so I removed it.