### PR TITLE
Fix: uncaught error in fetch progress reader

### DIFF
--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -73,7 +73,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
 
     let animationId: number
 
-    const windowSize = Math.floor(this.options.scrollingWaveformWindow! * audioContext.sampleRate)
+    const windowSize = Math.floor((this.options.scrollingWaveformWindow || 0) * audioContext.sampleRate)
 
     const drawWaveform = () => {
       if (this.isWaveformPaused) {


### PR DESCRIPTION
## Short description
Resolves https://github.com/katspaugh/wavesurfer.js/discussions/3313

## Implementation details

We clone the fetch response to track loading progress, so errors need to be caught for both the main fetch promise and the progress reader.