### PR TITLE
Feat(Timeline): Add timeOffset in options so that the scale can be aligned with data

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -24,6 +24,8 @@ export type TimelinePluginOptions = {
   primaryLabelSpacing?: number
   /** Interval between secondary numeric labels  in timeIntervals (i.e notch count) */
   secondaryLabelSpacing?: number
+  /** offset in seconds for the numeric labels */
+  timeOffset?: number  
   /** Custom inline style to apply to the container */
   style?: Partial<CSSStyleDeclaration> | string
   /** Turn the time into a suitable label for the time. */
@@ -143,6 +145,11 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     return 2
   }
 
+    // Return how many seconds the labels are offset.
+    private defaultTimeOffset(pxPerSec: number): number {
+      return 0;
+    }
+
   private virtualAppend(start: number, container: HTMLElement, element: HTMLElement) {
     let wasVisible = false
 
@@ -182,6 +189,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     const primaryLabelSpacing = this.options.primaryLabelSpacing
     const secondaryLabelInterval = this.options.secondaryLabelInterval ?? this.defaultSecondaryLabelInterval(pxPerSec)
     const secondaryLabelSpacing = this.options.secondaryLabelSpacing
+    const timeOffset = this.options.timeOffset ?? this.defaultTimeOffset(pxPerSec)
     const isTop = this.options.insertPosition === 'beforebegin'
 
     const timeline = createElement('div', {
@@ -248,7 +256,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
       const mode = isPrimary ? 'primary' : isSecondary ? 'secondary' : 'tick'
       notch.setAttribute('part', `timeline-notch timeline-notch-${mode}`)
 
-      const offset = i * pxPerSec
+      const offset = (i + timeOffset) * pxPerSec
       notch.style.left = `${offset}px`
       this.virtualAppend(offset, timeline, notch)
     }


### PR DESCRIPTION
I am using the timeline to display BPM (Beat's per minute) for a given sound file. But sound files don't always start exactly with beat 0 at 0 ms. options.timeOffset allows you to shift the labels up or down the timeline and line them up with the waveform.

I normally don't do git. In fact I just lost two days worth of work while fuckling around with git shit. but here you are.

I like your library though, it's easy to understand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `timeOffset` property for the timeline plugin, allowing users to customize the alignment of numeric labels.
- **Enhancements**
	- Improved timeline functionality by enabling adjustable offsets for better display alignment with other visual elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->