### PR TITLE
Fix: [Record] Access `getAvailableAudioDevices` with `RecordPlugin`

### DIFF
--- a/examples/record.js
+++ b/examples/record.js
@@ -56,7 +56,7 @@ pauseButton.onclick = () => {
 const micSelect = document.querySelector('#mic-select')
 {
   // Mic selection
-  record.getAvailableAudioDevices().then((devices) => {
+  RecordPlugin.getAvailableAudioDevices().then((devices) => {
     devices.forEach((device) => {
       const option = document.createElement('option')
       option.value = device.deviceId


### PR DESCRIPTION
## Short description

Updates the Record example to use `RecordPlugin` instead of `record` to access the `getAvailableAudioDevices` function. 

## Implementation details

## How to test it

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
