### PR TITLE
Type minimap container as optional

### DIFF
--- a/src/plugins/minimap.ts
+++ b/src/plugins/minimap.ts
@@ -8,7 +8,7 @@ import WaveSurfer, { type WaveSurferOptions } from '../wavesurfer.js'
 export type MinimapPluginOptions = {
   overlayColor?: string
   insertPosition?: InsertPosition
-} & WaveSurferOptions
+} & Partial<WaveSurferOptions>
 
 const defaultOptions = {
   height: 50,


### PR DESCRIPTION
Makes the minimap option `container` optional.

In the options passed to `MinimapPlugin.create()`, the `container` option is optional. However, the typing has it set as required. Not including it resulted in the TypeScript error `TS2345: Argument of type {} is not assignable to parameter of type MinimapPluginOptions. Property container is missing in type {} but required in type WaveSurferOptions.` This PR removes that error since the option is not required, and in fact, the minimap code handles the case where `container` is undefined.

The previous workaround was to coerce the typing: `MinimapPlugin.create({} as MinimapPluginOptions)`

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
