### PR TITLE
Fix: Region update event

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -25,7 +25,7 @@ export type RegionEvents = {
   /** Before the region is removed */
   remove: []
   /** When the region's parameters are being updated */
-  update: []
+  update: [side?: 'start' | 'end']
   /** When dragging or resizing is finished */
   'update-end': []
   /** On play */
@@ -270,7 +270,7 @@ class SingleRegion extends EventEmitter<RegionEvents> {
       this.end = newEnd
 
       this.renderPosition()
-      this.emit('update')
+      this.emit('update', side)
     }
   }
 
@@ -502,8 +502,11 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     this.regions.push(region)
 
     const regionSubscriptions = [
-      region.on('update', () => {
-        this.adjustScroll(region)
+      region.on('update', (side) => {
+        // Undefined side indicates that we are dragging not resizing
+        if (!side) {
+          this.adjustScroll(region)
+        }
       }),
 
       region.on('update-end', () => {


### PR DESCRIPTION
## Short description
Resolves #3494

## Implementation details
Pass the `side` variable to the update event. We only call `adjustScroll` when it is the region being dragged.

## How to test it
Use [localhost regions example](http://127.0.0.1:9090/#regions.js)
See that `adjustScroll` only fires for region drag events

*IMPORTANT NOTE: this stops a broken experience but it fails to fully implement what a user would expect to happen when resizing/dragging a region with a scrollbar.  

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
