### PR TITLE
Fix: rm force-loading of audio

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -69,7 +69,6 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     this.revokeSrc()
     const newSrc = blob instanceof Blob ? URL.createObjectURL(blob) : url
     this.media.src = newSrc
-    this.media.load()
   }
 
   protected destroy() {


### PR DESCRIPTION
## Short description
Resolves #3435

## Implementation details

Calling load isn't necessary. The browser will now decide whether to load audio or not based on the `preload` property of the audio element which wavesurfer doesn't explicitly set. So it should likely default to `metadata` as per the [docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#preload).