### PR TITLE
Fix: DOMException in destroy

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -171,7 +171,6 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       playbackRate: options.audioRate,
     })
 
-    this.abortController = new AbortController()
     this.options = Object.assign({}, defaultOptions, options)
     this.timer = new Timer()
 
@@ -403,8 +402,12 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
     // Fetch the entire audio as a blob if pre-decoded data is not provided
     if (!blob && !channelData) {
+      const fetchParams = this.options.fetchParams || {}
+      if (window.AbortController && !fetchParams.signal) {
+        this.abortController = new AbortController()
+        fetchParams.signal = this.abortController?.signal;
+      }
       const onProgress = (percentage: number) => this.emit('loading', percentage)
-      const fetchParams = { signal: this.abortController?.signal, ...(this.options.fetchParams || {}) }
       blob = await Fetcher.fetchBlob(url, onProgress, fetchParams)
     }
 


### PR DESCRIPTION
## Short description
fix: https://github.com/katspaugh/wavesurfer.js/issues/3637

## Implementation details
1. move `new AbortController()` from `constructor` to `loadAudio`
2. add compatibility check for `AbortController`

## How to test it
refer to: https://github.com/katspaugh/wavesurfer.js/issues/3637

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
