### PR TITLE
Fix: pass media error object to error event

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -256,7 +256,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       }),
 
       this.onMediaEvent('error', (err) => {
-        this.emit('error', err.error)
+        this.emit('error', (this.getMediaElement().error ?? new Error('Media error')) as Error)
       }),
     )
   }


### PR DESCRIPTION
## Short description
Resolves #3963

## Implementation details
MediaError errors weren't passed to the error event.