### PR TITLE
Allow user to update peaks and/or duration with setOptions

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -353,6 +353,16 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   /** Set new wavesurfer options and re-render it */
   public setOptions(options: Partial<WaveSurferOptions>) {
     this.options = Object.assign({}, this.options, options)
+    if (options.duration && !options.peaks) {
+      this.decodedData = Decoder.createBuffer(this.exportPeaks(), options.duration)
+    }
+    if (options.peaks && options.duration) {
+      // Create new decoded data buffer from peaks and duration
+      this.decodedData = Decoder.createBuffer(
+        options.peaks,
+        options.duration
+      );
+    }
     this.renderer.setOptions(this.options)
 
     if (options.audioRate) {


### PR DESCRIPTION
## Issue: Need a way to update visual progress without triggering 'seeking' events

### Current Behavior
When syncing WaveSurfer with external audio/time sources (like Tone.js transport), calling `setTime()` triggers the 'seeking' event because it updates both the media element's time and the visual progress. This will allow seeking and interact events to continue to work when syncing with an external source.

### Problem
In scenarios where WaveSurfer is being used as a visual representation of audio that's controlled externally, we don't always want to trigger the media element's seeking behavior. Currently, there's no clean way to update just the visual progress without triggering seeking events.

### Proposed Solution
Add a new public method to update only the visual progress

Let me know your thoughts, maybe you have a better solution with a your understanding of the lib.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced waveform progress tracking with a new method to update visual progress more precisely during audio playback.

- **Improvements**
	- Improved handling of audio data options, allowing for better management of duration and peaks during playback. 
	- Improved synchronization between audio playback and waveform visualization. 
	- Added conditional checks for managing duration and peaks in audio options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->