### PR TITLE
Fix timeupdate render to use requestAnimationFrame

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -190,7 +190,10 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       const currentTime = this.getCurrentTime()
       this.renderer.renderProgress(currentTime / this.getDuration(), this.isPlaying())
       this.emit('timeupdate', currentTime)
-      requestAnimationFrame(timeUpdateRerender)
+
+      if(this.isPlaying()){
+        requestAnimationFrame(timeUpdateRerender)
+      }
     }
 
     this.mediaSubscriptions.push(
@@ -407,7 +410,11 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       const sampleSize = Math.round(channel.length / maxLength)
       for (let i = 0; i < maxLength; i++) {
         const sample = channel.slice(i * sampleSize, (i + 1) * sampleSize)
-        const max = Math.max(...sample)
+        let max = 0
+        for (let x = 0; x < sample.length; x++) {
+          const n = sample[x]
+          if (Math.abs(n) > Math.abs(max)) max = n
+        }
         data.push(Math.round(max * precision) / precision)
       }
       peaks.push(data)

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -186,12 +186,15 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   }
 
   private initPlayerEvents() {
+    const timeUpdateRerender = () => {
+      const currentTime = this.getCurrentTime()
+      this.renderer.renderProgress(currentTime / this.getDuration(), this.isPlaying())
+      this.emit('timeupdate', currentTime)
+      requestAnimationFrame(timeUpdateRerender)
+    }
+
     this.mediaSubscriptions.push(
-      this.onMediaEvent('timeupdate', () => {
-        const currentTime = this.getCurrentTime()
-        this.renderer.renderProgress(currentTime / this.getDuration(), this.isPlaying())
-        this.emit('timeupdate', currentTime)
-      }),
+      this.onMediaEvent('timeupdate', timeUpdateRerender),
 
       this.onMediaEvent('play', () => {
         this.emit('play')
@@ -404,11 +407,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       const sampleSize = Math.round(channel.length / maxLength)
       for (let i = 0; i < maxLength; i++) {
         const sample = channel.slice(i * sampleSize, (i + 1) * sampleSize)
-        let max = 0
-        for (let x = 0; x < sample.length; x++) {
-          const n = sample[x]
-          if (Math.abs(n) > Math.abs(max)) max = n
-        }
+        const max = Math.max(...sample)
         data.push(Math.round(max * precision) / precision)
       }
       peaks.push(data)

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -197,6 +197,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
         this.renderer.renderProgress(currentTime / this.getDuration(), this.isPlaying())
         this.emit('timeupdate', currentTime)
       }),
+      
       this.onMediaEvent('play', () => {
         this.emit('play')
         this.timer.start()

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -186,7 +186,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   }
 
   private initPlayerEvents() {
-    if(this.isPlaying()){
+    if (this.isPlaying()) {
       this.emit('play')
       this.timer.start()
     }
@@ -197,7 +197,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
         this.renderer.renderProgress(currentTime / this.getDuration(), this.isPlaying())
         this.emit('timeupdate', currentTime)
       }),
-      
+
       this.onMediaEvent('play', () => {
         this.emit('play')
         this.timer.start()

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -186,19 +186,17 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   }
 
   private initPlayerEvents() {
-    const timeUpdateRerender = () => {
-      const currentTime = this.getCurrentTime()
-      this.renderer.renderProgress(currentTime / this.getDuration(), this.isPlaying())
-      this.emit('timeupdate', currentTime)
-
-      if(this.isPlaying()){
-        requestAnimationFrame(timeUpdateRerender)
-      }
+    if(this.isPlaying()){
+      this.emit('play');
+      this.timer.start()
     }
 
     this.mediaSubscriptions.push(
-      this.onMediaEvent('timeupdate', timeUpdateRerender),
-
+      this.onMediaEvent('timeupdate', () => {
+        const currentTime = this.getCurrentTime()
+        this.renderer.renderProgress(currentTime / this.getDuration(), this.isPlaying())
+        this.emit('timeupdate', currentTime)
+      }),
       this.onMediaEvent('play', () => {
         this.emit('play')
         this.timer.start()

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -187,7 +187,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
   private initPlayerEvents() {
     if(this.isPlaying()){
-      this.emit('play');
+      this.emit('play')
       this.timer.start()
     }
 


### PR DESCRIPTION
## Short description
Resolves #

## Implementation details
Changed how initial re-rendering is handled. Previously, this wasn't wrapped with requestAnimationFrame and that's why the global waveform was laggy on the first play (it was perfectly fine when pausing and resuming)

## How to test it
Go to [example](https://wavesurfer.xyz/examples/?react-global-player.js) and try to play 2nd track. The row waveform will be playing perfectly, the global one will lag. Try to run this PR locally and you'll see that this lag is gone now due to requestAnimationFrame.

## Screenshots


## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
