### PR TITLE
Fix: Retrieve scrollWidth from Wavesurfer wrapper in TimelinePlugin

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -167,7 +167,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
 
   private initTimeline() {
     const duration = this.wavesurfer?.getDuration() ?? this.options.duration ?? 0
-    const pxPerSec = this.timelineWrapper.scrollWidth / duration
+    const pxPerSec = (this.wavesurfer?.getWrapper().scrollWidth || this.timelineWrapper.scrollWidth) / duration
     const timeInterval = this.options.timeInterval ?? this.defaultTimeInterval(pxPerSec)
     const primaryLabelInterval = this.options.primaryLabelInterval ?? this.defaultPrimaryLabelInterval(pxPerSec)
     const primaryLabelSpacing = this.options.primaryLabelSpacing


### PR DESCRIPTION
## Short description
In this PR, the width used to calculate `pxPerSec` in TimelinePlugin is retrieved from the `scrollWidth` of the Wavesurfer wrapper, for cases where the timeline wrapper itself is not a child of the wavesurfer wrapper. This enables timelines and waveform to stay visually in sync when zooming.

Resolves #3742

## Implementation details
Used `this.wavesurfer.getWrapper()` to access the `scrollWidth` property when possible, otherwise default to `this.timelineWrapper.scrollWidth`.

## How to test it

1. Create a Wavesurfer instance, with e.g. "#waveform" as a container
2. Create a TimelinePlugin instance, with e.g. "#timeline" as a container
3. Call .zoom(zoomLevel) on the Wavesurfer instance to change the zoom level of the waveform

=> The timeline will rerender properly and follow the current zoom level of the waveform

```
import WaveSurfer from 'wavesurfer.js'
import TimelinePlugin from 'wavesurfer.js/dist/plugins/timeline.esm.js'

// Create an instance of TimelinePlugin
const timeline = TimelinePlugin.create({
  container: '#timeline',
})

// Create an instance of WaveSurfer
const wavesurfer = WaveSurfer.create({
  container: '#waveform',
  waveColor: 'rgb(200, 0, 200)',
  progressColor: 'rgb(100, 0, 100)',
  url: '/examples/audio/audio.wav',
  minPxPerSec: 100,
  plugins: [timeline],
})

/*
<html>
  <label>
    Zoom: <input type="range" min="10" max="1000" value="100" />
  </label>

  <div id="timeline"></div>
  <div id="waveform"></div>
  <p>
    📖 <a href="https://wavesurfer.xyz/docs/classes/plugins_timeline.TimelinePlugin">Timeline plugin docs</a>
  </p>
</html>
*/

// Update the zoom level on slider change
wavesurfer.once('decode', () => {
  const slider = document.querySelector('input[type="range"]')

  slider.addEventListener('input', (e) => {
    const minPxPerSec = e.target.valueAsNumber
    wavesurfer.zoom(minPxPerSec)
  })
})
```

## Screenshots

https://github.com/katspaugh/wavesurfer.js/assets/43746763/08e172f2-8ded-4919-b5d6-cf2f5e6ba80c

## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
