### PR TITLE
Fix: [Spectrogram] fix cropping and scaling issues

### DIFF
--- a/examples/spectrogram.js
+++ b/examples/spectrogram.js
@@ -9,7 +9,7 @@ const ws = WaveSurfer.create({
   waveColor: 'rgb(200, 0, 200)',
   progressColor: 'rgb(100, 0, 100)',
   url: '/examples/audio/audio.wav',
-  sampleRate: 22050,
+  sampleRate: 44100,
 })
 
 // Initialize the Spectrogram plugin
@@ -18,6 +18,11 @@ ws.registerPlugin(
     labels: true,
     height: 200,
     splitChannels: true,
+    scale: 'mel', // or 'linear'
+    frequencyMax: 8000,
+    frequencyMin: 0,
+    fftSamples: 1024,
+    labelsBackground: 'rgba(0, 0, 0, 0.1)',
   }),
 )
 

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -674,22 +674,23 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
         ctx.textAlign = textAlign
         ctx.textBaseline = 'middle'
 
-        const freq = freqStart + step * i
+        let freq
+        if (this.scale == 'mel') {
+          const melMin = this.hzToMel(0)
+          const melMax = this.hzToMel(this.frequencyMax)
+          freq = this.melToHz(melMin + (i / labelIndex) * (melMax - melMin))
+        } else {
+          freq = freqStart + step * i
+        }
+
         const label = this.freqType(freq)
         const units = this.unitType(freq)
-        const yLabelOffset = 2
         const x = 16
-        let y
+        let y = (1 + c) * getMaxY - (i / labelIndex) * getMaxY
 
-        if (i == 0) {
-          y = getMaxY + i - 10
-        } else {
-          y = getMaxY - i * 50 + yLabelOffset
-        }
-        if (this.scale == 'mel' && freq != 0) {
-          y = (y * this.hzToMel(freq)) / freq
-        }
-        y = c * getMaxY + y
+        // Make sure label remains in view
+        y = Math.min(Math.max(y, c * getMaxY + 10), (1 + c) * getMaxY - 10)
+
         // unit label
         ctx.fillStyle = textColorUnit
         ctx.font = fontSizeUnit + ' ' + fontType


### PR DESCRIPTION
## Short description

Resolves #3663, #3140

## Implementation details

I've attempted to address some issues with the spectrogram rendering creating an image of the wrong height for the target container, causing it to be too tall or short to fill the area, and meaning the frequency labels do not line up with data in the image. There are some magic numbers in here (E.g. division by 2 or 4) I don't understand so appreciate if someone else can vet this!

(Marked as draft for now as I'm running tests locally but it's taking quite a while.)

Separate to this I've implemented some caching of the result of `getFrequencies()` as well as the rendered bitmaps as this can be quite slow, and for my use case we allow zooming in and out so I wanted to speed up the rendering. If this is something you'd like included I can add to this PR or open another one later.

## How to test it


## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced audio playback quality with an updated sample rate.
	- Added new configuration options for the Spectrogram, including frequency range and scale settings.
- **Bug Fixes**
	- Improved error handling for color map validation.
- **Refactor**
	- Streamlined frequency scaling and rendering logic in the Spectrogram plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->