### PR TITLE
Feat: Record plugin - support to play the recorded audio slice when t…

### DIFF
--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -102,14 +102,12 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
       const duration = this.options.scrollingWaveformWindow
 
       if (this.wavesurfer) {
-        if (!this.originalOptions) {
-          this.originalOptions ??= {
-            cursorWidth: this.wavesurfer.options.cursorWidth,
-            interact: this.wavesurfer.options.interact
-          }
-          this.wavesurfer.options.cursorWidth = 0
-          this.wavesurfer.options.interact = false
+        this.originalOptions ??= {
+          cursorWidth: this.wavesurfer.options.cursorWidth,
+          interact: this.wavesurfer.options.interact
         }
+        this.wavesurfer.options.cursorWidth = 0
+        this.wavesurfer.options.interact = false
         this.wavesurfer.load('', [this.dataWindow], duration)
       }
 


### PR DESCRIPTION
…he recording is paused

## Short description
Add support to play the recorded audio slice when the recording is in the paused state

## Implementation details
When the `pauseRecording()` is called, the data is requested through `this.mediaRecorder?.requestData()` and passed by param to event 'record-pause' emission like the 'record-end' event

## How to test it


## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
