### PR TITLE
Fix: adding nonce as a option in wavesurfer parameters to solve CSP problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "cypress:canary": "cypress open --e2e -b chrome:canary",
     "test": "cypress run --browser chrome",
     "serve": "npx live-server --port=9090 --no-browser --ignore='.*,src,cypress,scripts'",
-    "start": "npm run build:dev & npm run serve"
+    "start": "npm run build:dev & npm run serve",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,7 @@
     "cypress:canary": "cypress open --e2e -b chrome:canary",
     "test": "cypress run --browser chrome",
     "serve": "npx live-server --port=9090 --no-browser --ignore='.*,src,cypress,scripts'",
-    "start": "npm run build:dev & npm run serve",
-    "prepare": "npm run build"
+    "start": "npm run build:dev & npm run serve"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -169,10 +169,10 @@ class Renderer extends EventEmitter<RendererEvents> {
     const div = document.createElement('div')
     const shadow = div.attachShadow({ mode: 'open' })
 
-    const nonce = this.options.nonce;
+    const cspNonce = this.options.cspNonce && typeof this.options.cspNonce === 'string' ? this.options.cspNonce.replace(/"/g, '') : '';
 
     shadow.innerHTML = `
-      <style ${nonce ? `nonce="${nonce}"` : ''}>
+      <style${cspNonce ? ` nonce="${cspNonce}"` : ''}>
         :host {
           user-select: none;
           min-width: 1px;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -169,8 +169,10 @@ class Renderer extends EventEmitter<RendererEvents> {
     const div = document.createElement('div')
     const shadow = div.attachShadow({ mode: 'open' })
 
+    const nonce = this.options.nonce;
+
     shadow.innerHTML = `
-      <style>
+      <style ${nonce ? `nonce="${nonce}"` : ''}>
         :host {
           user-select: none;
           min-width: 1px;

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -77,7 +77,7 @@ export type WaveSurferOptions = {
   /** Playback "backend" to use, defaults to MediaElement */
   backend?: 'WebAudio' | 'MediaElement'
   /** Nonce for CSP if necessary */
-  nonce?: string
+  cspNonce?: string
 }
 
 const defaultOptions = {

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -76,6 +76,8 @@ export type WaveSurferOptions = {
   fetchParams?: RequestInit
   /** Playback "backend" to use, defaults to MediaElement */
   backend?: 'WebAudio' | 'MediaElement'
+  /** Nonce for CSP if necessary */
+  nonce?: string
 }
 
 const defaultOptions = {


### PR DESCRIPTION
## Short description
Resolves #3602

## Implementation details
I've added the nonce property as a new parameter in the WaveSurferOptions type. In the renderer.ts it checks if it was passed, and if it was, it adds it to the style being injected. This assumes you have the nonce value in your frontend to be able to be passed as a option.

## How to test it
Try adding a valid nonce value to your WaveSurfer element like this: {nonce: 'example-value'}

## Screenshots
![image](https://github.com/user-attachments/assets/3dbcd3a2-c96a-4a1c-8f77-ca4226b05a49)
![image](https://github.com/user-attachments/assets/34a48067-21c4-4863-ba2e-acdea4bf13bc)

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
