### PR TITLE
set public renderMicStream of Record plugin

### DIFF
--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -47,7 +47,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     return new RecordPlugin(options || {})
   }
 
-  private renderMicStream(stream: MediaStream): () => void {
+  public renderMicStream(stream: MediaStream): () => void {
     const audioContext = new AudioContext()
     const source = audioContext.createMediaStreamSource(stream)
     const analyser = audioContext.createAnalyser()


### PR DESCRIPTION
## Implementation details
You can now use a real-time MediaStream object to generate waves with Record plugin

## How to test it
Example get stream by tag audio

## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
