### PR TITLE
Feat: add part attribute to timeline

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -173,6 +173,8 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
       },
     })
 
+    timeline.setAttribute('part', 'timeline')
+
     if (typeof this.options.style === 'string') {
       timeline.setAttribute('style', timeline.getAttribute('style') + this.options.style)
     } else if (typeof this.options.style === 'object') {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -212,7 +212,7 @@ class Renderer extends EventEmitter<RendererEvents> {
 
       <div class="scroll" part="scroll">
         <div class="wrapper" part="wrapper">
-          <div class="canvases" part="canvases"></div>
+          <div class="canvases"></div>
           <div class="progress" part="progress"></div>
           <div class="cursor" part="cursor"></div>
         </div>
@@ -442,7 +442,6 @@ class Renderer extends EventEmitter<RendererEvents> {
   ) {
     const pixelRatio = window.devicePixelRatio || 1
     const canvas = document.createElement('canvas')
-    canvas.setAttribute('part', 'canvas canvas-wave')
     const length = channelData[0].length
     canvas.width = Math.round((width * (end - start)) / length)
     canvas.height = height * pixelRatio
@@ -462,7 +461,6 @@ class Renderer extends EventEmitter<RendererEvents> {
     // Draw a progress canvas
     if (canvas.width > 0 && canvas.height > 0) {
       const progressCanvas = canvas.cloneNode() as HTMLCanvasElement
-      progressCanvas.setAttribute('part', 'canvas canvas-progress');
       const progressCtx = progressCanvas.getContext('2d') as CanvasRenderingContext2D
       progressCtx.drawImage(canvas, 0, 0)
       // Set the composition method to draw only where the waveform is drawn
@@ -481,7 +479,6 @@ class Renderer extends EventEmitter<RendererEvents> {
   ): Promise<void> {
     // A container for canvases
     const canvasContainer = document.createElement('div')
-    canvasContainer.setAttribute('part', 'canvas-container')
     const height = this.getHeight(options.height)
     canvasContainer.style.height = `${height}px`
     this.canvasWrapper.style.minHeight = `${height}px`
@@ -489,7 +486,6 @@ class Renderer extends EventEmitter<RendererEvents> {
 
     // A container for progress canvases
     const progressContainer = canvasContainer.cloneNode() as HTMLElement
-    progressContainer.setAttribute('part', 'progress-container')
     this.progressWrapper.appendChild(progressContainer)
 
     const dataLength = channelData[0].length

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -209,7 +209,7 @@ class Renderer extends EventEmitter<RendererEvents> {
 
       <div class="scroll" part="scroll">
         <div class="wrapper" part="wrapper">
-          <div class="canvases"></div>
+          <div class="canvases" part="canvases"></div>
           <div class="progress" part="progress"></div>
           <div class="cursor" part="cursor"></div>
         </div>
@@ -424,6 +424,7 @@ class Renderer extends EventEmitter<RendererEvents> {
   ) {
     const pixelRatio = window.devicePixelRatio || 1
     const canvas = document.createElement('canvas')
+    canvas.setAttribute('part', 'canvas canvas-wave')
     const length = channelData[0].length
     canvas.width = Math.round((width * (end - start)) / length)
     canvas.height = height * pixelRatio
@@ -443,6 +444,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     // Draw a progress canvas
     if (canvas.width > 0 && canvas.height > 0) {
       const progressCanvas = canvas.cloneNode() as HTMLCanvasElement
+      progressCanvas.setAttribute('part', 'canvas canvas-progress');
       const progressCtx = progressCanvas.getContext('2d') as CanvasRenderingContext2D
       progressCtx.drawImage(canvas, 0, 0)
       // Set the composition method to draw only where the waveform is drawn
@@ -457,6 +459,7 @@ class Renderer extends EventEmitter<RendererEvents> {
   private renderChannel(channelData: Array<Float32Array | number[]>, options: WaveSurferOptions, width: number) {
     // A container for canvases
     const canvasContainer = document.createElement('div')
+    canvasContainer.setAttribute('part', 'canvas-container')
     const height = this.getHeight(options.height)
     canvasContainer.style.height = `${height}px`
     this.canvasWrapper.style.minHeight = `${height}px`
@@ -464,6 +467,7 @@ class Renderer extends EventEmitter<RendererEvents> {
 
     // A container for progress canvases
     const progressContainer = canvasContainer.cloneNode() as HTMLElement
+    progressContainer.setAttribute('part', 'progress-container')
     this.progressWrapper.appendChild(progressContainer)
 
     // Determine the currently visible part of the waveform


### PR DESCRIPTION
## Short description
Add part attributes to the other remaining elements rendered in the wavesurfer

Resolves #
Makes writing css easier outside the shadow root

## Implementation details
- timeline
- canvases
- canvas 
- canvas-wave
- canvas-progress
- canvas-container
- progress-container 

## How to test it


## Screenshots
<img width="603" alt="image" src="https://github.com/katspaugh/wavesurfer.js/assets/47955954/f31ab0ab-1d18-4379-bb73-f0a176bac6f7">


## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
