### PR TITLE
Fix(Regions): a timeout before region-created

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -607,7 +607,10 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
 
     this.subscriptions.push(...regionSubscriptions)
 
-    this.emit('region-created', region)
+    // A small timeout to allow internal events to be emitted first
+    setTimeout(() => {
+      this.emit('region-created', region)
+    }, 0)
   }
 
   /** Create a region with given parameters */


### PR DESCRIPTION
## Short description
Resolves #3938

## Implementation details

A timeout for region-created event to allow removing regions right after creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the timing of the `region-created` event emission to improve event handling during region creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->