### PR TITLE
Fix: allow loading an empty URL string with peaks

### DIFF
--- a/cypress/e2e/options.cy.js
+++ b/cypress/e2e/options.cy.js
@@ -544,9 +544,8 @@ describe('WaveSurfer options tests', () => {
         duration: 12.5,
       })
 
-      expect(wavesurfer.getDuration().toFixed(2)).to.equal('12.50')
-
       wrapReady(wavesurfer, 'redraw').then(() => {
+        expect(wavesurfer.getDuration().toFixed(2)).to.equal('12.50')
         cy.get(id).matchImageSnapshot('pre-decoded-no-audio')
         done()
       })

--- a/src/plugins/minimap.ts
+++ b/src/plugins/minimap.ts
@@ -91,9 +91,9 @@ class MinimapPlugin extends BasePlugin<MinimapPluginEvents, MinimapPluginOptions
     const media = this.wavesurfer.getMediaElement()
     if (!data || !media) return
 
-    const peaks = [];
+    const peaks = []
     for (let i = 0; i < data.numberOfChannels; i++) {
-      peaks.push(data.getChannelData(i));
+      peaks.push(data.getChannelData(i))
     }
 
     this.miniWavesurfer = WaveSurfer.create({

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -345,7 +345,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
     // Wait for the audio duration
     // It should be a promise to allow event listeners to subscribe to the ready and decode events
-    duration =
+    const audioDuration =
       (await Promise.resolve(duration || this.getDuration())) ||
       (await new Promise((resolve) => {
         this.onceMediaEvent('loadedmetadata', () => resolve(this.getDuration()))
@@ -353,7 +353,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
     // Decode the audio data or use user-provided peaks
     if (channelData) {
-      this.decodedData = Decoder.createBuffer(channelData, duration || 0)
+      this.decodedData = Decoder.createBuffer(channelData, audioDuration || 0)
     } else if (blob) {
       const arrayBuffer = await blob.arrayBuffer()
       this.decodedData = await Decoder.decode(arrayBuffer, this.options.sampleRate)


### PR DESCRIPTION
## Short description
Resolves #3324

## Implementation details
The `load` method will not attempt to fetch an empty URL. It will just render a predecoded waveform if peaks and duration are provided.
