### PR TITLE
Fix: setMediaElement to properly subscribe/unsubscribe media events

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -83,6 +83,10 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     this.media.load()
   }
 
+  protected setMediaElement(element: HTMLMediaElement) {
+    this.media = element
+  }
+
   /** Start playing the audio */
   public play(): Promise<void> {
     return this.media.play()
@@ -150,11 +154,6 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   /** Get the HTML media element */
   public getMediaElement(): HTMLMediaElement {
     return this.media
-  }
-
-  /** Set HTML media element */
-  public setMediaElement(element: HTMLMediaElement) {
-    this.media = element
   }
 
   /** Set a sink id to change the audio output device */


### PR DESCRIPTION
## Short description
When we change the underlying `media` element using `setMediaElement` the progress bar would not update as the track was playing. This was because of various media events subscriptions was missing. 
 
Resolves #3266

## Implementation details
To ensure that we are properly handling setting of a new media element `setMediaElement` has been tweaked as follows:

1. Unsubscribe from all event listeners for current `media` element
2. Attach the new `media` element
3. Subscribe to media (player) events for newly attached `media`

## How to test it

1. Create a Wavesurfer instance
2. Attached another `media` element using `setMediaElement`
3. Play

The progress bar should be updated as the track play progresses.

## Screenshots


## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
