### PR TITLE
Fix: async duration to allow ready event subscriptions

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -304,7 +304,7 @@ describe('WaveSurfer basic tests', () => {
         expect(originalMedia.eventCount).to.be.greaterThan(0)
 
         win.wavesurfer.setMediaElement(media)
-        expect(originalMedia.eventCount).to.equal(0)
+        expect(originalMedia.eventCount).to.be.lessThan(1)
       })
     })
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -428,12 +428,16 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.setSrc(url, blob)
 
     // Wait for the audio duration
-    const audioDuration =
-      duration ||
-      this.getDuration() ||
-      (await new Promise((resolve) => {
-        this.onMediaEvent('loadedmetadata', () => resolve(this.getDuration()), { once: true })
-      }))
+    const audioDuration = await new Promise<number>((resolve) => {
+      const staticDuration = duration || this.getDuration()
+      if (staticDuration) {
+        resolve(staticDuration)
+      } else {
+        this.mediaSubscriptions.push(
+          this.onMediaEvent('loadedmetadata', () => resolve(this.getDuration()), { once: true }),
+        )
+      }
+    })
 
     // Set the duration if the player is a WebAudioPlayer without a URL
     if (!url && !blob) {


### PR DESCRIPTION
## Short description
Resolves #3744

## Implementation details

When both peaks and duration were passes as options, onReady subscriptions weren't firing because the load was happening synchronously. With this PR, duration is always a promise.