### PR TITLE
Fix: splitChannels height

### DIFF
--- a/cypress/e2e/options.cy.js
+++ b/cypress/e2e/options.cy.js
@@ -309,6 +309,30 @@ describe('WaveSurfer options tests', () => {
     })
   })
 
+  it('should split channels with individual channel heights', (done) => {
+    cy.window().then((win) => {
+      const wavesurfer = win.WaveSurfer.create({
+        container: id,
+        url: '../../examples/audio/stereo.mp3',
+        splitChannels: [
+          {
+            waveColor: 'red',
+            height: 60,
+          },
+          {
+            waveColor: 'blue',
+            height: 30,
+          },
+        ],
+      })
+
+      wrapReady(wavesurfer).then(() => {
+        cy.get(id).matchImageSnapshot('split-channels-heights')
+        done()
+      })
+    })
+  })
+
   it('should use plugins with Regions', (done) => {
     cy.window().then((win) => {
       const regions = win.Regions.create()

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -122,11 +122,11 @@ class Renderer extends EventEmitter<RendererEvents> {
     )
   }
 
-  private getHeight(): number {
+  private getHeight(optionsHeight?: WaveSurferOptions['height']): number {
     const defaultHeight = 128
-    if (this.options.height == null) return defaultHeight
-    if (!isNaN(Number(this.options.height))) return Number(this.options.height)
-    if (this.options.height === 'auto') return this.parent.clientHeight || defaultHeight
+    if (optionsHeight == null) return defaultHeight
+    if (!isNaN(Number(optionsHeight))) return Number(optionsHeight)
+    if (optionsHeight === 'auto') return this.parent.clientHeight || defaultHeight
     return defaultHeight
   }
 
@@ -164,7 +164,7 @@ class Renderer extends EventEmitter<RendererEvents> {
           z-index: 2;
         }
         :host .canvases {
-          min-height: ${this.getHeight()}px;
+          min-height: ${this.getHeight(this.options.height)}px;
         }
         :host .canvases > div {
           position: relative;
@@ -448,7 +448,7 @@ class Renderer extends EventEmitter<RendererEvents> {
   private renderChannel(channelData: Array<Float32Array | number[]>, options: WaveSurferOptions, width: number) {
     // A container for canvases
     const canvasContainer = document.createElement('div')
-    const height = this.getHeight()
+    const height = this.getHeight(options.height)
     canvasContainer.style.height = `${height}px`
     this.canvasWrapper.style.minHeight = `${height}px`
     this.canvasWrapper.appendChild(canvasContainer)

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -62,7 +62,7 @@ export type WaveSurferOptions = {
   /** Decoding sample rate. Doesn't affect the playback. Defaults to 8000 */
   sampleRate?: number
   /** Render each audio channel as a separate waveform */
-  splitChannels?: WaveSurferOptions[]
+  splitChannels?: Partial<WaveSurferOptions>[]
   /** Stretch the waveform to the full height */
   normalize?: boolean
   /** The list of plugins to initialize on start */


### PR DESCRIPTION
## Short description
Resolves #3400 and #3395.

## Implementation details

Height in `splitChannels` is now taken into account when rendering individual channels.

<img width="418" alt="Screenshot 2023-12-12 at 15 15 27" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/cfbb1dea-2d10-40e6-a8e7-445a237f0aee">