### PR TITLE
Fix: scroll zoomed waveform on iOS

### DIFF
--- a/src/draggable.ts
+++ b/src/draggable.ts
@@ -17,6 +17,7 @@ export function makeDraggable(
 
     e.preventDefault()
     e.stopPropagation()
+    element.style.touchAction = 'none'
 
     let startX = e.clientX
     let startY = e.clientY
@@ -51,6 +52,8 @@ export function makeDraggable(
     }
 
     const up = () => {
+      element.style.touchAction = ''
+
       if (isDragging) {
         onEnd?.()
       }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -149,7 +149,6 @@ class Renderer extends EventEmitter<RendererEvents> {
           overflow-y: hidden;
           width: 100%;
           position: relative;
-          touch-action: none;
         }
         :host .noScrollbar {
           scrollbar-color: transparent;
@@ -219,6 +218,10 @@ class Renderer extends EventEmitter<RendererEvents> {
       newParent.appendChild(this.container)
 
       this.parent = newParent
+    }
+
+    if (options.dragToSeek && !this.options.dragToSeek) {
+      this.initDrag()
     }
 
     this.options = options


### PR DESCRIPTION
## Short description
Resolves #3257

## Implementation details
`touch-action: none` on the scroll container was preventing scrolling on iOS.
It was added for `dragToSeek`, so I made it apply only when that option is enabled and dragging is performed.