### PR TITLE
Fix: check if ResizeObserver is defined (Safari 12)

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -109,13 +109,15 @@ class Renderer extends EventEmitter<RendererEvents> {
     })
 
     // Re-render the waveform on container resize
-    const delay = this.createDelay(100)
-    this.resizeObserver = new ResizeObserver(() => {
-      delay()
-        .then(() => this.onContainerResize())
-        .catch(() => undefined)
-    })
-    this.resizeObserver.observe(this.scrollContainer)
+    if (typeof ResizeObserver === 'function') {
+      const delay = this.createDelay(100)
+      this.resizeObserver = new ResizeObserver(() => {
+        delay()
+          .then(() => this.onContainerResize())
+          .catch(() => undefined)
+      })
+      this.resizeObserver.observe(this.scrollContainer)
+    }
   }
 
   private onContainerResize() {


### PR DESCRIPTION
## Short description
Resolves #3732

## Implementation details
ResizeObserver isn't available in older browsers.