### PR TITLE
update: expose setScroll api from render

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -261,7 +261,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     return this.scrollContainer.scrollLeft
   }
 
-  private setScroll(pixels: number) {
+  setScroll(pixels: number) {
     this.scrollContainer.scrollLeft = pixels
   }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -382,6 +382,11 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     return this.renderer.getScroll()
   }
 
+  /** Set the current scroll position in pixels */
+  public setScroll(pixels: number) {
+    return this.renderer.setScroll(pixels)
+  }
+
   /** Move the start of the viewing window to a specific time in the audio (in seconds) */
   public setScrollTime(time: number) {
     const percentage = time / this.getDuration()


### PR DESCRIPTION
## Short description
Resolves #3659

I didn't check pixels in `setScroll` because it's redundant, setting invalid value for scrollLeft will be set as left or right edge.