### PR TITLE
fix: when width is set high, now multiple canvases are rendered

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -532,7 +532,9 @@ class Renderer extends EventEmitter<RendererEvents> {
     }
 
     // Draw the entire waveform
-    if (!this.isScrollable) {
+    // Note, when the waveform container's width is set to a very large value, then the waveform will not be scrollable.
+    // However, we still want to draw the waveform in chunks for a) performance improvements, and b) so that the canvas never exceeds the browser's maximum canvas width.
+    if (!this.isScrollable && width < Renderer.MAX_CANVAS_WIDTH) {
       draw(0, dataLength)
       return
     }


### PR DESCRIPTION

## Short description
Resolves #3682

## Implementation details
Please see #3682

## How to test it
Please see #3682

## Screenshots
Please see #3682

## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
