### PR TITLE
Feat: support seeking with no audio loaded

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -91,7 +91,8 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   }
 
   /** Start playing the audio */
-  public play(): Promise<void> {
+  public async play(): Promise<void> {
+    if (!this.media.src) return
     return this.media.play()
   }
 
@@ -143,6 +144,11 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   /** Get the playback speed */
   public getPlaybackRate(): number {
     return this.media.playbackRate
+  }
+
+  /** Check if the audio is seeking */
+  public isSeeking(): boolean {
+    return this.media.seeking
   }
 
   /** Set the playback speed, pass an optional false to NOT preserve the pitch */

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -684,7 +684,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     this.canvasWrapper.style.clipPath = `polygon(${percents}% 0, 100% 0, 100% 100%, ${percents}% 100%)`
     this.progressWrapper.style.width = `${percents}%`
     this.cursor.style.left = `${percents}%`
-    this.cursor.style.marginLeft = Math.round(percents) === 100 ? `-${this.options.cursorWidth}px` : ''
+    this.cursor.style.transform = `translateX(-${Math.round(percents) === 100 ? this.options.cursorWidth : 0}px)`
 
     if (this.isScrollable && this.options.autoScroll) {
       this.scrollIntoView(progress, isPlaying)

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -186,14 +186,20 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     })
   }
 
+  private updateProgress(currentTime = this.getCurrentTime()): number {
+    this.renderer.renderProgress(currentTime / this.getDuration(), this.isPlaying())
+    return currentTime
+  }
+
   private initTimerEvents() {
     // The timer fires every 16ms for a smooth progress animation
     this.subscriptions.push(
       this.timer.on('tick', () => {
-        const currentTime = this.getCurrentTime()
-        this.renderer.renderProgress(currentTime / this.getDuration(), true)
-        this.emit('timeupdate', currentTime)
-        this.emit('audioprocess', currentTime)
+        if (!this.isSeeking()) {
+          const currentTime = this.updateProgress()
+          this.emit('timeupdate', currentTime)
+          this.emit('audioprocess', currentTime)
+        }
       }),
     )
   }
@@ -206,8 +212,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
     this.mediaSubscriptions.push(
       this.onMediaEvent('timeupdate', () => {
-        const currentTime = this.getCurrentTime()
-        this.renderer.renderProgress(currentTime / this.getDuration(), this.isPlaying())
+        const currentTime = this.updateProgress()
         this.emit('timeupdate', currentTime)
       }),
 
@@ -452,6 +457,12 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   /** Toggle if the waveform should react to clicks */
   public toggleInteraction(isInteractive: boolean) {
     this.options.interact = isInteractive
+  }
+
+  /** Jumpt to a specific time in the audio (in seconds) */
+  public setTime(time: number) {
+    super.setTime(time)
+    this.updateProgress(time)
   }
 
   /** Seek to a percentage of audio as [0..1] (0 = beginning, 1 = end) */


### PR DESCRIPTION
## Short description
Resolves #3298

## Implementation details

If no audio is loaded but a waveform is rendered using pre-decoded peaks and duration, clicking on the waveform will now set the cursor to that position.
