### PR TITLE
Fix: Split channel overflowing when height:auto

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -147,11 +147,19 @@ class Renderer extends EventEmitter<RendererEvents> {
     )
   }
 
-  private getHeight(optionsHeight?: WaveSurferOptions['height']): number {
+  private getHeight(
+    optionsHeight?: WaveSurferOptions['height'],
+    optionsSplitChannel?: WaveSurferOptions['splitChannels'],
+  ): number {
     const defaultHeight = 128
+    const numberOfChannels = this.audioData?.numberOfChannels || 1
     if (optionsHeight == null) return defaultHeight
     if (!isNaN(Number(optionsHeight))) return Number(optionsHeight)
-    if (optionsHeight === 'auto') return this.parent.clientHeight || defaultHeight
+    if (optionsHeight === 'auto') {
+      const height = this.parent.clientHeight || defaultHeight
+      if (optionsSplitChannel?.every((channel) => !channel.overlay)) return height / numberOfChannels
+      return height
+    }
     return defaultHeight
   }
 
@@ -189,7 +197,7 @@ class Renderer extends EventEmitter<RendererEvents> {
           z-index: 2;
         }
         :host .canvases {
-          min-height: ${this.getHeight(this.options.height)}px;
+          min-height: ${this.getHeight(this.options.height, this.options.splitChannels)}px;
         }
         :host .canvases > div {
           position: relative;
@@ -577,7 +585,7 @@ class Renderer extends EventEmitter<RendererEvents> {
   ) {
     // A container for canvases
     const canvasContainer = document.createElement('div')
-    const height = this.getHeight(options.height)
+    const height = this.getHeight(options.height, options.splitChannels)
     canvasContainer.style.height = `${height}px`
     if (overlay && channelIndex > 0) {
       canvasContainer.style.marginTop = `-${height}px`


### PR DESCRIPTION

## Short description
Resolves https://github.com/katspaugh/wavesurfer.js/discussions/3690

## Implementation details

Alter getHeight function to divide the parentHeight by number of channels if the height=auto of the wavesurfer instance


## How to test it
- Give the parent container a height
- Set `height : auto` & `splitChannel : []` of Wavesurfer instance
- Observe the waveforms not overflowing outside the parent container as their heights are 

## Screenshots (Observe split channels is half the size of the parent)

splitChannel=[] | splitChannel=undefined
--- | --- 
![image](https://github.com/katspaugh/wavesurfer.js/assets/54700621/49c78686-7858-4710-a19e-e3dbb5650c7e) |  ![image](https://github.com/katspaugh/wavesurfer.js/assets/54700621/1d663346-bac3-4b91-b936-913ab572ab7e) 
