### PR TITLE
Refactor: optimize Timeline virtual rendering

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -8,7 +8,7 @@ type RendererEvents = {
   drag: [relativeX: number]
   dragstart: [relativeX: number]
   dragend: [relativeX: number]
-  scroll: [relativeStart: number, relativeEnd: number]
+  scroll: [relativeStart: number, relativeEnd: number, scrollLeft: number, scrollRight: number]
   render: []
   rendered: []
 }
@@ -105,7 +105,7 @@ class Renderer extends EventEmitter<RendererEvents> {
       const { scrollLeft, scrollWidth, clientWidth } = this.scrollContainer
       const startX = scrollLeft / scrollWidth
       const endX = (scrollLeft + clientWidth) / scrollWidth
-      this.emit('scroll', startX, endX)
+      this.emit('scroll', startX, endX, scrollLeft, scrollLeft + clientWidth)
     })
 
     // Re-render the waveform on container resize
@@ -730,7 +730,7 @@ class Renderer extends EventEmitter<RendererEvents> {
       const newScroll = this.scrollContainer.scrollLeft
       const startX = newScroll / scrollWidth
       const endX = (newScroll + clientWidth) / scrollWidth
-      this.emit('scroll', startX, endX)
+      this.emit('scroll', startX, endX, newScroll, newScroll + clientWidth)
     }
   }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -131,7 +131,7 @@ export type WaveSurferEvents = {
   /** When the user ends dragging the cursor */
   dragend: [relativeX: number]
   /** When the waveform is scrolled (panned) */
-  scroll: [visibleStartTime: number, visibleEndTime: number]
+  scroll: [visibleStartTime: number, visibleEndTime: number, scrollLeft: number, scrollRight: number]
   /** When the zoom level changes */
   zoom: [minPxPerSec: number]
   /** Just before the waveform is destroyed so you can clean up your events */
@@ -275,9 +275,9 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       }),
 
       // Scroll
-      this.renderer.on('scroll', (startX, endX) => {
+      this.renderer.on('scroll', (startX, endX, scrollLeft, scrollRight) => {
         const duration = this.getDuration()
-        this.emit('scroll', startX * duration, endX * duration)
+        this.emit('scroll', startX * duration, endX * duration, scrollLeft, scrollRight)
       }),
 
       // Redraw


### PR DESCRIPTION
## Short description
Reported in https://github.com/katspaugh/wavesurfer.js/issues/3696

## Implementation details
The virtual rendering in Timeline was doing too many DOM operations on each scroll, making the playback choppy. I've made it append and remove nodes only when their visibility changes.