### PR TITLE
Fix: [Regions] export Region class for TypeScript docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img width="626" alt="waveform screenshot" src="https://github.com/katspaugh/wavesurfer.js/assets/381895/05f03bed-800e-4fa1-b09a-82a39a1c62ce">
 
-**Golden sponsor 💖** [Closed Caption Creator](https://www.closedcaptioncreator.com)
+**Gold sponsor 💖** [Closed Caption Creator](https://www.closedcaptioncreator.com)
 
 ## Getting started
 

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -65,7 +65,7 @@ export type RegionParams = {
   contentEditable?: boolean
 }
 
-class SingleRegion extends EventEmitter<RegionEvents> {
+class Region extends EventEmitter<RegionEvents> {
   public element: HTMLElement
   public id: string
   public start: number
@@ -80,7 +80,11 @@ class SingleRegion extends EventEmitter<RegionEvents> {
   public contentEditable = false
   public subscriptions: (() => void)[] = []
 
-  constructor(params: RegionParams, private totalDuration: number, private numberOfChannels = 0) {
+  constructor(
+    params: RegionParams,
+    private totalDuration: number,
+    private numberOfChannels = 0,
+  ) {
     super()
 
     this.subscriptions = []
@@ -586,7 +590,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
 
     const duration = this.wavesurfer.getDuration()
     const numberOfChannels = this.wavesurfer?.getDecodedData()?.numberOfChannels
-    const region = new SingleRegion(options, duration, numberOfChannels)
+    const region = new Region(options, duration, numberOfChannels)
 
     if (!duration) {
       this.subscriptions.push(
@@ -639,7 +643,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         const end = ((x + initialSize) / width) * duration
 
         // Create a region but don't save it until the drag ends
-        region = new SingleRegion(
+        region = new Region(
           {
             ...options,
             start,
@@ -678,5 +682,3 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
 }
 
 export default RegionsPlugin
-
-export type Region = InstanceType<typeof SingleRegion>

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -80,11 +80,7 @@ class Region extends EventEmitter<RegionEvents> {
   public contentEditable = false
   public subscriptions: (() => void)[] = []
 
-  constructor(
-    params: RegionParams,
-    private totalDuration: number,
-    private numberOfChannels = 0,
-  ) {
+  constructor(params: RegionParams, private totalDuration: number, private numberOfChannels = 0) {
     super()
 
     this.subscriptions = []


### PR DESCRIPTION
## Short description

This should fix the docs generation at https://wavesurfer.xyz/docs/types/plugins_regions.Region