### PR TITLE
Fix Timeline Rendering on Zoom

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -161,17 +161,17 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
       }
     }
 
-    setTimeout(() => {
-      if (!this.wavesurfer) return
-      const scrollLeft = this.wavesurfer.getScroll()
-      const scrollRight = scrollLeft + this.wavesurfer.getWidth()
-      renderIfVisible(scrollLeft, scrollRight)
-      this.subscriptions.push(
-        this.wavesurfer.on('scroll', (_start, _end, scrollLeft, scrollRight) => {
-          renderIfVisible(scrollLeft, scrollRight)
-        }),
-      )
-    }, 0)
+    if (!this.wavesurfer) return
+    const scrollLeft = this.wavesurfer.getScroll()
+    const scrollRight = scrollLeft + this.wavesurfer.getWidth()
+
+    renderIfVisible(scrollLeft, scrollRight)
+
+    this.subscriptions.push(
+      this.wavesurfer.on('scroll', (_start, _end, scrollLeft, scrollRight) => {
+        renderIfVisible(scrollLeft, scrollRight)
+      }),
+    )
   }
 
   private initTimeline() {

--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -163,7 +163,9 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
 
     setTimeout(() => {
       if (!this.wavesurfer) return
-      renderIfVisible(0, this.wavesurfer?.getWidth() || 0)
+      const scrollLeft = this.wavesurfer.getScroll()
+      const scrollRight = scrollLeft + this.wavesurfer.getWidth()
+      renderIfVisible(scrollLeft, scrollRight)
       this.subscriptions.push(
         this.wavesurfer.on('scroll', (_start, _end, scrollLeft, scrollRight) => {
           renderIfVisible(scrollLeft, scrollRight)


### PR DESCRIPTION
## Short description
This should fix the timeline disappearing when Zooming in on the waveform. Resolves #3782 

## Implementation details
Instead of having virtualAppend initially call renderIfVisible with start = 0. Gets the current scroll window position and utilized it as the start instead. This means that the correct markers are rendered when the timeline is reinitialized after a zoom. Also removed the deferring of the initial call as it was causing timeline flickering while zooming.

## How to test it
Create a window with a timeline. Change the cursor position to be something other than 0. Zoom in and out.

## Screenshots

https://github.com/user-attachments/assets/005975ff-7297-4e9e-beab-8a9aef12df5a

https://github.com/user-attachments/assets/56babe3b-c5d4-4657-8358-5ca2d5b8974c

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved responsiveness of the timeline by optimizing visibility checks to execute immediately based on the current scroll position.
- **Bug Fixes**
	- Enhanced error handling to ensure operations are only performed when the `wavesurfer` instance is initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->