### PR TITLE
change url 

### DIFF
--- a/examples/spectrogram.js
+++ b/examples/spectrogram.js
@@ -30,7 +30,7 @@ ws.once('interaction', () => {
 <html>
   <div id="waveform"></div>
   <p>
-    📖 <a href="https://wavesurfer.xyz/docs/classes/plugins_spectrogram.SpectrogramPlugin">Spectrogram plugin docs</a>
+    📖 <a href="https://wavesurfer.xyz/docs/modules/plugins_spectrogram">Spectrogram plugin docs</a>
   </p>
 </html>
 */


### PR DESCRIPTION
## Short description
Resolves #
showing the homepage instead of the doc
## Implementation details
changed from this [faulty link](https://wavesurfer.xyz/docs/classes/plugins_spectrogram.SpectrogramPlugin) to this [link](https://wavesurfer.xyz/docs/modules/plugins_spectrogram)

## How to test it


## Screenshots


## Checklist
* [X] This PR is covered by e2e tests
* [X] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation link for the Spectrogram plugin to ensure users have access to the latest resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->