### PR TITLE
add dragDebounceTime as an option

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -92,7 +92,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     })
 
     // Drag
-    if (this.options.dragToSeek) {
+    if (this.options.dragToSeek === true || typeof this.options.dragToSeek === 'object') {
       this.initDrag()
     }
 
@@ -239,7 +239,7 @@ class Renderer extends EventEmitter<RendererEvents> {
       this.parent = newParent
     }
 
-    if (options.dragToSeek && !this.options.dragToSeek) {
+    if (options.dragToSeek === true || typeof this.options.dragToSeek === 'object') {
       this.initDrag()
     }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -74,6 +74,8 @@ export type WaveSurferOptions = {
   fetchParams?: RequestInit
   /** Playback "backend" to use, defaults to MediaElement */
   backend?: 'WebAudio' | 'MediaElement'
+  /** Number of ms to debounce dragging when `dragToSeek` is true; defaults to 200ms */
+  dragDebounceTime?: number
 }
 
 const defaultOptions = {
@@ -87,6 +89,7 @@ const defaultOptions = {
   autoScroll: true,
   autoCenter: true,
   sampleRate: 8000,
+  dragDebounceTime: 200,
 }
 
 export type WaveSurferEvents = {
@@ -311,7 +314,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
             () => {
               this.seekTo(relativeX)
             },
-            this.isPlaying() ? 0 : 200,
+            this.isPlaying() ? 0 : this.options.dragDebounceTime,
           )
 
           this.emit('interaction', relativeX * this.getDuration())

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -53,7 +53,7 @@ export type WaveSurferOptions = {
   /** Allow to drag the cursor to seek to a new position. If an object with `debounceTime` is provided instead
    * then `dragToSeek` will also be true. If `true` the default is 200ms
    */
-  dragToSeek?: boolean | DragToSeekOptions
+  dragToSeek?: boolean | { debounceTime: number }
   /** Hide the scrollbar */
   hideScrollbar?: boolean
   /** Audio rate, i.e. the playback speed */
@@ -76,10 +76,6 @@ export type WaveSurferOptions = {
   fetchParams?: RequestInit
   /** Playback "backend" to use, defaults to MediaElement */
   backend?: 'WebAudio' | 'MediaElement'
-}
-
-export type DragToSeekOptions = {
-  debounceTime?: number;
 }
 
 const defaultOptions = {
@@ -313,22 +309,19 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
           // Set the audio position with a debounce
           clearTimeout(debounce)
-          let debounceTime;
+          let debounceTime
 
           if (this.isPlaying()) {
-            debounceTime = 0;
+            debounceTime = 0
           } else if (this.options.dragToSeek === true) {
-            debounceTime = 200;
+            debounceTime = 200
           } else if (typeof this.options.dragToSeek === 'object' && this.options.dragToSeek !== undefined) {
-            debounceTime = this.options.dragToSeek['debounceTime'];
+            debounceTime = this.options.dragToSeek['debounceTime']
           }
 
-          debounce = setTimeout(
-            () => {
-              this.seekTo(relativeX)
-            },
-            debounceTime,
-          )
+          debounce = setTimeout(() => {
+            this.seekTo(relativeX)
+          }, debounceTime)
 
           this.emit('interaction', relativeX * this.getDuration())
           this.emit('drag', relativeX)

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -50,8 +50,10 @@ export type WaveSurferOptions = {
   autoplay?: boolean
   /** Pass false to disable clicks on the waveform */
   interact?: boolean
-  /** Allow to drag the cursor to seek to a new position */
-  dragToSeek?: boolean
+  /** Allow to drag the cursor to seek to a new position. If an object with `debounceTime` is provided instead
+   * then `dragToSeek` will also be true. If `true` the default is 200ms
+   */
+  dragToSeek?: boolean | DragToSeekOptions
   /** Hide the scrollbar */
   hideScrollbar?: boolean
   /** Audio rate, i.e. the playback speed */
@@ -74,8 +76,10 @@ export type WaveSurferOptions = {
   fetchParams?: RequestInit
   /** Playback "backend" to use, defaults to MediaElement */
   backend?: 'WebAudio' | 'MediaElement'
-  /** Number of ms to debounce dragging when `dragToSeek` is true; defaults to 200ms */
-  dragDebounceTime?: number
+}
+
+export type DragToSeekOptions = {
+  debounceTime?: number;
 }
 
 const defaultOptions = {
@@ -89,7 +93,6 @@ const defaultOptions = {
   autoScroll: true,
   autoCenter: true,
   sampleRate: 8000,
-  dragDebounceTime: 200,
 }
 
 export type WaveSurferEvents = {
@@ -310,11 +313,21 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
           // Set the audio position with a debounce
           clearTimeout(debounce)
+          let debounceTime;
+
+          if (this.isPlaying()) {
+            debounceTime = 0;
+          } else if (this.options.dragToSeek === true) {
+            debounceTime = 200;
+          } else if (typeof this.options.dragToSeek === 'object' && this.options.dragToSeek !== undefined) {
+            debounceTime = this.options.dragToSeek['debounceTime'];
+          }
+
           debounce = setTimeout(
             () => {
               this.seekTo(relativeX)
             },
-            this.isPlaying() ? 0 : this.options.dragDebounceTime,
+            debounceTime,
           )
 
           this.emit('interaction', relativeX * this.getDuration())


### PR DESCRIPTION
## adds dragDebounceTime as an option and uses it as the debounce time in ms when dragging the timeline and `dragToSeek` is true. A default is set at 200ms.
Resolves #3589

## adds an optional field to the configuration object

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
