### PR TITLE
Feat: Improve scroll position adjustments on zoom in/out

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -625,15 +625,21 @@ class Renderer extends EventEmitter<RendererEvents> {
 
     // Remember the current cursor position
     const { scrollWidth } = this.scrollContainer
-    const before = this.progressWrapper.getBoundingClientRect()
+    const { right: before } = this.progressWrapper.getBoundingClientRect()
 
     // Re-render the waveform
     this.render(this.audioData)
 
     // Adjust the scroll position so that the cursor stays in the same place
     if (this.isScrollable && scrollWidth !== this.scrollContainer.scrollWidth) {
-      const after = this.progressWrapper.getBoundingClientRect()
-      this.scrollContainer.scrollLeft += Math.floor(after.right - before.right)
+      const { right: after } = this.progressWrapper.getBoundingClientRect()
+      let delta = after - before
+      // to limit compounding floating-point drift
+      // we need to round to the half px furthest from 0
+      delta *= 2
+      delta = delta < 0 ? Math.floor(delta) : Math.ceil(delta)
+      delta /= 2
+      this.scrollContainer.scrollLeft += delta
     }
   }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -625,15 +625,15 @@ class Renderer extends EventEmitter<RendererEvents> {
 
     // Remember the current cursor position
     const { scrollWidth } = this.scrollContainer
-    const oldCursorPosition = this.progressWrapper.clientWidth
+    const before = this.progressWrapper.getBoundingClientRect()
 
     // Re-render the waveform
     this.render(this.audioData)
 
     // Adjust the scroll position so that the cursor stays in the same place
     if (this.isScrollable && scrollWidth !== this.scrollContainer.scrollWidth) {
-      const newCursorPosition = this.progressWrapper.clientWidth
-      this.scrollContainer.scrollLeft += newCursorPosition - oldCursorPosition
+      const after = this.progressWrapper.getBoundingClientRect()
+      this.scrollContainer.scrollLeft += Math.floor(after.right - before.right)
     }
   }
 


### PR DESCRIPTION
## Short description
The playhead position can drift a lot during zoom operations. Especially when zooming out when the playhead is at the end. 

This PR improves the accuracy of the offset needed to `scrollLeft` to keep the playhead visible. It does this by adding 1/2 pixel values to the `scrollLeft`

(1/2 pixels is the level of precision supported with scrollbars)

Resolves #
Limits issue where playhead ends up off screen durning zoom operations.

## Implementation details


## How to test it
Using the [Basic Zoom](http://127.0.0.1:9090/#zoom.js)

Zoom out and set play head towards the end.
Zoom in to the play head
Then zoom out.
Note that the playhead is immediately lost on zoom out


## Screenshots
With updates
https://github.com/katspaugh/wavesurfer.js/assets/47955954/f5ab9031-c080-45ab-995c-1a0ff3b5bf7c

Without updates

https://github.com/katspaugh/wavesurfer.js/assets/47955954/e3bb6895-0cdf-4674-93f9-5128083d849d




## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
