### PR TITLE
Feat: Add setScrollTime method

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -143,6 +143,23 @@ describe('WaveSurfer basic tests', () => {
     })
   })
 
+  it('should scroll on setScrollTime if zoomed in', () => {
+    cy.window().then((win) => {
+      win.wavesurfer.zoom(300)
+      const zoomedWidth = win.wavesurfer.getWrapper().clientWidth
+      win.wavesurfer.zoom(600)
+      const newWidth = win.wavesurfer.getWrapper().clientWidth
+
+      expect(Math.round(newWidth / zoomedWidth)).to.equal(2)
+
+      win.wavesurfer.setScrollTime(20)
+
+      cy.wait(1000).then(() => {
+        expect(win.wavesurfer.getScroll()).to.be.greaterThan(100)
+      })
+    })
+  })
+
   it('should export decoded audio data', () => {
     cy.window().then((win) => {
       const data = win.wavesurfer.getDecodedData()

--- a/src/player.ts
+++ b/src/player.ts
@@ -106,7 +106,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     return !this.media.paused && !this.media.ended
   }
 
-  /** Jumpt to a specific time in the audio (in seconds) */
+  /** Jump to a specific time in the audio (in seconds) */
   public setTime(time: number) {
     this.media.currentTime = time
   }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -249,7 +249,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     return this.scrollContainer.scrollLeft
   }
 
-  setScroll(pixels: number) {
+  private setScroll(pixels: number) {
     this.scrollContainer.scrollLeft = pixels
   }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -249,6 +249,16 @@ class Renderer extends EventEmitter<RendererEvents> {
     return this.scrollContainer.scrollLeft
   }
 
+  setScroll(pixels: number) {
+    this.scrollContainer.scrollLeft = pixels
+  }
+
+  setScrollPercentage(percent: number) {
+    const { scrollWidth } = this.scrollContainer
+    const scrollStart =  scrollWidth * percent
+    this.setScroll(scrollStart)
+  }
+
   destroy() {
     this.container.remove()
     this.resizeObserver?.disconnect()

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -350,7 +350,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     return this.renderer.getScroll()
   }
 
-  /** Move the viewing window to a specific time in the audio (in seconds) */
+  /** Move the start of the viewing window to a specific time in the audio (in seconds) */
   public setScrollTime(time: number) {
     let percentage = time / this.getDuration()
     this.renderer.setScrollPercentage(percentage)

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -352,7 +352,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
   /** Move the start of the viewing window to a specific time in the audio (in seconds) */
   public setScrollTime(time: number) {
-    let percentage = time / this.getDuration()
+    const percentage = time / this.getDuration()
     this.renderer.setScrollPercentage(percentage)
   }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -350,6 +350,12 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     return this.renderer.getScroll()
   }
 
+  /** Move the viewing window to a specific time in the audio (in seconds) */
+  public setScrollTime(time: number) {
+    let percentage = time / this.getDuration()
+    this.renderer.setScrollPercentage(percentage)
+  }
+
   /** Get all registered plugins */
   public getActivePlugins() {
     return this.plugins
@@ -459,7 +465,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.options.interact = isInteractive
   }
 
-  /** Jumpt to a specific time in the audio (in seconds) */
+  /** Jump to a specific time in the audio (in seconds) */
   public setTime(time: number) {
     super.setTime(time)
     this.updateProgress(time)


### PR DESCRIPTION
## Short description

This adds a `setScrollTime` method to `wavesurfer` that takes a time in seconds. It also adds `setScroll` and `setScrollPercentage` methods to `renderer` which are used by `setScrollTime`.

This allows the viwing window to be set indepenently of the play head.

Resolves: https://github.com/katspaugh/wavesurfer.js/issues/3411
Related: https://github.com/katspaugh/wavesurfer.js/discussions/3361


## Implementation details

`setScrollTime` uses the current duration to calculate the percentage within the file. It forwards that percentage to `setScrollPercentage` in the `renderer`, which then uses the width of the scroll container to calculate an exact offset to pass to `setScroll`.

## How to test it

```
yarn cypress
```

## Screenshots


## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
