### PR TITLE
Fix: don't use a blob URL for unknown MIME types

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -63,11 +63,15 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     }
   }
 
+  private canPlayType(type: string): boolean {
+    return this.media.canPlayType(type) !== ''
+  }
+
   protected setSrc(url: string, blob?: Blob) {
     const src = this.getSrc()
     if (src === url) return
     this.revokeSrc()
-    const newSrc = blob instanceof Blob ? URL.createObjectURL(blob) : url
+    const newSrc = blob instanceof Blob && this.canPlayType(blob.type) ? URL.createObjectURL(blob) : url
     this.media.src = newSrc
   }
 

--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -188,6 +188,10 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
     }
   }
 
+  public canPlayType(mimeType: string) {
+    return /^(audio|video)\//.test(mimeType)
+  }
+
   /** Get the GainNode used to play the audio. Can be used to attach filters. */
   public getGainNode(): GainNode {
     return this.gainNode


### PR DESCRIPTION
## Short description
Resolves #3380 

As per [this comment](https://github.com/katspaugh/wavesurfer.js/discussions/3380#discussioncomment-8034069), if an audio file is fetched from a server that doesn't send the correct MIME type, the downloaded blob might fail to play in an audio element.

## Implementation details

I've added a check when setting an audio src to a blob URL: if the MIME type is not supported, it will fallback to the original audio URL.