### PR TITLE
Zoom plugin improvements

### DIFF
--- a/examples/zoom-plugin.js
+++ b/examples/zoom-plugin.js
@@ -19,8 +19,8 @@ const wavesurfer = WaveSurfer.create({
 // Initialize the Zoom plugin
 wavesurfer.registerPlugin(
   ZoomPlugin.create({
-    // the amount of zoom per wheel step, e.g. 0.1 means a 10% magnification per scroll
-    scale: 0.2,
+    // the amount of zoom per wheel step, e.g. 0.5 means a 50% magnification per scroll
+    scale: 0.5,
   }),
 )
 

--- a/examples/zoom-plugin.js
+++ b/examples/zoom-plugin.js
@@ -21,6 +21,8 @@ wavesurfer.registerPlugin(
   ZoomPlugin.create({
     // the amount of zoom per wheel step, e.g. 0.5 means a 50% magnification per scroll
     scale: 0.5,
+    // Optionally, specify the maximum pixels-per-second factor while zooming
+    maxZoom: 100,
   }),
 )
 

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -20,10 +20,10 @@
 import { BasePlugin, BasePluginEvents } from '../base-plugin.js'
 
 export type ZoomPluginOptions = {
-  scale?: number // the amount of zoom per wheel step, e.g. 0.1 means a 10% magnification per scroll
+  scale?: number // the amount of zoom per wheel step, e.g. 0.5 means a 50% magnification per scroll
 }
 const defaultOptions = {
-  scale: 0.2,
+  scale: 0.5,
 }
 
 export type ZoomPluginEvents = BasePluginEvents

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -52,7 +52,7 @@ class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
   }
 
   private onWheel = (e: WheelEvent) => {
-    if (!this.wavesurfer?.options.minPxPerSec || !this.container || Math.abs(e.deltaX) >= Math.abs(e.deltaY)) {
+    if (!this.wavesurfer || !this.container || Math.abs(e.deltaX) >= Math.abs(e.deltaY)) {
       return
     }
     // prevent scrolling the sidebar while zooming

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -60,18 +60,12 @@ class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
 
     const duration = this.wavesurfer.getDuration()
     const oldMinPxPerSec = this.wavesurfer.options.minPxPerSec
-    const x = e.clientX
     const width = this.container.clientWidth
-    const scrollX = this.wavesurfer.getScroll()
-    const pointerTime = (scrollX + x) / oldMinPxPerSec
     const newMinPxPerSec = oldMinPxPerSec * (e.deltaY > 0 ? 1 - this.options.scale : 1 + this.options.scale)
-    const newLeftSec = (width / newMinPxPerSec) * (x / width)
     if (newMinPxPerSec * duration < width) {
       this.wavesurfer.zoom(width / duration)
-      this.container.scrollLeft = 0
     } else {
       this.wavesurfer.zoom(newMinPxPerSec)
-      this.container.scrollLeft = (pointerTime - newLeftSec) * newMinPxPerSec
     }
   }
 

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -61,12 +61,18 @@ class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
 
     const duration = this.wavesurfer.getDuration()
     const oldMinPxPerSec = this.wavesurfer.options.minPxPerSec
+    const x = e.clientX
     const width = this.container.clientWidth
+    const scrollX = this.wavesurfer.getScroll()
+    const pointerTime = (scrollX + x) / oldMinPxPerSec
     const newMinPxPerSec = this.calculateNewZoom(oldMinPxPerSec, -e.deltaY)
+    const newLeftSec = (width / newMinPxPerSec) * (x / width)
     if (newMinPxPerSec * duration < width) {
       this.wavesurfer.zoom(width / duration)
+      this.container.scrollLeft = 0
     } else {
       this.wavesurfer.zoom(newMinPxPerSec)
+      this.container.scrollLeft = (pointerTime - newLeftSec) * newMinPxPerSec
     }
   }
 

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -52,7 +52,7 @@ class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
   }
 
   private onWheel = (e: WheelEvent) => {
-    if (!this.wavesurfer?.options.minPxPerSec || !this.container) {
+    if (!this.wavesurfer?.options.minPxPerSec || !this.container || Math.abs(e.deltaX) >= Math.abs(e.deltaY)) {
       return
     }
     // prevent scrolling the sidebar while zooming

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -61,7 +61,7 @@ class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
     const duration = this.wavesurfer.getDuration()
     const oldMinPxPerSec = this.wavesurfer.options.minPxPerSec
     const width = this.container.clientWidth
-    const newMinPxPerSec = oldMinPxPerSec * (e.deltaY > 0 ? 1 - this.options.scale : 1 + this.options.scale)
+    const newMinPxPerSec = Math.max(0, oldMinPxPerSec - e.deltaY * this.options.scale)
     if (newMinPxPerSec * duration < width) {
       this.wavesurfer.zoom(width / duration)
     } else {


### PR DESCRIPTION
This makes changes to `ZoomPlugin`, which was added in #3276. Each change is on its own commit on this branch, to make reversions/modifications easier if requested before approval.

### Fix scroll when using trackpad
The zoom is currently triggered by the wheel event. On a trackpad, horizontal scrolling fires a wheel event with both an X- and Y- delta, unless the user scrolls perfectly horizontally on the trackpad, which is not typical. This creates a poor UX when the user is attempting to scroll because the waveform errantly zooms simultaneously. This PR changes the event listener to perform a zoom only when the Y-delta is greater than the X-delta, which is the case for the pinch gesture.

### Account for wheel speed when zooming (breaking change)
Currently the zoom level is adjusted by the same amount for each wheel event that is fired. This PR changes the event listener to adjust the zoom level in proportion to the scroll/pinch distance. This offers a more consistent UX than relying on the quantity of event instances. As a result, `scale` changes from a magnification factor to a coefficient. A scale of `.2` felt too unresponsive with the new formula so this changes the default to `.5`.

### Allow using zoom plugin when `minPxPerSec` is 0 or default
The zoom formula that this change introduces swapped `scale` for `minPxPerSec` as the coefficient. Therefore, it is now possible to use this plugin without first having set `minPxPerSec` to a non-zero value.

 ### Add `maxZoom` option
Optional. Specifies a maximum `minPxPerSec` value while zooming.


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
