### PR TITLE
fixes 3390 covertColorValues vertical color gradient is misaligned when devicePixelRatio is not 1

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -259,7 +259,8 @@ class Renderer extends EventEmitter<RendererEvents> {
 
     const canvasElement = document.createElement('canvas')
     const ctx = canvasElement.getContext('2d') as CanvasRenderingContext2D
-    const gradient = ctx.createLinearGradient(0, 0, 0, canvasElement.height)
+    const gradientHeight = canvasElement.height * (window.devicePixelRatio || 1)
+    const gradient = ctx.createLinearGradient(0, 0, 0, gradientHeight)
 
     const colorStopPercentage = 1 / (color.length - 1)
     color.forEach((color, index) => {


### PR DESCRIPTION
renderer: covertColorValues vertical color gradient is misaligned when devicePixelRatio is not 1

## Short description
Resolves #3390

## Implementation details
In renderer.ts `convertColorValues`
```
    const gradientHeight = canvasElement.height * (window.devicePixelRatio || 1)
    const gradient = ctx.createLinearGradient(0, 0, 0, gradientHeight)
```

## How to test it
Add a color gradient array. Check on desktop and then on mobile. Gradient on mobile is misaligned before fix. Post fix, it will align on different screens as expected.