### PR TITLE
Refactor: rollup all types into a separate types.d.ts file

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.8.7",
     "rollup": "^3.26.2",
+    "rollup-plugin-dts": "^6.1.0",
     "typescript": "^5.0.4"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import glob from 'glob'
 import typescript from '@rollup/plugin-typescript'
 import terser from '@rollup/plugin-terser'
+import dts from 'rollup-plugin-dts'
 
 const plugins = [typescript(), terser()]
 
@@ -34,6 +35,13 @@ export default [
       exports: 'default',
     },
     plugins,
+  },
+
+  // Compiled type definitions
+  {
+    input: './dist/wavesurfer.d.ts',
+    output: [{ file: 'dist/types.d.ts', format: 'es' }],
+    plugins: [dts()],
   },
 
   // Wavesurfer plugins

--- a/src/base-plugin.ts
+++ b/src/base-plugin.ts
@@ -17,17 +17,15 @@ export class BasePlugin<EventTypes extends BasePluginEvents, Options> extends Ev
     this.options = options
   }
 
-  onInit() {
-    // Overridden in plugin definition
-    return
-  }
+  protected onInit() {}
 
-  init(wavesurfer: WaveSurfer) {
+  /** Do not call directly, only called by WavesSurfer internally */
+  public _init(wavesurfer: WaveSurfer) {
     this.wavesurfer = wavesurfer
     this.onInit()
   }
 
-  destroy() {
+  public destroy() {
     this.emit('destroy')
     this.subscriptions.forEach((unsubscribe) => unsubscribe())
   }

--- a/src/base-plugin.ts
+++ b/src/base-plugin.ts
@@ -7,17 +7,22 @@ export type BasePluginEvents = {
 
 export type GenericPlugin = BasePlugin<BasePluginEvents, unknown>
 
+/** Base class for wavesurfer plugins */
 export class BasePlugin<EventTypes extends BasePluginEvents, Options> extends EventEmitter<EventTypes> {
   protected wavesurfer?: WaveSurfer
   protected subscriptions: (() => void)[] = []
   protected options: Options
 
+  /** Create a plugin instance */
   constructor(options: Options) {
     super()
     this.options = options
   }
 
-  protected onInit() {}
+  /** Called after this.wavesurfer is available */
+  protected onInit() {
+    return
+  }
 
   /** Do not call directly, only called by WavesSurfer internally */
   public _init(wavesurfer: WaveSurfer) {
@@ -25,6 +30,7 @@ export class BasePlugin<EventTypes extends BasePluginEvents, Options> extends Ev
     this.onInit()
   }
 
+  /** Destroy the plugin and unsubscribe from all events */
   public destroy() {
     this.emit('destroy')
     this.subscriptions.forEach((unsubscribe) => unsubscribe())

--- a/src/event-emitter.ts
+++ b/src/event-emitter.ts
@@ -16,8 +16,8 @@ type EventMap<EventTypes extends GeneralEventTypes> = {
 class EventEmitter<EventTypes extends GeneralEventTypes> {
   private listeners = {} as EventMap<EventTypes>
 
-  /** Add an event listener */
-  public addEventListener<EventName extends keyof EventTypes>(
+  /** Subscribe to an event. Returns an unsubscribe function. */
+  public on<EventName extends keyof EventTypes>(
     event: EventName,
     listener: EventListener<EventTypes, EventName>,
     options?: { once?: boolean },
@@ -29,28 +29,23 @@ class EventEmitter<EventTypes extends GeneralEventTypes> {
 
     if (options?.once) {
       const unsubscribeOnce = () => {
-        this.removeEventListener(event, unsubscribeOnce)
-        this.removeEventListener(event, listener)
+        this.un(event, unsubscribeOnce)
+        this.un(event, listener)
       }
-      this.addEventListener(event, unsubscribeOnce)
+      this.on(event, unsubscribeOnce)
       return unsubscribeOnce
     }
 
-    return () => this.removeEventListener(event, listener)
+    return () => this.un(event, listener)
   }
 
-  public removeEventListener<EventName extends keyof EventTypes>(
+  /** Unsubscribe from an event */
+  public un<EventName extends keyof EventTypes>(
     event: EventName,
     listener: EventListener<EventTypes, EventName>,
   ): void {
     this.listeners[event]?.delete(listener)
   }
-
-  /** Subscribe to an event. Returns an unsubscribe function. */
-  public on = this.addEventListener
-
-  /** Unsubscribe from an event */
-  public un = this.removeEventListener
 
   /** Subscribe to an event only once */
   public once<EventName extends keyof EventTypes>(

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -304,7 +304,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
   /** Register a wavesurfer.js plugin */
   public registerPlugin<T extends GenericPlugin>(plugin: T): T {
-    plugin.init(this)
+    plugin._init(this)
     this.plugins.push(plugin)
 
     // Unregister plugin on destroy

--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -35,6 +35,12 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
     this.gainNode.connect(this.audioContext.destination)
   }
 
+  /** Subscribe to an event. Returns an unsubscribe function. */
+  addEventListener = this.on
+
+  /** Unsubscribe from an event */
+  removeEventListener = this.un
+
   async load() {
     return
   }
@@ -174,6 +180,17 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
   /** Get the GainNode used to play the audio. Can be used to attach filters. */
   public getGainNode(): GainNode {
     return this.gainNode
+  }
+
+  /** Get decoded audio */
+  public getChannelData(): Float32Array[] {
+    const channels: Float32Array[] = []
+    if (!this.buffer) return channels
+    const numChannels = this.buffer.numberOfChannels
+    for (let i = 0; i < numChannels; i++) {
+      channels.push(this.buffer.getChannelData(i))
+    }
+    return channels
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,28 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@babel/code-frame@^7.22.13":
+  version "7.23.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
+  integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
+  dependencies:
+    "@babel/highlight" "^7.23.4"
+    chalk "^2.4.2"
+
+"@babel/helper-validator-identifier@^7.22.20":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
+  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
+
+"@babel/highlight@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz#edaadf4d8232e1a961432db785091207ead0621b"
+  integrity sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.20"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -122,7 +144,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15":
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
@@ -548,7 +570,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.4.1:
+chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1492,6 +1514,11 @@ jest-image-snapshot@4.2.0:
     rimraf "^2.6.2"
     ssim.js "^3.1.1"
 
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
@@ -1643,6 +1670,13 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+magic-string@^0.30.4:
+  version "0.30.5"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.5.tgz#1994d980bd1c8835dc6e78db7cbd4ae4f24746f9"
+  integrity sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -2044,6 +2078,15 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rollup-plugin-dts@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-6.1.0.tgz#56e9c5548dac717213c6a4aa9df523faf04f75ae"
+  integrity sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==
+  dependencies:
+    magic-string "^0.30.4"
+  optionalDependencies:
+    "@babel/code-frame" "^7.22.13"
 
 rollup@^3.26.2:
   version "3.29.4"


### PR DESCRIPTION
## Short description

I've cleaned up the public API a bit, and restored the combined types in `types.d.ts` which were reverted in #3450.

### Breaking changes

* Removed `addEventListener` and `removeEventListener`. Only `on` and `un` should be used in the public API.
* Renamed `BasePlugin.init` to `BasePlugin._init` to discourage calling it directly, as it's an internal method that has to remain public.

### Additions

* `WebAudioPlayer.getChannelData` – needed by the Multitrack plugin.
* `dist/types.d.ts` – all core wavesurfer types in one module