### PR TITLE
docs: add test cases for abort and destroy

### DIFF
--- a/cypress/e2e/abort.cy.js
+++ b/cypress/e2e/abort.cy.js
@@ -38,7 +38,7 @@ describe('WaveSurfer abort handling tests', () => {
         // catch load error
         win.wavesurfer.load('../../examples/audio/demo.wav').catch((e) => {
           expect(e.name).to.equal('AbortError')
-          expect(e.message).to.equal('The user aborted a request.')
+          expect(e.message).to.match(/aborted/)
           resolve()
         })
 
@@ -64,7 +64,7 @@ describe('WaveSurfer abort handling tests', () => {
         // listening wavesurfer emit error event
         win.wavesurfer.on('error', (e) => {
           expect(e.name).to.equal('AbortError')
-          expect(e.message).to.equal('The user aborted a request.')
+          expect(e.message).to.match(/aborted/)
           resolve()
         })
       })

--- a/cypress/e2e/abort.cy.js
+++ b/cypress/e2e/abort.cy.js
@@ -1,0 +1,73 @@
+describe('WaveSurfer abort handling tests', () => {
+  beforeEach(() => {
+    cy.visit('cypress/e2e/index.html')
+
+    cy.window().its('WaveSurfer').should('exist')
+  })
+
+  // https://github.com/katspaugh/wavesurfer.js/issues/3637
+  it('load url after destroyed should emit ready', () => {
+    cy.window().then((win) => {
+      return new Promise((resolve) => {
+        win.wavesurfer = win.WaveSurfer.create({
+          container: '#waveform',
+          height: 200,
+          waveColor: 'rgb(200, 200, 0)',
+          progressColor: 'rgb(100, 100, 0)',
+        })
+
+        win.wavesurfer.destroy()
+
+        win.wavesurfer.load('../../examples/audio/demo.wav')
+
+        win.wavesurfer.on('ready', resolve)
+      })
+    })
+  })
+
+  it('destroy before wavesurfer ready should throw AbortError Exception', () => {
+    cy.window().then((win) => {
+      return new Promise((resolve) => {
+        win.wavesurfer = win.WaveSurfer.create({
+          container: '#waveform',
+          height: 200,
+          waveColor: 'rgb(200, 200, 0)',
+          progressColor: 'rgb(100, 100, 0)',
+        })
+
+        // catch load error
+        win.wavesurfer.load('../../examples/audio/demo.wav').catch((e) => {
+          expect(e.name).to.equal('AbortError')
+          expect(e.message).to.equal('The user aborted a request.')
+          resolve()
+        })
+
+        win.wavesurfer.destroy()
+      })
+    })
+  })
+
+  it('destroy before wavesurfer ready should emit AbortError Exception', () => {
+    cy.window().then((win) => {
+      return new Promise((resolve) => {
+        win.wavesurfer = win.WaveSurfer.create({
+          container: '#waveform',
+          height: 200,
+          waveColor: 'rgb(200, 200, 0)',
+          progressColor: 'rgb(100, 100, 0)',
+        })
+
+        win.wavesurfer.load('../../examples/audio/demo.wav').catch(() => {})
+
+        win.wavesurfer.destroy()
+
+        // listening wavesurfer emit error event
+        win.wavesurfer.on('error', (e) => {
+          expect(e.name).to.equal('AbortError')
+          expect(e.message).to.equal('The user aborted a request.')
+          resolve()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Short description
add two test cases for abort, refer to: https://github.com/katspaugh/wavesurfer.js/pull/3641#issuecomment-2041978173

## Implementation details
case1: destroy before wavesurfer ready should emit AbortError Exception, it is for https://github.com/katspaugh/wavesurfer.js/pull/3614
case2: load url after destroyed should not emit AbortError Exception, it is for https://github.com/katspaugh/wavesurfer.js/issues/3637

## How to test it
yarn run cypress

## Screenshots
<img width="453" alt="image" src="https://github.com/katspaugh/wavesurfer.js/assets/22289445/d9aca3b2-2761-4874-8f25-3e7a9c7827dd">

## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
