### PR TITLE
Refactor: promise-based chunked rendering

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -25,6 +25,25 @@ describe('WaveSurfer basic tests', () => {
     cy.window().its('wavesurfer').should('be.an', 'object')
   })
 
+  it('should emit a redrawcomplete event', () => {
+    cy.window().then((win) => {
+      const { wavesurfer } = win
+      expect(wavesurfer.getDuration().toFixed(2)).to.equal('21.77')
+
+      wavesurfer.options.minPxPerSec = 200
+      wavesurfer.load('../../examples/audio/audio.wav')
+
+      return new Promise((resolve) => {
+        wavesurfer.once('redrawcomplete', () => {
+          wavesurfer.zoom(100)
+          wavesurfer.once('redrawcomplete', () => {
+            resolve()
+          })
+        })
+      })
+    })
+  })
+
   it('should load an audio file without errors', () => {
     cy.window().then((win) => {
       expect(win.wavesurfer.getDuration().toFixed(2)).to.equal('21.77')

--- a/examples/events.js
+++ b/examples/events.js
@@ -26,9 +26,14 @@ wavesurfer.on('ready', (duration) => {
   console.log('Ready', duration + 's')
 })
 
-/** When a waveform is drawn */
-wavesurfer.on('redraw', () => {
-  console.log('Redraw')
+/** When visible waveform is drawn */
+wavesurfer.on('redrawcomplete', () => {
+  console.log('Redraw began')
+})
+
+/** When all audio channel chunks of the waveform have drawn */
+wavesurfer.on('redrawcomplete', () => {
+  console.log('Redraw complete')
 })
 
 /** When the audio starts playing */

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -107,7 +107,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     this.resizeObserver = new ResizeObserver(() => {
       delay()
         .then(() => this.onContainerResize())
-        .catch(() => {})
+        .catch(() => undefined)
     })
     this.resizeObserver.observe(this.scrollContainer)
   }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -534,7 +534,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     draw(start, end)
 
     // Draw the waveform in chunks equal to the size of the viewport, starting from the position of the viewport
-    await Promise.allSettled([
+    await Promise.all([
       // Draw the chunks to the left of the viewport
       (async () => {
         if (start === 0) return
@@ -599,7 +599,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     try {
       if (this.options.splitChannels) {
         // Render a waveform for each channel
-        await Promise.allSettled(
+        await Promise.all(
           Array.from({ length: audioData.numberOfChannels }).map((_, i) => {
             const options = { ...this.options, ...this.options.splitChannels?.[i] }
             return this.renderChannel([audioData.getChannelData(i)], options, width)

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -21,7 +21,7 @@ class Renderer extends EventEmitter<RendererEvents> {
   private canvasWrapper: HTMLElement
   private progressWrapper: HTMLElement
   private cursor: HTMLElement
-  private timeouts: Array<{ timeout?: ReturnType<typeof setTimeout> }> = []
+  private timeouts: Array<() => void> = []
   private isScrollable = false
   private audioData: AudioBuffer | null = null
   private resizeObserver: ResizeObserver | null = null
@@ -105,7 +105,9 @@ class Renderer extends EventEmitter<RendererEvents> {
     // Re-render the waveform on container resize
     const delay = this.createDelay(100)
     this.resizeObserver = new ResizeObserver(() => {
-      delay(() => this.onContainerResize())
+      delay()
+        .then(() => this.onContainerResize())
+        .catch(() => {})
     })
     this.resizeObserver.observe(this.scrollContainer)
   }
@@ -252,12 +254,27 @@ class Renderer extends EventEmitter<RendererEvents> {
     this.resizeObserver?.disconnect()
   }
 
-  private createDelay(delayMs = 10): (fn: () => void) => void {
-    const context: { timeout?: ReturnType<typeof setTimeout> } = {}
-    this.timeouts.push(context)
-    return (callback: () => void) => {
-      context.timeout && clearTimeout(context.timeout)
-      context.timeout = setTimeout(callback, delayMs)
+  private createDelay(delayMs = 10): () => Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    let reject: (() => void) | undefined
+
+    const onClear = () => {
+      if (timeout) clearTimeout(timeout)
+      if (reject) reject()
+    }
+
+    this.timeouts.push(onClear)
+
+    return () => {
+      return new Promise((resolveFn, rejectFn) => {
+        onClear()
+        reject = rejectFn
+        timeout = setTimeout(() => {
+          timeout = undefined
+          reject = undefined
+          resolveFn()
+        }, delayMs)
+      })
     }
   }
 
@@ -455,7 +472,11 @@ class Renderer extends EventEmitter<RendererEvents> {
     }
   }
 
-  private renderChannel(channelData: Array<Float32Array | number[]>, options: WaveSurferOptions, width: number, done: () => void) {
+  private async renderChannel(
+    channelData: Array<Float32Array | number[]>,
+    options: WaveSurferOptions,
+    width: number,
+  ): Promise<void> {
     // A container for canvases
     const canvasContainer = document.createElement('div')
     const height = this.getHeight(options.height)
@@ -467,10 +488,31 @@ class Renderer extends EventEmitter<RendererEvents> {
     const progressContainer = canvasContainer.cloneNode() as HTMLElement
     this.progressWrapper.appendChild(progressContainer)
 
+    const dataLength = channelData[0].length
+
+    // Draw a portion of the waveform from start peak to end peak
+    const draw = (start: number, end: number) => {
+      this.renderSingleCanvas(
+        channelData,
+        options,
+        width,
+        height,
+        Math.max(0, start),
+        Math.min(end, dataLength),
+        canvasContainer,
+        progressContainer,
+      )
+    }
+
+    // Draw the entire waveform
+    if (!this.isScrollable) {
+      draw(0, dataLength)
+      return
+    }
+
     // Determine the currently visible part of the waveform
     const { scrollLeft, scrollWidth, clientWidth } = this.scrollContainer
-    const len = channelData[0].length
-    const scale = len / scrollWidth
+    const scale = dataLength / scrollWidth
 
     let viewportWidth = Math.min(Renderer.MAX_CANVAS_WIDTH, clientWidth)
 
@@ -488,61 +530,35 @@ class Renderer extends EventEmitter<RendererEvents> {
     const end = Math.floor(start + viewportWidth * scale)
     const viewportLen = end - start
 
-    // Draw a portion of the waveform from start peak to end peak
-    const draw = (start: number, end: number) => {
-      this.renderSingleCanvas(
-        channelData,
-        options,
-        width,
-        height,
-        Math.max(0, start),
-        Math.min(end, len),
-        canvasContainer,
-        progressContainer,
-      )
-    }
+    // Draw the visible part of the waveform
+    draw(start, end)
 
-    const status: { [k:string]: boolean } = { head: false, tail: end >= len }
-    const complete = (type: string) => {
-      status[type] = true
-      if (status.head && status.tail) {
-        done()
-      }
-    }
-
-    // Draw the waveform in viewport chunks, each with a delay
-    const headDelay = this.createDelay()
-    const tailDelay = this.createDelay()
-    const renderHead = (fromIndex: number, toIndex: number) => {
-      draw(fromIndex, toIndex)
-      if (fromIndex > 0) {
-        headDelay(() => {
-          renderHead(fromIndex - viewportLen, toIndex - viewportLen)
-        })
-      } else {
-        complete('head')
-      }
-    }
-    const renderTail = (fromIndex: number, toIndex: number) => {
-      draw(fromIndex, toIndex)
-      if (toIndex < len) {
-        tailDelay(() => {
-          renderTail(fromIndex + viewportLen, toIndex + viewportLen)
-        })
-      } else {
-        complete('tail')
-      }
-    }
-
-    renderHead(start, end)
-    if (end < len) {
-      renderTail(end, end + viewportLen)
-    }
+    // Draw the waveform in chunks equal to the size of the viewport, starting from the position of the viewport
+    await Promise.allSettled([
+      // Draw the chunks to the left of the viewport
+      (async () => {
+        if (start === 0) return
+        const delay = this.createDelay()
+        for (let i = start; i >= 0; i -= viewportLen) {
+          await delay()
+          draw(Math.max(0, i - viewportLen), i)
+        }
+      })(),
+      // Draw the chunks to the right of the viewport
+      (async () => {
+        if (end === dataLength) return
+        const delay = this.createDelay()
+        for (let i = end; i < dataLength; i += viewportLen) {
+          await delay()
+          draw(i, Math.min(dataLength, i + viewportLen))
+        }
+      })(),
+    ])
   }
 
-  render(audioData: AudioBuffer) {
+  async render(audioData: AudioBuffer) {
     // Clear previous timeouts
-    this.timeouts.forEach((context) => context.timeout && clearTimeout(context.timeout))
+    this.timeouts.forEach((clear) => clear())
     this.timeouts = []
 
     // Clear the canvases
@@ -575,31 +591,32 @@ class Renderer extends EventEmitter<RendererEvents> {
     this.cursor.style.backgroundColor = `${this.options.cursorColor || this.options.progressColor}`
     this.cursor.style.width = `${this.options.cursorWidth}px`
 
-    // Render the waveform
-    if (this.options.splitChannels) {
-      let counter = 0
-      const done = () => {
-        counter++
-        if (counter === audioData.numberOfChannels) {
-          this.emit('rendered')
-        }
-      }
-
-      // Render a waveform for each channel
-      for (let i = 0; i < audioData.numberOfChannels; i++) {
-        const options = { ...this.options, ...this.options.splitChannels[i] }
-        this.renderChannel([audioData.getChannelData(i)], options, width, done)
-      }
-    } else {
-      // Render a single waveform for the first two channels (left and right)
-      const channels = [audioData.getChannelData(0)]
-      if (audioData.numberOfChannels > 1) channels.push(audioData.getChannelData(1))
-      this.renderChannel(channels, this.options, width, () => this.emit('rendered'))
-    }
-
     this.audioData = audioData
 
     this.emit('render')
+
+    // Render the waveform
+    try {
+      if (this.options.splitChannels) {
+        // Render a waveform for each channel
+        await Promise.allSettled(
+          Array.from({ length: audioData.numberOfChannels }).map((_, i) => {
+            const options = { ...this.options, ...this.options.splitChannels?.[i] }
+            return this.renderChannel([audioData.getChannelData(i)], options, width)
+          }),
+        )
+      } else {
+        // Render a single waveform for the first two channels (left and right)
+        const channels = [audioData.getChannelData(0)]
+        if (audioData.numberOfChannels > 1) channels.push(audioData.getChannelData(1))
+        await this.renderChannel(channels, this.options, width)
+      }
+    } catch {
+      // Render cancelled due to another render
+      return
+    }
+
+    this.emit('rendered')
   }
 
   reRender() {


### PR DESCRIPTION
## Short description

As outlined [in a comment](https://github.com/katspaugh/wavesurfer.js/pull/3480/files#r1447869479) in #3480, I've refactored the code that was awaiting all waveform chunks to be rendered into sequenced promises.

## Implementation details

The rendering timeouts are now also promise-based, and it a render timeout is cancelled due to another rendering (e.g. when zooming using a slider), it will also reject the correspondng promise. So it's possible to track the entire chain of promises to determine where `rendercomplete` should be called.

@brian-byassee @jason-whitted please review