### PR TITLE
Emit 'ready' event before returning from loadPredecoded

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -334,6 +334,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       this.decodedData = Decoder.createBuffer(this.options.peaks, this.options.duration)
       await Promise.resolve() // wait for event listeners to subscribe
       this.renderDecoded()
+      this.emit('ready', this.getDuration())
     }
   }
 


### PR DESCRIPTION
## Short description
Resolves #3287

## Implementation details
Emit `ready` event before returning from `loadPredecoded`

## How to test it
Same as done in #3287

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
