### PR TITLE
Fix: emit final timeupdate on audio end

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -247,6 +247,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       }),
 
       this.onMediaEvent('ended', () => {
+        this.emit('timeupdate', this.getDuration())
         this.emit('finish')
       }),
 


### PR DESCRIPTION
## Short description
Resolves #3708

## Implementation details

When the audio ends, emit one last `timeupdate` event with the total duration as a parameter.