### PR TITLE
Canvas width takes padding on scrollContainer into account

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -272,7 +272,8 @@ class Renderer extends EventEmitter<RendererEvents> {
   }
 
   getWidth(): number {
-    return this.scrollContainer.clientWidth
+    const { paddingLeft, paddingRight } = getComputedStyle(this.scrollContainer)
+    return this.scrollContainer.clientWidth - parseFloat(paddingLeft) - parseFloat(paddingRight)
   }
 
   getScroll(): number {
@@ -636,7 +637,8 @@ class Renderer extends EventEmitter<RendererEvents> {
 
     // Determine the width of the waveform
     const pixelRatio = this.getPixelRatio()
-    const parentWidth = this.scrollContainer.clientWidth
+    const { paddingLeft, paddingRight } = getComputedStyle(this.scrollContainer)
+    const parentWidth = this.scrollContainer.clientWidth - parseFloat(paddingLeft) - parseFloat(paddingRight)
     const scrollWidth = Math.ceil(audioData.duration * (this.options.minPxPerSec || 0))
 
     // Whether the container should scroll


### PR DESCRIPTION
Set the width of the render canvas to the width of the scrollContainer minus the left&right padding on it.

## Short description
Resolves #3892 

## Implementation details
On two spots in render.ts the paddingLeft and paddingRight of the scrollContainer is subtracted from its clientWidth. Once when setting the canvas size, so it takes up the right amount of space. Second in the `getWidth()` function.

## How to test it
```
::part(scroll) {
  padding: 12px;
}
```

## Screenshots
See #3892 
<img width="426" alt="Screenshot too wide canvas" src="https://github.com/user-attachments/assets/74cd3dd8-afce-4d80-9219-815b11d04bed">
You can see it is a little bit wider than the wrappers above it (when completely zoomed out), in this case `2*12px = 24px` .
<img width="401" alt="Width of the wrapper" src="https://github.com/user-attachments/assets/8ccd29a9-a3f7-4e5c-a847-6f9a4ba916df">


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced width calculations for the waveform and scroll container, ensuring accurate display.
	- Improved error handling in the image export functionality to prevent silent failures.

These updates contribute to a more reliable and visually accurate user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->