### PR TITLE
Fix: [Spectrogram] Resample spectrogram at Mel frequencies without ch…

### DIFF
--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -537,20 +537,16 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
   private createMelFilterBank(numMelFilters, sampleRate) {
     const melMin = this.hzToMel(0)
     const melMax = this.hzToMel(sampleRate / 2)
-    const melPoints = []
-    for (let i = 0; i <= numMelFilters + 1; i++) {
-      melPoints.push(this.melToHz(melMin + (i / (numMelFilters + 1)) * (melMax - melMin)))
-    }
     const melFilterBank = Array.from({ length: numMelFilters }, () => Array(this.fftSamples / 2 + 1).fill(0))
-    for (let i = 1; i <= numMelFilters; i++) {
-      for (let j = 0; j < this.fftSamples / 2 + 1; j++) {
-        const freq = j * (sampleRate / this.fftSamples)
-        if (freq >= melPoints[i - 1] && freq <= melPoints[i]) {
-          melFilterBank[i - 1][j] = (freq - melPoints[i - 1]) / (melPoints[i] - melPoints[i - 1])
-        } else if (freq >= melPoints[i] && freq <= melPoints[i + 1]) {
-          melFilterBank[i - 1][j] = (melPoints[i + 1] - freq) / (melPoints[i + 1] - melPoints[i])
-        }
-      }
+    const scale = (sampleRate / this.fftSamples)
+    for (let i = 0; i < numMelFilters; i++) {
+        let hz = this.melToHz(melMin + (i / numMelFilters) * (melMax - melMin))
+        let j = Math.floor(hz / scale)
+        let hzLow = j * scale
+        let hzHigh = (j + 1) * scale
+        let r = (hz - hzLow) / (hzHigh - hzLow)
+        melFilterBank[i][j] = 1 - r
+        melFilterBank[i][j + 1] = r
     }
     return melFilterBank
   }


### PR DESCRIPTION
This changes `melFilterBank` such that power spectra are correctly resampled.

## Short description

The way that `melFilterBank` is computed now, the Mel spectrogram is _not_ calculated by linearly interpolating the linear spectrogram at nearby frequencies. Instead, it computes a weighted average where the sum of weights depends on the frequency. One consequence of this is that the Mel spectrogram of white noise does not appear to be white.

## Implementation details

The Mel spectrogram is now calculated by resampling and linearly interpolating the linear spectrogram.

## Screenshots

Spectrogram of Gaussian white noise before: 
![mel_spectrogram_before](https://github.com/user-attachments/assets/18adfc54-07e6-4e5b-895e-7a9353117ed0)

Spectrogram of Gaussian white noise after:
![mel_spectrogram_after](https://github.com/user-attachments/assets/1d0a282e-4792-439e-be75-29f4158309fc)


`melFilterBank` before:
![filterbank_before](https://github.com/user-attachments/assets/49455c3b-96e7-40f6-a96e-e1f99584a709)
![sums_before](https://github.com/user-attachments/assets/becc3390-626e-4026-b623-ad70c3399c93)

`melFilterBank` after:
![filterbank_after](https://github.com/user-attachments/assets/ae5ea43b-6455-4e65-971b-501f65506980)
![sums_after](https://github.com/user-attachments/assets/5c2b6ef6-ac78-465d-ab76-cb6f5543ca27)

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
