### PR TITLE
Fix: init minimap immediately

### DIFF
--- a/src/plugins/minimap.ts
+++ b/src/plugins/minimap.ts
@@ -60,6 +60,10 @@ class MinimapPlugin extends BasePlugin<MinimapPluginEvents, MinimapPluginOptions
     }
 
     this.initWaveSurferEvents()
+
+    Promise.resolve().then(() => {
+      this.initMinimap()
+    })
   }
 
   private initMinimapWrapper(): HTMLElement {


### PR DESCRIPTION
## Short description
Resolves #3566

## Implementation details

The Minimap plugin will now attempt to initialize on creation. If the audio isn't decoded yet, it will initialize on ready.