### PR TITLE
Feat: Add preload option

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -5,6 +5,7 @@ type PlayerOptions = {
   mediaControls?: boolean
   autoplay?: boolean
   playbackRate?: number
+  preload?: 'none' | 'metadata' | 'auto' | ''
 }
 
 class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
@@ -29,6 +30,11 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     if (options.autoplay) {
       this.media.autoplay = true
     }
+    // Preload
+    if (options.preload) {
+      this.media.preload = options.preload
+    }
+
     // Speed
     if (options.playbackRate != null) {
       this.onceMediaEvent('canplay', () => {

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -48,6 +48,8 @@ export type WaveSurferOptions = {
   mediaControls?: boolean
   /** Play the audio on load */
   autoplay?: boolean
+  /** Indicating what data should be preloaded. */
+  preload?: 'none' | 'metadata' | 'auto' | ''
   /** Pass false to disable clicks on the waveform */
   interact?: boolean
   /** Allow to drag the cursor to seek to a new position */
@@ -160,6 +162,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       mediaControls: options.mediaControls,
       autoplay: options.autoplay,
       playbackRate: options.audioRate,
+      preload: options.preload,
     })
 
     this.options = Object.assign({}, defaultOptions, options)


### PR DESCRIPTION
## Short description
Resolves #3435. Add the ability to set preload option. https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preload

## Implementation details
```js
const wavesurfer = WaveSurfer.create({
  container: document.body,
  preload: 'none'
})
```
