### PR TITLE
feat: override blob MIME type

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -79,7 +79,7 @@ export type WaveSurferOptions = {
   /** Nonce for CSP if necessary */
   cspNonce?: string
   /** Override the Blob MIME type */
-  mimeType?: string
+  blobMimeType?: string
 }
 
 const defaultOptions = {
@@ -437,9 +437,9 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       }
       const onProgress = (percentage: number) => this.emit('loading', percentage)
       blob = await Fetcher.fetchBlob(url, onProgress, fetchParams)
-      const overridedMimeType = this.options.mimeType
-      if (overridedMimeType) {
-        blob = new Blob([blob], { type: overridedMimeType })
+      const overridenMimeType = this.options.blobMimeType
+      if (overridenMimeType) {
+        blob = new Blob([blob], { type: overridenMimeType })
       }
     }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -78,6 +78,8 @@ export type WaveSurferOptions = {
   backend?: 'WebAudio' | 'MediaElement'
   /** Nonce for CSP if necessary */
   cspNonce?: string
+  /** Override the Blob MIME type */
+  mimeType?: string
 }
 
 const defaultOptions = {
@@ -435,6 +437,10 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       }
       const onProgress = (percentage: number) => this.emit('loading', percentage)
       blob = await Fetcher.fetchBlob(url, onProgress, fetchParams)
+      const overridedMimeType = this.options.mimeType
+      if (overridedMimeType) {
+        blob = new Blob([blob], { type: overridedMimeType })
+      }
     }
 
     // Set the mediaelement source


### PR DESCRIPTION
## Short description

Add a new option(mimeType) to override the blob MIME when the server doesn't send the correct MIME in content-type.

discussion: https://github.com/katspaugh/wavesurfer.js/discussions/3621
related pr: https://github.com/katspaugh/wavesurfer.js/pull/3471

## Implementation details

After fetchBlob in loadAudio, if there there is mimeType option, override the Blob MIME.

## How to test it

## Screenshots

## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced audio loading configuration by adding optional MIME type specification for audio files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->