### PR TITLE
Fix: region-clicked event and seek issue inside region (#3911, #3804)

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -527,9 +527,9 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       // Check if the region is between the scrollLeft and scrollLeft + clientWidth
       const isVisible = start + width > scrollLeft && start < scrollLeft + clientWidth
 
-      if (isVisible) {
+      if (isVisible && !element.parentElement) {
         container.appendChild(element)
-      } else {
+      } else if (!isVisible && element.parentElement) {
         element.remove()
       }
     }


### PR DESCRIPTION
## Short description
Added parentElement check in virtualAppend method to prevent redundant DOM operations that were breaking click event handling during zoomed playback.

Resolves #3911
Resolves #3804

This PR resolves two related issues with region-clicked events and seeking inside regions in WaveSurfer.js:

1. **Issue #3911:**  
   The `region-clicked` event was not firing on Chrome and Safari when the zoom slider was used. This behavior was inconsistent across browsers, as Firefox worked as expected.

2. **Issue #3804:**  
   Since version 7.8.2, clicking inside a region no longer seeks the audio position correctly on Chrome and Edge. The expected behavior (as seen in Firefox) is that clicking inside a region seeks the audio to the clicked position.
  

## Implementation details
Modified regions.ts virtualAppend method to check element's DOM state before append/remove operations:
```typescript
if (isVisible && !element.parentElement) {
    container.appendChild(element)
} else if (!isVisible && element.parentElement) {
    element.remove()
}
```