### PR TITLE
Feat: [Regions] emit region-update event

### DIFF
--- a/examples/regions.js
+++ b/examples/regions.js
@@ -3,16 +3,17 @@
 import WaveSurfer from 'wavesurfer.js'
 import RegionsPlugin from 'wavesurfer.js/dist/plugins/regions.esm.js'
 
-// Create an instance of WaveSurfer
+// Initialize the Regions plugin
+const regions = RegionsPlugin.create()
+
+// Create a WaveSurfer instance
 const ws = WaveSurfer.create({
   container: '#waveform',
   waveColor: 'rgb(200, 0, 200)',
   progressColor: 'rgb(100, 0, 100)',
   url: '/examples/audio/audio.wav',
+  plugins: [regions],
 })
-
-// Initialize the Regions plugin
-const wsRegions = ws.registerPlugin(RegionsPlugin.create())
 
 // Give regions a random color when they are created
 const random = (min, max) => Math.random() * (max - min) + min
@@ -21,7 +22,7 @@ const randomColor = () => `rgba(${random(0, 255)}, ${random(0, 255)}, ${random(0
 // Create some regions at specific time ranges
 ws.on('decode', () => {
   // Regions
-  wsRegions.addRegion({
+  regions.addRegion({
     start: 0,
     end: 8,
     content: 'Resize me',
@@ -29,7 +30,7 @@ ws.on('decode', () => {
     drag: false,
     resize: true,
   })
-  wsRegions.addRegion({
+  regions.addRegion({
     start: 9,
     end: 10,
     content: 'Cramped region',
@@ -37,7 +38,7 @@ ws.on('decode', () => {
     minLength: 1,
     maxLength: 10,
   })
-  wsRegions.addRegion({
+  regions.addRegion({
     start: 12,
     end: 17,
     content: 'Drag me',
@@ -46,23 +47,23 @@ ws.on('decode', () => {
   })
 
   // Markers (zero-length regions)
-  wsRegions.addRegion({
+  regions.addRegion({
     start: 19,
     content: 'Marker',
     color: randomColor(),
   })
-  wsRegions.addRegion({
+  regions.addRegion({
     start: 20,
     content: 'Second marker',
     color: randomColor(),
   })
 })
 
-wsRegions.enableDragSelection({
+regions.enableDragSelection({
   color: 'rgba(255, 0, 0, 0.1)',
 })
 
-wsRegions.on('region-updated', (region) => {
+regions.on('region-updated', (region) => {
   console.log('Updated region', region)
 })
 
@@ -75,11 +76,11 @@ document.querySelector('input[type="checkbox"]').onclick = (e) => {
 
 {
   let activeRegion = null
-  wsRegions.on('region-in', (region) => {
+  regions.on('region-in', (region) => {
     console.log('region-in', region)
     activeRegion = region
   })
-  wsRegions.on('region-out', (region) => {
+  regions.on('region-out', (region) => {
     console.log('region-out', region)
     if (activeRegion === region) {
       if (loop) {
@@ -89,7 +90,7 @@ document.querySelector('input[type="checkbox"]').onclick = (e) => {
       }
     }
   })
-  wsRegions.on('region-clicked', (region, e) => {
+  regions.on('region-clicked', (region, e) => {
     e.stopPropagation() // prevent triggering a click on the waveform
     activeRegion = region
     region.play()

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -74,7 +74,7 @@ export type RegionParams = {
   contentEditable?: boolean
 }
 
-export class Region extends EventEmitter<RegionEvents> {
+class SingleRegion extends EventEmitter<RegionEvents> implements Region {
   public element: HTMLElement
   public id: string
   public start: number
@@ -89,11 +89,7 @@ export class Region extends EventEmitter<RegionEvents> {
   public contentEditable = false
   public subscriptions: (() => void)[] = []
 
-  constructor(
-    params: RegionParams,
-    private totalDuration: number,
-    private numberOfChannels = 0,
-  ) {
+  constructor(params: RegionParams, private totalDuration: number, private numberOfChannels = 0) {
     super()
 
     this.subscriptions = []
@@ -600,7 +596,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
 
     const duration = this.wavesurfer.getDuration()
     const numberOfChannels = this.wavesurfer?.getDecodedData()?.numberOfChannels
-    const region = new Region(options, duration, numberOfChannels)
+    const region = new SingleRegion(options, duration, numberOfChannels)
 
     if (!duration) {
       this.subscriptions.push(
@@ -653,7 +649,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         const end = ((x + initialSize) / width) * duration
 
         // Create a region but don't save it until the drag ends
-        region = new Region(
+        region = new SingleRegion(
           {
             ...options,
             start,
@@ -692,3 +688,4 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
 }
 
 export default RegionsPlugin
+export type Region = SingleRegion

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -12,12 +12,21 @@ import createElement from '../dom.js'
 export type RegionsPluginOptions = undefined
 
 export type RegionsPluginEvents = BasePluginEvents & {
+  /** When a region is created */
   'region-created': [region: Region]
+  /** When a region is being updated */
+  'region-update': [region: Region, side?: 'start' | 'end']
+  /** When a region is done updating */
   'region-updated': [region: Region]
+  /** When a region is removed */
   'region-removed': [region: Region]
+  /** When a region is clicked */
   'region-clicked': [region: Region, e: MouseEvent]
+  /** When a region is double-clicked */
   'region-double-clicked': [region: Region, e: MouseEvent]
+  /** When playback enters a region */
   'region-in': [region: Region]
+  /** When playback leaves a region */
   'region-out': [region: Region]
 }
 
@@ -80,7 +89,11 @@ export class Region extends EventEmitter<RegionEvents> {
   public contentEditable = false
   public subscriptions: (() => void)[] = []
 
-  constructor(params: RegionParams, private totalDuration: number, private numberOfChannels = 0) {
+  constructor(
+    params: RegionParams,
+    private totalDuration: number,
+    private numberOfChannels = 0,
+  ) {
     super()
 
     this.subscriptions = []
@@ -545,6 +558,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         if (!side) {
           this.adjustScroll(region)
         }
+        this.emit('region-update', region, side)
       }),
 
       region.on('update-end', () => {


### PR DESCRIPTION
## Short description
Resolves #3779

## Implementation details

A new Regions event is added:

```
  /** When a region is being updated */
  'region-update': [region: Region, side?: 'start' | 'end']
```

## Example usage

```js
import WaveSurfer from 'wavesurfer.js'
import RegionsPlugin from 'wavesurfer.js/dist/plugins/regions.esm.js'

// Initialize the Regions plugin
const regions = RegionsPlugin.create()

// Create an instance of WaveSurfer
const wavesurfer = WaveSurfer.create({
  container: '#waveform',
  url: '/examples/audio/audio.wav',
  plugins: [regions],
})

regions.on('region-update', (region, side) => {
  console.log('A region is being dragged or resized', region)
})
```