### PR TITLE
fix(spectrogram): Fix spectrogram gain calculation

### DIFF
--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -345,8 +345,8 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
     this.frequencyMin = options.frequencyMin || 0
     this.frequencyMax = options.frequencyMax || 0
 
-    this.gainDB = options.gainDB || 20
-    this.rangeDB = options.rangeDB || 80
+    this.gainDB = options.gainDB ?? 20
+    this.rangeDB = options.rangeDB ?? 80
     this.scale = options.scale || 'mel'
     this.numMelFilters = options.numMelFilters || this.fftSamples / 8
     if (this.scale == 'mel') {
@@ -602,7 +602,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
         for (let j = 0; j < fftSamples / 2; j++) {
           // Based on: https://manual.audacityteam.org/man/spectrogram_view.html
           let valueDB = 20 * Math.log10(spectrum[j])
-          if (valueDB < -this.rangeDB) {
+          if (valueDB < -this.gainDB - this.rangeDB) {
             array[j] = 0
           } else if (valueDB > -this.gainDB) {
             array[j] = 255


### PR DESCRIPTION
## Short description
Resolves two issues with spectrograms:
* The gain calculation did not seem to be correct.
* A gain of 0 was erroneously replaced by 20

## Implementation details


## How to test it


## Screenshots
Example of gain issue:
<img width="584" alt="Screenshot 2024-12-20 at 5 44 33 PM" src="https://github.com/user-attachments/assets/5dcf0626-2fa1-472c-a609-cd68bd595266" />
Fixed:
<img width="583" alt="Screenshot 2024-12-20 at 5 46 27 PM" src="https://github.com/user-attachments/assets/e30cd753-e716-45f7-bf65-818473329db1" />


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
