### PR TITLE
Feat: add redrawcomplete event

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -99,8 +99,10 @@ export type WaveSurferEvents = {
   decode: [duration: number]
   /** When the audio is both decoded and can play */
   ready: [duration: number]
-  /** When a waveform is drawn */
+  /** When visible waveform is drawn */
   redraw: []
+  /** When all audio channel chunks of the waveform have drawn */
+  redrawcomplete: []
   /** When the audio starts playing */
   play: []
   /** When the audio pauses */
@@ -254,6 +256,11 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       // Redraw
       this.renderer.on('render', () => {
         this.emit('redraw')
+      }),
+
+      // RedrawComplete
+      this.renderer.on('rendered', () => {
+        this.emit('redrawcomplete')
       }),
     )
 


### PR DESCRIPTION
## Short description
Currently the `redraw` event firers before `renderHead` and `renderTail` have completed. This adds a new event `redrawcomplete` that fires once both head and tail have completed rendering.

In longer files `redrawcomplete` can take awhile to fire so we left `redraw` and `redrawcomplete` as two separate events

Resolves #

## Implementation details


## How to test it
1. Navigate to [zoom example](http://127.0.0.1:9090/#zoom-plugin.js)
2. Add: `['zoom', 'redraw', 'redrawcomplete'].forEach((e) => wavesurfer.on(e, () => console.log(Date.now(), e)))`
3. view console

## Screenshots
<img width="490" alt="image" src="https://github.com/katspaugh/wavesurfer.js/assets/47955954/61483628-1c28-4044-8dba-f5c00b468c6c">


## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
