### PR TITLE
Fix `y` position in `click` and `dbclick` events

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -75,7 +75,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     const getClickPosition = (e: MouseEvent): [number, number] => {
       const rect = this.wrapper.getBoundingClientRect()
       const x = e.clientX - rect.left
-      const y = e.clientX - rect.left
+      const y = e.clientY - rect.top
       const relativeX = x / rect.width
       const relativeY = y / rect.height
       return [relativeX, relativeY]


### PR DESCRIPTION
## Short description
Resolves #3687 

## Implementation details


## How to test it


## Screenshots

https://github.com/katspaugh/wavesurfer.js/assets/15643533/242e0636-3fe4-4f73-92a0-df55dada7a8a

## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
