### PR TITLE
Feat: Add timeline-notch-{mode} to part

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -185,7 +185,6 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     }
 
     const notchEl = document.createElement('div')
-    notchEl.setAttribute('part', 'timeline-notch')
     notchEl.setAttribute(
       'style',
       `
@@ -218,6 +217,9 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
         notch.textContent = this.options.formatTimeCallback(i)
         if (isPrimary) notch.style.opacity = '1'
       }
+
+      const mode = isPrimary ? 'primary' : isSecondary ? 'secondary' : 'tick'
+      notch.setAttribute('part', `timeline-notch timeline-notch-${mode}`)
 
       notch.style.left = `${i * pxPerSec}px`
       timeline.appendChild(notch)


### PR DESCRIPTION
## Short description
The current timeline plugin creates elements with `div[part=timeline-notch]`.  There are currently three different types of timeline notches: primary, secondary, and unlabeled tickmarks.  This PR appends one of the following to each notch element part:
* `timeline-notch-primary`
* `timeline-notch-seconary`
* `timeline-notch-tick`

Resolves #

## Implementation details
Updated `plugins/timeline.ts` to set the `part` attribute.

## How to test it
Inspect the timeline `div` tags in the examples section. All notch elements should contain one of the following:
- `part="timeline-notch timeline-notch-primary"`
- `part="timeline-notch timeline-notch-secondary"`
- `part="timeline-notch timeline-notch-tick"`

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
