### PR TITLE
Fix: [Region] regions overlap detection with a delay

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -467,24 +467,26 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
   private avoidOverlapping(region: Region) {
     if (!region.content) return
 
-    // Check that the label doesn't overlap with other labels
-    // If it does, push it down until it doesn't
-    const div = region.content as HTMLElement
-    const box = div.getBoundingClientRect()
+    setTimeout(() => {
+      // Check that the label doesn't overlap with other labels
+      // If it does, push it down until it doesn't
+      const div = region.content as HTMLElement
+      const box = div.getBoundingClientRect()
 
-    const overlap = this.regions
-      .map((reg) => {
-        if (reg === region || !reg.content) return 0
+      const overlap = this.regions
+        .map((reg) => {
+          if (reg === region || !reg.content) return 0
 
-        const otherBox = reg.content.getBoundingClientRect()
-        if (box.left < otherBox.left + otherBox.width && otherBox.left < box.left + box.width) {
-          return otherBox.height
-        }
-        return 0
-      })
-      .reduce((sum, val) => sum + val, 0)
+          const otherBox = reg.content.getBoundingClientRect()
+          if (box.left < otherBox.left + otherBox.width && otherBox.left < box.left + box.width) {
+            return otherBox.height
+          }
+          return 0
+        })
+        .reduce((sum, val) => sum + val, 0)
 
-    div.style.marginTop = `${overlap}px`
+      div.style.marginTop = `${overlap}px`
+    }, 10)
   }
 
   private adjustScroll(region: Region) {


### PR DESCRIPTION
## Short description

Region overlap detection works incorrectly when regions are created successively. They need to wait for each other to correcrly check for an overlap. So I've added a small timeout.