### PR TITLE
fix broken options link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Alternatively, insert a UMD script tag which exports the library as a global `Wa
 <script src="https://unpkg.com/wavesurfer.js@7"></script>
 ```
 
-Create a wavesurfer instance and pass various [options](#wavesurfer-options):
+Create a wavesurfer instance and pass various [options](http://wavesurfer.xyz/docs/options):
 ```js
 const wavesurfer = WaveSurfer.create({
   container: '#waveform',


### PR DESCRIPTION
## Short description
Resolves #3947

Though maybe also move wavesurfer up above plugins in left navigation? (I assume is alphabetial ording right now)

Small change to README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the options documentation link for better accessibility.
	- Expanded details on removed options and methods, including replacements for plugins.
	- Provided guidance on alternative approaches for deprecated features.
- **New Features**
	- Introduced the `Hover` plugin as a replacement for the `Cursor` plugin.
	- Added the `Record` plugin to replace the `Microphone` plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->