### PR TITLE
Fix: allow "playing" WebAudioPlayer w/o a URL

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -92,7 +92,6 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
 
   /** Start playing the audio */
   public async play(): Promise<void> {
-    if (!this.media.src) return
     return this.media.play()
   }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -399,6 +399,14 @@ class WaveSurfer extends Player<WaveSurferEvents> {
         this.onceMediaEvent('loadedmetadata', () => resolve(this.getDuration()))
       }))
 
+    // Set the duration if the player is a WebAudioPlayer without a URL
+    if (!url && !blob) {
+      const media = this.getMediaElement()
+      if (media instanceof WebAudioPlayer) {
+        media.duration = audioDuration
+      }
+    }
+
     // Decode the audio data or use user-provided peaks
     if (channelData) {
       this.decodedData = Decoder.createBuffer(channelData, audioDuration || 0)

--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -54,6 +54,7 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
 
   set src(value: string) {
     this.currentSrc = value
+    this._duration = undefined
 
     if (!value) {
       this.buffer = null

--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -19,16 +19,17 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
   private audioContext: AudioContext
   private gainNode: GainNode
   private bufferNode: AudioBufferSourceNode | null = null
-  private autoplay = false
   private playStartTime = 0
   private playedDuration = 0
   private _muted = false
   private _playbackRate = 1
+  private _duration: number | undefined = undefined
   private buffer: AudioBuffer | null = null
   public currentSrc = ''
   public paused = true
   public crossOrigin: string | null = null
   public seeking = false
+  public autoplay = false
 
   constructor(audioContext = new AudioContext()) {
     super()
@@ -89,7 +90,9 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
 
     this.bufferNode?.disconnect()
     this.bufferNode = this.audioContext.createBufferSource()
-    this.bufferNode.buffer = this.buffer
+    if (this.buffer) {
+      this.bufferNode.buffer = this.buffer
+    }
     this.bufferNode.playbackRate.value = this._playbackRate
     this.bufferNode.connect(this.gainNode)
 
@@ -164,18 +167,21 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
     return time * this._playbackRate
   }
   set currentTime(value) {
-    this.emit('seeking')
     const wasPlaying = !this.paused
 
     wasPlaying && this._pause()
     this.playedDuration = value / this._playbackRate
     wasPlaying && this._play()
 
+    this.emit('seeking')
     this.emit('timeupdate')
   }
 
   get duration() {
-    return this.buffer?.duration || 0
+    return this._duration ?? (this.buffer?.duration || 0)
+  }
+  set duration(value: number) {
+    this._duration = value
   }
 
   get volume() {


### PR DESCRIPTION
## Short description
Resolves #3575

## Implementation details

Two fixes for the WebAudioPlayer:

* The `seeking` event is now emitted _after_ `currentTime` is set to a new value
* Allow starting a playback without an src
* Pass a custom pre-calculated duration if audio src is not set

This effectively allows visually "playing" pre-decoded peaks and duration without an audio URL using the WebAudioPlayer.