### PR TITLE
Adding options to allow/disallow resizing the start or end of a region

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -60,6 +60,10 @@ export type RegionParams = {
   drag?: boolean
   /** Allow/dissallow resizing the region */
   resize?: boolean
+  /** Allow/dissallow resizing the start of the region */
+  resizeStart?: boolean
+  /** Allow/dissallow resizing the end of the region */
+  resizeEnd?: boolean
   /** The color of the region (CSS color) */
   color?: string
   /** Content string or HTML element */
@@ -81,6 +85,8 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
   public end: number
   public drag: boolean
   public resize: boolean
+  public resizeStart: boolean
+  public resizeEnd: boolean
   public color: string
   public content?: HTMLElement
   public minLength = 0
@@ -98,6 +104,8 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     this.end = this.clampPosition(params.end ?? params.start)
     this.drag = params.drag ?? true
     this.resize = params.resize ?? true
+    this.resizeStart = params.resizeStart ?? true
+    this.resizeEnd = params.resizeEnd ?? true
     this.color = params.color ?? 'rgba(0, 0, 0, 0.1)'
     this.minLength = params.minLength ?? this.minLength
     this.maxLength = params.maxLength ?? this.maxLength
@@ -296,6 +304,8 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
 
   private onResize(dx: number, side: 'start' | 'end') {
     if (!this.resize) return
+    if (!this.resizeStart && side === 'start') return
+    if (!this.resizeEnd && side === 'end') return
     this._onUpdate(dx, side)
   }
 
@@ -388,6 +398,14 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
       } else {
         this.removeResizeHandles(this.element)
       }
+    }
+
+    if (options.resizeStart !== undefined) {
+      this.resizeStart = options.resizeStart
+    }
+
+    if (options.resizeEnd !== undefined) {
+      this.resizeEnd = options.resizeEnd
     }
   }
 


### PR DESCRIPTION
## Short description
This optionally allows disabling resizing one end of a region. My use case is to allow extending a region in only one direction. This doesn't change any of the styling because it's easy enough to override the styling for a handle with css.

## Implementation details
Just a few minor options on the region plugin. Similar to the resize option, we just check the setting in the onResize handler.

## How to test it
Set `resizeStart` or `resizeEnd` to false and check that you can't change the value of the start/end respectively.

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new properties for controlling the resizing of regions: `resizeStart` and `resizeEnd`.
	- Enhanced flexibility in region manipulation by allowing dynamic modification of resizing options.
  
- **Bug Fixes**
	- Improved checks during resizing operations to respect new flags, preventing unwanted resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->