### PR TITLE
feat(spectrogram): add logarithmic, bark and erb scales

### DIFF
--- a/examples/spectrogram.js
+++ b/examples/spectrogram.js
@@ -18,7 +18,7 @@ ws.registerPlugin(
     labels: true,
     height: 200,
     splitChannels: true,
-    scale: 'mel', // or 'linear'
+    scale: 'mel', // or 'linear', 'logarithmic', 'bark', 'erb'
     frequencyMax: 8000,
     frequencyMin: 0,
     fftSamples: 1024,


### PR DESCRIPTION
## Short description

This PR is my attempt to add support for more Y scales when rendering spectrograms. To reach feature parity with Audacity, only the Period scale is missing, but I couldn't find much information on it, so I left it out for now.

Resolves #1648

## Implementation details

I made the function used to create the Mel filter bank generic to make it usable also for different scales and I added all the other common spectrogram scales. The output is not perfect, but I think it's not too bad either. Any suggestion to improve it is more than welcome. I also added some typings to make it easier to work with the plugin (types only, no breaking changes)

## How to test it

Run `yarn start`, go to the "Spectrogram" example and change the `scale` property from `mel` to `logarithmic`, `bark`, or `erb`.


## Screenshots

### Logarithmic

<img width="1547" alt="image" src="https://github.com/user-attachments/assets/a2f1a5e1-a089-4788-878d-551e73c534c3" />

### Bark

<img width="1548" alt="image" src="https://github.com/user-attachments/assets/6408a470-e232-4a2f-9b31-4bf483fba6f7" />

### ERB

<img width="1547" alt="image" src="https://github.com/user-attachments/assets/545c3215-3896-4ebf-b263-4046377455a8" />

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded frequency scaling options in the Spectrogram plugin to include 'logarithmic', 'bark', and 'erb'.
	- Enhanced functionality for audio frequency analysis and visualization through new filter bank methods.

- **Bug Fixes**
	- Improved type safety with updated method signatures for better compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->