### PR TITLE
Fix: reset media element on load

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -72,6 +72,13 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     if (url && src === url) return
     this.revokeSrc()
     const newSrc = blob instanceof Blob && (this.canPlayType(blob.type) || !url) ? URL.createObjectURL(blob) : url
+
+    // Reset the media element, otherwise it keeps the previous source
+    if (src) {
+      this.media.src = ''
+      this.media.load()
+    }
+
     try {
       this.media.src = newSrc
     } catch (e) {


### PR DESCRIPTION
## Short description
Resolves #4009

## Implementation details
The media element has to be reset when setting a new src.