### PR TITLE
Fix: [Regions] region-in/out event for markers

### DIFF
--- a/examples/regions.js
+++ b/examples/regions.js
@@ -76,9 +76,11 @@ document.querySelector('input[type="checkbox"]').onclick = (e) => {
 {
   let activeRegion = null
   wsRegions.on('region-in', (region) => {
+    console.log('region-in', region)
     activeRegion = region
   })
   wsRegions.on('region-out', (region) => {
+    console.log('region-out', region)
     if (activeRegion === region) {
       if (loop) {
         region.play()

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -379,7 +379,11 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     this.subscriptions.push(
       this.wavesurfer.on('timeupdate', (currentTime) => {
         // Detect when regions are being played
-        const playedRegions = this.regions.filter((region) => region.start <= currentTime && region.end >= currentTime)
+        const playedRegions = this.regions.filter(
+          (region) =>
+            region.start <= currentTime &&
+            (region.end === region.start ? region.start + 0.05 : region.end) >= currentTime,
+        )
 
         // Trigger region-in when activeRegions doesn't include a played regions
         playedRegions.forEach((region) => {


### PR DESCRIPTION
## Short description
Resolves #3328

## Implementation details

Markers' `end` position is equal to the `start` position, so the current region detection wasn't working.