### PR TITLE
Fix: [Zoom] Performance improvements (especially w/ trackpad zoom)

### DIFF
--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -33,13 +33,13 @@ export type ZoomPluginOptions = {
    * The amount the wheel or trackpad needs to be moved before zooming the waveform. Set this value to 0 to have totally
    * fluid zooming (this has a high CPU cost).
    *
-   * @default 10
+   * @default 5
    */
   deltaThreshold?: number
 }
 const defaultOptions = {
   scale: 0.5,
-  deltaThreshold: 10,
+  deltaThreshold: 5,
 }
 
 export type ZoomPluginEvents = BasePluginEvents

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -86,10 +86,7 @@ class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
       const width = this.container.clientWidth
       const scrollX = this.wavesurfer.getScroll()
       const pointerTime = (scrollX + x) / oldMinPxPerSec
-      const newMinPxPerSec = this.calculateNewZoom(
-        oldMinPxPerSec,
-        this.options.deltaThreshold > 0 ? this.accumulatedDelta : -e.deltaY,
-      )
+      const newMinPxPerSec = this.calculateNewZoom(oldMinPxPerSec, this.accumulatedDelta)
       const newLeftSec = (width / newMinPxPerSec) * (x / width)
 
       if (newMinPxPerSec * duration < width) {

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -4,6 +4,8 @@
  * Zoom in or out on the waveform when scrolling the mouse wheel
  *
  * @author HoodyHuo (https://github.com/HoodyHuo)
+ * @author Chris Morbitzer (https://github.com/cmorbitzer)
+ * @author Sam Hulick (https://github.com/ffxsam)
  *
  * @example
  * // ... initialising wavesurfer with the plugin
@@ -20,11 +22,24 @@
 import { BasePlugin, BasePluginEvents } from '../base-plugin.js'
 
 export type ZoomPluginOptions = {
-  scale?: number // the amount of zoom per wheel step, e.g. 0.5 means a 50% magnification per scroll
-  maxZoom?: number // the maximum pixels-per-second factor while zooming
+  /**
+   * The amount of zoom per wheel step, e.g. 0.5 means a 50% magnification per scroll
+   *
+   * @default 0.5
+   */
+  scale?: number
+  maxZoom?: number // The maximum pixels-per-second factor while zooming
+  /**
+   * The amount the wheel or trackpad needs to be moved before zooming the waveform. Set this value to 0 to have totally
+   * fluid zooming (this has a high CPU cost).
+   *
+   * @default 10
+   */
+  deltaThreshold?: number
 }
 const defaultOptions = {
   scale: 0.5,
+  deltaThreshold: 10,
 }
 
 export type ZoomPluginEvents = BasePluginEvents
@@ -33,6 +48,7 @@ class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
   protected options: ZoomPluginOptions & typeof defaultOptions
   private wrapper: HTMLElement | undefined = undefined
   private container: HTMLElement | null = null
+  private accumulatedDelta = 0
 
   constructor(options?: ZoomPluginOptions) {
     super(options || {})
@@ -59,20 +75,33 @@ class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
     // prevent scrolling the sidebar while zooming
     e.preventDefault()
 
-    const duration = this.wavesurfer.getDuration()
-    const oldMinPxPerSec = this.wavesurfer.options.minPxPerSec
-    const x = e.clientX
-    const width = this.container.clientWidth
-    const scrollX = this.wavesurfer.getScroll()
-    const pointerTime = (scrollX + x) / oldMinPxPerSec
-    const newMinPxPerSec = this.calculateNewZoom(oldMinPxPerSec, -e.deltaY)
-    const newLeftSec = (width / newMinPxPerSec) * (x / width)
-    if (newMinPxPerSec * duration < width) {
-      this.wavesurfer.zoom(width / duration)
-      this.container.scrollLeft = 0
-    } else {
-      this.wavesurfer.zoom(newMinPxPerSec)
-      this.container.scrollLeft = (pointerTime - newLeftSec) * newMinPxPerSec
+    // Update the accumulated delta...
+    this.accumulatedDelta += -e.deltaY
+
+    // ...and only scroll once we've hit our threshold
+    if (this.options.deltaThreshold === 0 || Math.abs(this.accumulatedDelta) >= this.options.deltaThreshold) {
+      const duration = this.wavesurfer.getDuration()
+      const oldMinPxPerSec = this.wavesurfer.options.minPxPerSec
+      const x = e.clientX
+      const width = this.container.clientWidth
+      const scrollX = this.wavesurfer.getScroll()
+      const pointerTime = (scrollX + x) / oldMinPxPerSec
+      const newMinPxPerSec = this.calculateNewZoom(
+        oldMinPxPerSec,
+        this.options.deltaThreshold > 0 ? this.accumulatedDelta : -e.deltaY,
+      )
+      const newLeftSec = (width / newMinPxPerSec) * (x / width)
+
+      if (newMinPxPerSec * duration < width) {
+        this.wavesurfer.zoom(width / duration)
+        this.container.scrollLeft = 0
+      } else {
+        this.wavesurfer.zoom(newMinPxPerSec)
+        this.container.scrollLeft = (pointerTime - newLeftSec) * newMinPxPerSec
+      }
+
+      // Reset the accumulated delta
+      this.accumulatedDelta %= this.options.deltaThreshold
     }
   }
 

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -101,7 +101,7 @@ class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
       }
 
       // Reset the accumulated delta
-      this.accumulatedDelta %= this.options.deltaThreshold
+      this.accumulatedDelta = 0
     }
   }
 


### PR DESCRIPTION
## Short description
Zooming with a trackpad was causing huge CPU spikes due to constant redraws. This PR imposes rate limiting via a delta threshold before actually redrawing the waveform.

## Implementation details
Debounce & throttle were not appropriate here, as we don't necessarily want to throttle the events, we just want to ignore the "in-between" delta values and have a more notched zoom (a la Adobe Audition).

## How to test it
Test using any trackpad with smooth scrolling (i.e. lots of event firing when scrolling).

## Checklist
* [ ] This PR is covered by e2e tests
* [?] It introduces no breaking API changes
