### PR TITLE
Feat: Record plugin - streaming waveform animation

### DIFF
--- a/examples/record.js
+++ b/examples/record.js
@@ -18,7 +18,7 @@ const createWaveSurfer = () => {
   })
 
   // Initialize the Record plugin
-  record = wavesurfer.registerPlugin(RecordPlugin.create({ scrollingWaveform }))
+  record = wavesurfer.registerPlugin(RecordPlugin.create({ scrollingWaveform, renderRecordedAudio: false }))
   // Render recorded audio
   record.on('record-end', (blob) => {
     const container = document.querySelector('#recordings')

--- a/examples/record.js
+++ b/examples/record.js
@@ -3,44 +3,54 @@
 import WaveSurfer from 'https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.esm.js'
 import RecordPlugin from 'https://unpkg.com/wavesurfer.js@7/dist/plugins/record.esm.js'
 
-// Create an instance of WaveSurfer
-const wavesurfer = WaveSurfer.create({
-  container: '#mic',
-  waveColor: 'rgb(200, 0, 200)',
-  progressColor: 'rgb(100, 0, 100)',
-})
+let wavesurfer, record
+let scrollingWaveform = false
 
-// Initialize the Record plugin
-const record = wavesurfer.registerPlugin(RecordPlugin.create())
-
-// Render recorded audio
-record.on('record-end', (blob) => {
-  const container = document.querySelector('#recordings')
-  const recordedUrl = URL.createObjectURL(blob)
-
-  // Create wavesurfer from the recorded audio
-  const wavesurfer = WaveSurfer.create({
-    container,
-    waveColor: 'rgb(200, 100, 0)',
-    progressColor: 'rgb(100, 50, 0)',
-    url: recordedUrl,
+const createWaveSurfer = () => {
+  // Create an instance of WaveSurfer
+  if (wavesurfer) {
+    wavesurfer.destroy()
+  }
+  wavesurfer = WaveSurfer.create({
+    container: '#mic',
+    waveColor: 'rgb(200, 0, 200)',
+    progressColor: 'rgb(100, 0, 100)',
   })
 
-  // Play button
-  const button = container.appendChild(document.createElement('button'))
-  button.textContent = 'Play'
-  button.onclick = () => wavesurfer.playPause()
-  wavesurfer.on('pause', () => (button.textContent = 'Play'))
-  wavesurfer.on('play', () => (button.textContent = 'Pause'))
+  // Initialize the Record plugin
+  record = wavesurfer.registerPlugin(RecordPlugin.create({ scrollingWaveform }))
+  // Render recorded audio
+  record.on('record-end', (blob) => {
+    const container = document.querySelector('#recordings')
+    const recordedUrl = URL.createObjectURL(blob)
 
-  // Download link
-  const link = container.appendChild(document.createElement('a'))
-  Object.assign(link, {
-    href: recordedUrl,
-    download: 'recording.' + blob.type.split(';')[0].split('/')[1] || 'webm',
-    textContent: 'Download recording',
+    // Create wavesurfer from the recorded audio
+    const wavesurfer = WaveSurfer.create({
+      container,
+      waveColor: 'rgb(200, 100, 0)',
+      progressColor: 'rgb(100, 50, 0)',
+      url: recordedUrl,
+    })
+
+    // Play button
+    const button = container.appendChild(document.createElement('button'))
+    button.textContent = 'Play'
+    button.onclick = () => wavesurfer.playPause()
+    wavesurfer.on('pause', () => (button.textContent = 'Play'))
+    wavesurfer.on('play', () => (button.textContent = 'Pause'))
+
+    // Download link
+    const link = container.appendChild(document.createElement('a'))
+    Object.assign(link, {
+      href: recordedUrl,
+      download: 'recording.' + blob.type.split(';')[0].split('/')[1] || 'webm',
+      textContent: 'Download recording',
+    })
   })
-})
+  pauseButton.style.display = 'none'
+  recButton.textContent = 'Record'
+}
+
 const pauseButton = document.querySelector('#pause')
 pauseButton.onclick = () => {
   if (record.isPaused()) {
@@ -65,28 +75,35 @@ const micSelect = document.querySelector('#mic-select')
     })
   })
 }
-{
-  // Record button
-  const recButton = document.querySelector('#record')
+// Record button
+const recButton = document.querySelector('#record')
 
-  recButton.onclick = () => {
-    if (record.isRecording()) {
-      record.stopRecording()
-      recButton.textContent = 'Record'
-      pauseButton.style.display = 'none'
-      return
-    }
-
-    recButton.disabled = true
-    // get selected device
-    const deviceId = micSelect.value
-    record.startRecording({ deviceId }).then(() => {
-      recButton.textContent = 'Stop'
-      recButton.disabled = false
-      pauseButton.style.display = 'inline'
-    })
+recButton.onclick = () => {
+  if (record.isRecording()) {
+    record.stopRecording()
+    recButton.textContent = 'Record'
+    pauseButton.style.display = 'none'
+    return
   }
+
+  recButton.disabled = true
+
+  // reset the wavesurfer instance
+
+  // get selected device
+  const deviceId = micSelect.value
+  record.startRecording({ deviceId }).then(() => {
+    recButton.textContent = 'Stop'
+    recButton.disabled = false
+    pauseButton.style.display = 'inline'
+  })
 }
+document.querySelector('input[type="checkbox"]').onclick = (e) => {
+  scrollingWaveform = e.target.checked
+  createWaveSurfer()
+}
+
+createWaveSurfer()
 
 /*
 <html>
@@ -102,6 +119,8 @@ const micSelect = document.querySelector('#mic-select')
   <select id="mic-select">
     <option value="" hidden>Select mic</option>
   </select>
+  <label style="display:inline-block;"><input type="checkbox"  /> Scrolling waveform</label>
+
   <div id="mic" style="border: 1px solid #ddd; border-radius: 4px; margin-top: 1rem"></div>
 
   <div id="recordings" style="margin: 1rem 0"></div>

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -11,6 +11,10 @@ export type RecordPluginOptions = {
   audioBitsPerSecond?: MediaRecorderOptions['audioBitsPerSecond']
   /** Whether to render the recorded audio, true by default */
   renderRecordedAudio?: boolean
+  /** Whether to render the scrolling waveform, true by default */
+  scrollingWaveform?: boolean
+  /** The duration of the scrolling waveform window, defaults to 5 seconds */
+  scrollingWaveformWindow?: number
 }
 
 export type RecordPluginDeviceOptions = {
@@ -25,7 +29,13 @@ export type RecordPluginEvents = BasePluginEvents & {
   'record-end': [blob: Blob]
 }
 
+type MicStream = {
+  onDestroy: () => void
+  onEnd: () => void
+}
+
 const DEFAULT_BITS_PER_SECOND = 128000
+const DEFAULT_SCROLLING_WAVEFORM_WINDOW = 5
 
 const MIME_TYPES = ['audio/webm', 'audio/wav', 'audio/mpeg', 'audio/mp4', 'audio/mp3']
 const findSupportedMimeType = () => MIME_TYPES.find((mimeType) => MediaRecorder.isTypeSupported(mimeType))
@@ -33,12 +43,17 @@ const findSupportedMimeType = () => MIME_TYPES.find((mimeType) => MediaRecorder.
 class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   private stream: MediaStream | null = null
   private mediaRecorder: MediaRecorder | null = null
+  private dataWindow: Float32Array | null = null
+  private isWaveformPaused = false
 
   /** Create an instance of the Record plugin */
   constructor(options: RecordPluginOptions) {
     super({
       ...options,
       audioBitsPerSecond: options.audioBitsPerSecond ?? DEFAULT_BITS_PER_SECOND,
+      scrollingWaveform: options.scrollingWaveform ?? false,
+      scrollingWaveformWindow: options.scrollingWaveformWindow ?? DEFAULT_SCROLLING_WAVEFORM_WINDOW,
+      renderRecordedAudio: options.renderRecordedAudio ?? false,
     })
   }
 
@@ -47,7 +62,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     return new RecordPlugin(options || {})
   }
 
-  public renderMicStream(stream: MediaStream): () => void {
+  public renderMicStream(stream: MediaStream): MicStream {
     const audioContext = new AudioContext()
     const source = audioContext.createMediaStreamSource(stream)
     const analyser = audioContext.createAnalyser()
@@ -55,26 +70,58 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
 
     const bufferLength = analyser.frequencyBinCount
     const dataArray = new Float32Array(bufferLength)
-    const sampleDuration = bufferLength / audioContext.sampleRate
 
     let animationId: number
 
+    const windowSize = Math.floor(this.options.scrollingWaveformWindow! * audioContext.sampleRate)
+
     const drawWaveform = () => {
+      if (this.isWaveformPaused) {
+        animationId = requestAnimationFrame(drawWaveform)
+        return
+      }
+
       analyser.getFloatTimeDomainData(dataArray)
+
+      if (this.options.scrollingWaveform) {
+        const newLength = Math.min(windowSize, this.dataWindow ? this.dataWindow.length + bufferLength : bufferLength)
+        const tempArray = new Float32Array(windowSize) // Always make it the size of the window, filling with zeros by default
+
+        if (this.dataWindow) {
+          const startIdx = Math.max(0, windowSize - this.dataWindow.length)
+          tempArray.set(this.dataWindow.slice(-newLength + bufferLength), startIdx)
+        }
+
+        tempArray.set(dataArray, windowSize - bufferLength)
+        this.dataWindow = tempArray
+      } else {
+        this.dataWindow = dataArray
+      }
+
+      const duration = this.options.scrollingWaveformWindow
+
       if (this.wavesurfer) {
         this.wavesurfer.options.cursorWidth = 0
         this.wavesurfer.options.interact = false
-        this.wavesurfer.load('', [dataArray], sampleDuration)
+        this.wavesurfer.load('', [this.dataWindow], duration)
       }
+
       animationId = requestAnimationFrame(drawWaveform)
     }
 
     drawWaveform()
 
-    return () => {
-      cancelAnimationFrame(animationId)
-      source?.disconnect()
-      audioContext?.close()
+    return {
+      onDestroy: () => {
+        cancelAnimationFrame(animationId)
+        source?.disconnect()
+        audioContext?.close()
+      },
+      onEnd: () => {
+        this.isWaveformPaused = true
+        cancelAnimationFrame(animationId)
+        this.stopMic()
+      },
     }
   }
 
@@ -89,10 +136,9 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
       throw new Error('Error accessing the microphone: ' + (err as Error).message)
     }
 
-    const onDestroy = this.renderMicStream(stream)
-
+    const { onDestroy, onEnd } = this.renderMicStream(stream)
     this.subscriptions.push(this.once('destroy', onDestroy))
-
+    this.subscriptions.push(this.once('record-end', onEnd))
     this.stream = stream
 
     return stream
@@ -109,7 +155,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   /** Start recording audio from the microphone */
   public async startRecording(options?: RecordPluginDeviceOptions) {
     const stream = this.stream || (await this.startMic(options))
-
+    this.dataWindow = null
     const mediaRecorder =
       this.mediaRecorder ||
       new MediaRecorder(stream, {
@@ -138,6 +184,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     }
 
     mediaRecorder.start()
+    this.isWaveformPaused = false
 
     this.emit('record-start')
   }
@@ -151,9 +198,13 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     return this.mediaRecorder?.state === 'paused'
   }
 
+  public isActive(): boolean {
+    return this.mediaRecorder?.state !== 'inactive'
+  }
+
   /** Stop the recording */
   public stopRecording() {
-    if (this.isRecording()) {
+    if (this.isActive()) {
       this.mediaRecorder?.stop()
     }
   }
@@ -161,6 +212,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   /** Pause the recording */
   public pauseRecording() {
     if (this.isRecording()) {
+      this.isWaveformPaused = true
       this.mediaRecorder?.pause()
       this.emit('record-pause')
     }
@@ -169,6 +221,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   /** Resume the recording */
   public resumeRecording() {
     if (this.isPaused()) {
+      this.isWaveformPaused = false
       this.mediaRecorder?.resume()
       this.emit('record-resume')
     }

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -11,7 +11,7 @@ export type RecordPluginOptions = {
   audioBitsPerSecond?: MediaRecorderOptions['audioBitsPerSecond']
   /** Whether to render the recorded audio, true by default */
   renderRecordedAudio?: boolean
-  /** Whether to render the scrolling waveform, true by default */
+  /** Whether to render the scrolling waveform, false by default */
   scrollingWaveform?: boolean
   /** The duration of the scrolling waveform window, defaults to 5 seconds */
   scrollingWaveformWindow?: number
@@ -53,7 +53,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
       audioBitsPerSecond: options.audioBitsPerSecond ?? DEFAULT_BITS_PER_SECOND,
       scrollingWaveform: options.scrollingWaveform ?? false,
       scrollingWaveformWindow: options.scrollingWaveformWindow ?? DEFAULT_SCROLLING_WAVEFORM_WINDOW,
-      renderRecordedAudio: options.renderRecordedAudio ?? false,
+      renderRecordedAudio: options.renderRecordedAudio ?? true,
     })
   }
 
@@ -178,7 +178,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
 
       this.emit('record-end', blob)
 
-      if (this.options.renderRecordedAudio !== false) {
+      if (this.options.renderRecordedAudio) {
         this.wavesurfer?.load(URL.createObjectURL(blob))
       }
     }


### PR DESCRIPTION
## Short description
Adds an option to the Record plugin to render a streaming waveform while recording. Limited to a given window of time (default 5s).

## Implementation details
Adds two options to the plugin config when calling `RecordPlugin.create()`
```ts
/** Whether to render the scrolling waveform, true by default */
scrollingWaveform?: boolean
/** The duration of the scrolling waveform window, defaults to 5 seconds */
scrollingWaveformWindow?: number
```
Left unset, the plugin works the same as before.

Also
- FIXED: stop while in paused state, works as expected
- FEAT: pausing the recording, pauses the wave display 

Note: This is my first contribution to this repo, so I'm not too sure of the protocol. If this is something you want to edit, give a bit of time, or ditch - I won't be offended 👍

## How to test it
Demo here https://wave-record-demo.pages.dev/
Tested on Mac Chrome, Safari. iOS Chrome, Safari

## Video
https://github.com/katspaugh/wavesurfer.js/assets/1137909/4325ea2a-efb7-4f40-aeb8-f434ed32f133


## Drawbacks
- Using `barGap` and `barWidth` may make the animation jittery as it doesn't account for any offset on the canvas.

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
