### PR TITLE
Chore: Update plugin exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,12 @@
     },
     "./dist/*": {
       "import": "./dist/*"
-    }
+    },
+    "./dist/plugins/*.esm.js": {
+      "import": "./dist/plugins/*.esm.js",
+      "types": "./dist/plugins/*.d.ts",
+      "require": "./dist/plugins/*.cjs"
+    },
   },
   "scripts": {
     "build:dev": "tsc -w --target ESNext",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
       "import": "./dist/plugins/*.esm.js",
       "types": "./dist/plugins/*.d.ts",
       "require": "./dist/plugins/*.cjs"
-    },
+    }
   },
   "scripts": {
     "build:dev": "tsc -w --target ESNext",


### PR DESCRIPTION
## Short description
Resolves https://github.com/katspaugh/wavesurfer.js/discussions/3531 (sorry, I guess I should've made this an issue but I thought maybe I was just messing something up)

## Implementation details
Type defs weren't working for imported plugins in a Next.js project.


## How to test it
- `bun create next-app`
- `bun add @wavesurfer/react wavesurfer.js`

```tsx
// app/page.tsx

'use client'
import React, { useRef, useEffect } from 'react';
import { useWavesurfer } from '@wavesurfer/react';
import RegionsPlugin from 'wavesurfer.js/dist/plugins/regions.esm.js'; // This import throws a type def warning usually

export default function Page() {
  const containerRef = useRef<HTMLDivElement>(null);

  const { wavesurfer } = useWavesurfer({
    container: containerRef,
    waveColor: 'violet',
    progressColor: 'purple',
    backend: 'MediaElement',
  });

  useEffect(() => {
    if (wavesurfer) {
      wavesurfer.load('/piano-loop.mp3');

      const wsRegions = wavesurfer.registerPlugin(RegionsPlugin.create()) // and RegionsPlugin.create() isn't typed

      wavesurfer.on('decode', () => {
        wsRegions.addRegion({
          start: 0,
          end: 8,
          content: 'Resize me',
          color: 'rgba(0, 0, 255, 1)',
          drag: false,
          resize: true,
        })
      })
    }

    return () => {
      if (wavesurfer) {
        wavesurfer.destroy();
      }
    };
  }, [wavesurfer]);

  return <div ref={containerRef}></div>
}

```

## Screenshots
This is the fixed version.
![image](https://github.com/katspaugh/wavesurfer.js/assets/224636/b889acc2-8815-480d-a577-7adf35da23a3)


## Checklist
* [ ] This PR is covered by e2e tests
* [?] It introduces no breaking API changes (I don't _think_ it does but I suppose it is possible if the `.esm.js` imports are overriding the normal `.js` imports?)