### PR TITLE
Fix: make toggleCursor in regions.js safe

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -219,7 +219,7 @@ class SingleRegion extends EventEmitter<RegionEvents> {
   }
 
   private toggleCursor(toggle: boolean) {
-    if (!this.drag) return
+    if (!this.drag || !this.element?.style) return
     this.element.style.cursor = toggle ? 'grabbing' : 'grab'
   }
 


### PR DESCRIPTION
## Short description
Make toggleCursor in regions.js safe.

Resolves #
It is possible for toggleCursor to be called but the element has been removed. This makes that event safe.

## Implementation details


## How to test it


## Screenshots
<img width="1001" alt="image" src="https://github.com/katspaugh/wavesurfer.js/assets/47955954/41d38956-6852-4a69-96f7-20719673d28f">

## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
