### PR TITLE
Do not render the waveform if viewport is 0

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -530,30 +530,32 @@ class Renderer extends EventEmitter<RendererEvents> {
     const end = Math.floor(start + viewportWidth * scale)
     const viewportLen = end - start
 
-    // Draw the visible part of the waveform
-    draw(start, end)
+    if (viewportLen > 0) {
+      // Draw the visible part of the waveform
+      draw(start, end)
 
-    // Draw the waveform in chunks equal to the size of the viewport, starting from the position of the viewport
-    await Promise.all([
-      // Draw the chunks to the left of the viewport
-      (async () => {
-        if (start === 0) return
-        const delay = this.createDelay()
-        for (let i = start; i >= 0; i -= viewportLen) {
-          await delay()
-          draw(Math.max(0, i - viewportLen), i)
-        }
-      })(),
-      // Draw the chunks to the right of the viewport
-      (async () => {
-        if (end === dataLength) return
-        const delay = this.createDelay()
-        for (let i = end; i < dataLength; i += viewportLen) {
-          await delay()
-          draw(i, Math.min(dataLength, i + viewportLen))
-        }
-      })(),
-    ])
+      // Draw the waveform in chunks equal to the size of the viewport, starting from the position of the viewport
+      await Promise.all([
+        // Draw the chunks to the left of the viewport
+        (async () => {
+          if (start === 0) return
+          const delay = this.createDelay()
+          for (let i = start; i >= 0; i -= viewportLen) {
+            await delay()
+            draw(Math.max(0, i - viewportLen), i)
+          }
+        })(),
+        // Draw the chunks to the right of the viewport
+        (async () => {
+          if (end === dataLength) return
+          const delay = this.createDelay()
+          for (let i = end; i < dataLength; i += viewportLen) {
+            await delay()
+            draw(i, Math.min(dataLength, i + viewportLen))
+          }
+        })(),
+      ])
+    }
   }
 
   async render(audioData: AudioBuffer) {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -534,7 +534,10 @@ class Renderer extends EventEmitter<RendererEvents> {
       return
     }
 
+    // Draw the visible part of the waveform
     draw(start, end)
+
+    // Draw the waveform in chunks equal to the size of the viewport, starting from the position of the viewport
     await Promise.all([
       // Draw the chunks to the left of the viewport
       (async () => {
@@ -555,6 +558,7 @@ class Renderer extends EventEmitter<RendererEvents> {
         }
       })(),
     ])
+
   }
 
   async render(audioData: AudioBuffer) {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -558,7 +558,6 @@ class Renderer extends EventEmitter<RendererEvents> {
         }
       })(),
     ])
-
   }
 
   async render(audioData: AudioBuffer) {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -530,32 +530,31 @@ class Renderer extends EventEmitter<RendererEvents> {
     const end = Math.floor(start + viewportWidth * scale)
     const viewportLen = end - start
 
-    if (viewportLen > 0) {
-      // Draw the visible part of the waveform
-      draw(start, end)
-
-      // Draw the waveform in chunks equal to the size of the viewport, starting from the position of the viewport
-      await Promise.all([
-        // Draw the chunks to the left of the viewport
-        (async () => {
-          if (start === 0) return
-          const delay = this.createDelay()
-          for (let i = start; i >= 0; i -= viewportLen) {
-            await delay()
-            draw(Math.max(0, i - viewportLen), i)
-          }
-        })(),
-        // Draw the chunks to the right of the viewport
-        (async () => {
-          if (end === dataLength) return
-          const delay = this.createDelay()
-          for (let i = end; i < dataLength; i += viewportLen) {
-            await delay()
-            draw(i, Math.min(dataLength, i + viewportLen))
-          }
-        })(),
-      ])
+    if (viewportLen <= 0) {
+      return
     }
+
+    draw(start, end)
+    await Promise.all([
+      // Draw the chunks to the left of the viewport
+      (async () => {
+        if (start === 0) return
+        const delay = this.createDelay()
+        for (let i = start; i >= 0; i -= viewportLen) {
+          await delay()
+          draw(Math.max(0, i - viewportLen), i)
+        }
+      })(),
+      // Draw the chunks to the right of the viewport
+      (async () => {
+        if (end === dataLength) return
+        const delay = this.createDelay()
+        for (let i = end; i < dataLength; i += viewportLen) {
+          await delay()
+          draw(i, Math.min(dataLength, i + viewportLen))
+        }
+      })(),
+    ])
   }
 
   async render(audioData: AudioBuffer) {


### PR DESCRIPTION
## Short description
Fixes memory leak that is caused by calling `draw()` in an infinite loop

## Implementation details
Check if `viewportLen` is greater than 0 before drawing (and adding canvases).
Without this check, the tail cycle will run infinitely, because `i += viewportLen` will never change the `i` value.

## How to test it
https://codesandbox.io/p/sandbox/fancy-lake-vddsjh
Inspect the DOM and see how many canvases are being added

## Screenshots
<img width="522" alt="image" src="https://github.com/katspaugh/wavesurfer.js/assets/6388788/c43af97a-0ef6-4392-bd39-0a68dd73c53a">

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
