### PR TITLE
Fix: draggable pointerout only on document

### DIFF
--- a/src/draggable.ts
+++ b/src/draggable.ts
@@ -52,6 +52,13 @@ export function makeDraggable(
       unsubscribeDocument()
     }
 
+    const onPointerLeave = (e: PointerEvent) => {
+      // Listen to events only on the document and not on inner elements
+      if (!e.relatedTarget || e.relatedTarget === document.documentElement) {
+        onPointerUp()
+      }
+    }
+
     const onClick = (event: MouseEvent) => {
       if (isDragging) {
         event.stopPropagation()
@@ -67,16 +74,16 @@ export function makeDraggable(
 
     document.addEventListener('pointermove', onPointerMove)
     document.addEventListener('pointerup', onPointerUp)
-    document.addEventListener('pointerout', onPointerUp)
-    document.addEventListener('pointercancel', onPointerUp)
+    document.addEventListener('pointerout', onPointerLeave)
+    document.addEventListener('pointercancel', onPointerLeave)
     document.addEventListener('touchmove', onTouchMove, { passive: false })
     document.addEventListener('click', onClick, { capture: true })
 
     unsubscribeDocument = () => {
       document.removeEventListener('pointermove', onPointerMove)
       document.removeEventListener('pointerup', onPointerUp)
-      document.removeEventListener('pointerout', onPointerUp)
-      document.removeEventListener('pointercancel', onPointerUp)
+      document.removeEventListener('pointerout', onPointerLeave)
+      document.removeEventListener('pointercancel', onPointerLeave)
       document.removeEventListener('touchmove', onTouchMove)
       setTimeout(() => {
         document.removeEventListener('click', onClick, { capture: true })

--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -177,9 +177,10 @@ class Polyline extends EventEmitter<{
       'ellipse',
       {
         xmlns: 'http://www.w3.org/2000/svg',
-        cx: x.toString(),
-        cy: y.toString(),
-        r: radius.toString(),
+        cx: x,
+        cy: y,
+        rx: radius,
+        ry: radius,
         fill: this.options.dragPointFill,
         stroke: this.options.dragPointStroke,
         'stroke-width': '2',


### PR DESCRIPTION
## Short description
Resolves #3476

## Implementation details

In draggable.js, the pointerout and pointercancel events will now be handled only when fired on the document object and not on inner elements. This allows dragging past the container until the mouse is completely outside of the page.

This PR also fixes a bug in the Envelope plugin where newly added points were not rendered correctly.