### PR TITLE
Make yarn build command cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,9 @@
     }
   },
   "scripts": {
+    "clean": "node ./scripts/clean.cjs",
     "build:dev": "tsc -w --target ESNext",
-    "build": "rm -rf dist && tsc && rollup -c",
+    "build": "npm run clean && tsc && rollup -c",
     "prepublishOnly": "npm run build",
     "lint": "eslint --ext .ts src --fix",
     "lint:report": "eslint --output-file eslint_report.json --format json --ext .ts src",

--- a/scripts/clean.cjs
+++ b/scripts/clean.cjs
@@ -1,9 +1,9 @@
-const path = require("path")
-const fs = require("fs")
+const path = require('path')
+const fs = require('fs')
 
 const run = () => {
-    const distPath = path.join(__dirname, '../dist')
-    fs.rmSync(distPath, { recursive: true, force: true })
+  const distPath = path.join(__dirname, '../dist')
+  fs.rmSync(distPath, { recursive: true, force: true })
 }
 
 run()

--- a/scripts/clean.cjs
+++ b/scripts/clean.cjs
@@ -1,0 +1,9 @@
+const path = require("path")
+const fs = require("fs")
+
+const run = () => {
+    const distPath = path.join(__dirname, '../dist')
+    fs.rmSync(distPath, { recursive: true, force: true })
+}
+
+run()


### PR DESCRIPTION
## Short description
The `build` npm script currently fails on non-unix platforms where `rm` is not defined. This PR makes the script cross-platform.
Resolves #3746

## Implementation details
1. Created a `scripts/clean.cjs` script to recursively delete `dist` folder using nodejs APIs
2. Added a `clean` npm script which calls `scripts/clean.cjs`
3. Call `npm run clean` instead of `rm -rf dist` in `build` npm script

## How to test it
Run `yarn build`. Any existing `dist` folder should be removed and the build process should execute correctly.

## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
