### PR TITLE
Feat: [Region] Add region-removed event

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -13,6 +13,7 @@ export type RegionsPluginOptions = undefined
 export type RegionsPluginEvents = BasePluginEvents & {
   'region-created': [region: Region]
   'region-updated': [region: Region]
+  'region-removed': [region: Region]
   'region-clicked': [region: Region, e: MouseEvent]
   'region-double-clicked': [region: Region, e: MouseEvent]
   'region-in': [region: Region]
@@ -478,6 +479,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       region.once('remove', () => {
         regionSubscriptions.forEach((unsubscribe) => unsubscribe())
         this.regions = this.regions.filter((reg) => reg !== region)
+        this.emit('region-removed', region)
       }),
     ]
 


### PR DESCRIPTION
## Short description
Add `region-removed` event to `RegionPluginEvents`, which emits when a Region's `remove` event is dispatched.

Resolves #

## Implementation details
This `region-removed` event fires after the Region has been removed and is not cancelable.


## How to test it


## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
