### PR TITLE
Refactor: re-throw error on load

### DIFF
--- a/cypress/e2e/error.cy.js
+++ b/cypress/e2e/error.cy.js
@@ -5,7 +5,7 @@ describe('WaveSurfer error handling tests', () => {
     cy.window().its('WaveSurfer').should('exist')
 
     cy.window().then((win) => {
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve) => {
         win.wavesurfer = win.WaveSurfer.create({
           container: '#waveform',
           height: 200,

--- a/src/player.ts
+++ b/src/player.ts
@@ -31,25 +31,25 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     }
     // Speed
     if (options.playbackRate != null) {
-      this.onceMediaEvent('canplay', () => {
-        if (options.playbackRate != null) {
-          this.media.playbackRate = options.playbackRate
-        }
-      })
+      this.onMediaEvent(
+        'canplay',
+        () => {
+          if (options.playbackRate != null) {
+            this.media.playbackRate = options.playbackRate
+          }
+        },
+        { once: true },
+      )
     }
   }
 
-  protected onMediaEvent(
-    event: keyof HTMLMediaElementEventMap,
-    callback: () => void,
-    options?: AddEventListenerOptions,
+  protected onMediaEvent<K extends keyof HTMLElementEventMap>(
+    event: K,
+    callback: (ev: HTMLElementEventMap[K]) => void,
+    options?: boolean | AddEventListenerOptions,
   ): () => void {
     this.media.addEventListener(event, callback, options)
-    return () => this.media.removeEventListener(event, callback)
-  }
-
-  protected onceMediaEvent(event: keyof HTMLMediaElementEventMap, callback: () => void): () => void {
-    return this.onMediaEvent(event, callback, { once: true })
+    return () => this.media.removeEventListener(event, callback, options)
   }
 
   protected getSrc() {

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -396,10 +396,6 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       blob = await Fetcher.fetchBlob(url, onProgress, this.options.fetchParams)
     }
 
-    if (!blob) {
-      return
-    }
-
     // Set the mediaelement source
     this.setSrc(url, blob)
 


### PR DESCRIPTION
## Short description

A follow-up on #3532.

## Implementation details

* The error event handler now takes an Error object
* Async fetching/decoding errors in the constructor are now caught and emitted as an `error` event.
* Calling `load` and `loadBlob` will still result in a rejected promise on error (it was swallowed in the original PR), while also emitting an `error` event.
* Remove a breaking blob check.