### PR TITLE
Feat: add error event

### DIFF
--- a/cypress/e2e/error.cy.js
+++ b/cypress/e2e/error.cy.js
@@ -1,0 +1,24 @@
+describe('WaveSurfer error handling tests', () => {
+  it('should fire error event if provided file url does not exist', () => {
+    cy.visit('cypress/e2e/index.html')
+
+    cy.window().its('WaveSurfer').should('exist')
+
+    cy.window().then((win) => {
+      return new Promise((resolve, reject) => {
+        win.wavesurfer = win.WaveSurfer.create({
+          container: '#waveform',
+          height: 200,
+          waveColor: 'rgb(200, 200, 0)',
+          progressColor: 'rgb(100, 100, 0)',
+          url: '../../examples/audio/DOES_NOT_EXIST.wav',
+        })
+
+        win.wavesurfer.on('error', () => {
+          console.log('error event fired')
+          resolve()
+        })
+      })
+    })
+  })
+})

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -130,6 +130,8 @@ export type WaveSurferEvents = {
   zoom: [minPxPerSec: number]
   /** Just before the waveform is destroyed so you can clean up your events */
   destroy: []
+  /** When browser is unable to fetch media file */
+  error: []
 }
 
 class WaveSurfer extends Player<WaveSurferEvents> {
@@ -236,6 +238,10 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
       this.onMediaEvent('seeking', () => {
         this.emit('seeking', this.getCurrentTime())
+      }),
+
+      this.onMediaEvent('error', () => {
+        this.emit('error')
       }),
     )
   }
@@ -366,6 +372,15 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     if (!blob && !channelData) {
       const onProgress = (percentage: number) => this.emit('loading', percentage)
       blob = await Fetcher.fetchBlob(url, onProgress, this.options.fetchParams)
+        .then((blob) => blob)
+        .catch(() => {
+          this.emit('error')
+          return undefined
+        })
+    }
+
+    if (!blob) {
+      return
     }
 
     // Set the mediaelement source

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -400,6 +400,11 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     } else if (blob) {
       const arrayBuffer = await blob.arrayBuffer()
       this.decodedData = await Decoder.decode(arrayBuffer, this.options.sampleRate)
+        .then((buffer) => buffer)
+        .catch(() => {
+          this.emit('error')
+          return null
+        })
     }
 
     if (this.decodedData) {

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -130,7 +130,7 @@ export type WaveSurferEvents = {
   zoom: [minPxPerSec: number]
   /** Just before the waveform is destroyed so you can clean up your events */
   destroy: []
-  /** When browser is unable to fetch media file */
+  /** When source file is unable to be fetched, decoded, or an error is thrown by media element */
   error: []
 }
 


### PR DESCRIPTION
## Short description

Adds support for `wavesurfer.on('error')` event. This is helpful when building components where the file source is unknown at build time and you might want to hook into that event to display an error message.

## Implementation details

It catches errors thrown by "Fetcher.fetchBlob" and emits it as an event named `error`

## How to test it

```
yarn test -- --spec ./cypress/e2e/error.cy.js
```


## Screenshots


## Checklist
* [x] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
      I think it's likely that this introduces a breaking API change if users previously relied on `.create` throwing an exception which is now caught and reported by `.on('error')`. 
