### PR TITLE
Fix(Spectrogram): update abbreviation for kHz to follow SI units

### DIFF
--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -732,7 +732,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
   }
 
   private unitType(freq) {
-    return freq >= 1000 ? 'KHz' : 'Hz'
+    return freq >= 1000 ? 'kHz' : 'Hz'
   }
 
   private getLabelFrequency(


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Hertz

## Short description
Resolves #

## Implementation details


## How to test it


## Screenshots


## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated frequency unit display from 'KHz' to 'kHz' for consistency in unit notation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->