### PR TITLE
Fix: invalid array length in renderer

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -528,6 +528,9 @@ class Renderer extends EventEmitter<RendererEvents> {
     let singleCanvasWidth = Math.min(Renderer.MAX_CANVAS_WIDTH, clientWidth, totalWidth)
     let drawnIndexes: Record<number, boolean> = {}
 
+    // Nothing to render
+    if (singleCanvasWidth === 0) return
+
     // Adjust width to avoid gaps between canvases when using bars
     if (options.barWidth || options.barGap) {
       const barWidth = options.barWidth || 0.5


### PR DESCRIPTION
## Short description
Resolves #3923

## Implementation details
If `singleCanvasWidth` is 0, do an early return w/o rendering anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved rendering logic to prevent errors when there is nothing to render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->