### PR TITLE
Feat: [Regions] pass sensitivity threshold to enableDragSelection

### DIFF
--- a/src/draggable.ts
+++ b/src/draggable.ts
@@ -28,8 +28,6 @@ export function makeDraggable(
       const y = event.clientY
       const dx = x - startX
       const dy = y - startY
-      startX = x
-      startY = y
 
       if (isDragging || Math.abs(dx) > threshold || Math.abs(dy) > threshold) {
         const rect = element.getBoundingClientRect()
@@ -41,6 +39,9 @@ export function makeDraggable(
         }
 
         onDrag(dx, dy, x - left, y - top)
+
+        startX = x
+        startY = y
       }
     }
 

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -535,7 +535,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
    * Enable creation of regions by dragging on an empty space on the waveform.
    * Returns a function to disable the drag selection.
    */
-  public enableDragSelection(options: Omit<RegionParams, 'start' | 'end'>): () => void {
+  public enableDragSelection(options: Omit<RegionParams, 'start' | 'end'>, threshold = 3): () => void {
     const wrapper = this.wavesurfer?.getWrapper()
     if (!wrapper || !(wrapper instanceof HTMLElement)) return () => undefined
 
@@ -588,6 +588,8 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
           region = null
         }
       },
+
+      threshold,
     )
   }
 


### PR DESCRIPTION
## Short description
Resolves #3428

## Implementation details
`enableDragSelection` now takes a fourth optional parameter – a sensitivity threshold (defaults to 3px). It translates to how far one should move the mouse before a dragging event kicks in. Everything below the threshold is considered just a click.