### PR TITLE
Ensure compatability between TimelinePlugin and RegionsPlugin

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -402,6 +402,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
 
   private initRegionsContainer(): HTMLElement {
     const div = document.createElement('div')
+    div.setAttribute('part', 'regions')
     div.setAttribute(
       'style',
       `
@@ -509,8 +510,8 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
    * Returns a function to disable the drag selection.
    */
   public enableDragSelection(options: Omit<RegionParams, 'start' | 'end'>): () => void {
-    const wrapper = this.wavesurfer?.getWrapper()?.querySelector('div')
-    if (!wrapper) return () => undefined
+    const wrapper = this.wavesurfer?.getWrapper()?.querySelector('div.canvases')
+    if (!wrapper || !(wrapper instanceof HTMLElement)) return () => undefined
 
     const initialSize = 5
     let region: Region | null = null

--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -49,7 +49,7 @@ export type TimelinePluginEvents = BasePluginEvents & {
 }
 
 class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOptions> {
-  private timelineWrapper: HTMLElement
+  public timelineWrapper: HTMLElement
   protected options: TimelinePluginOptions & typeof defaultOptions
 
   constructor(options?: TimelinePluginOptions) {
@@ -103,6 +103,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
   private initTimelineWrapper(): HTMLElement {
     const div = document.createElement('div')
     div.setAttribute('part', 'timeline')
+    div.setAttribute('style', 'pointer-events: none;')
     return div
   }
 


### PR DESCRIPTION
A few sensible changes to ensure safe interaction between the TimelinePlugin and RegionsPlugin in the DOM.

## Short description
Resolves #3293

## Implementation details
TimelinePlugin wrapper element has `pointer-events: none;` to ensure mouse interaction with other elements above or below the timeline. The RegionsPlugin targets the `canvases` div in `this.wavesurfer.getWrapper()` as the draggable target to avoid unexpectedly targeting an incorrect div.

## How to test it
```typescript
const wavesurfer = WaveSurfer.create({
  container: '#wavesurfer-container',
})
const timeline = TimelinePlugin.create({
  container: wavesurfer.getWrapper(),
  insertPosition: 'beforebegin'
})
wavesurfer.registerPlugin(timeline)
const regions = RegionsPlugin.create()
wavesurfer.registerPlugin(regions)
regions.enableDragSelection()
```
Dragging anywhere on the canvas, including over the timeline, should create a region.

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
