### PR TITLE
Updated player.ts to not pause audio for external media on destroy()

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -86,9 +86,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   }
 
   protected destroy() {
-    
     if (this.isExternalMedia) return
-    
     this.media.pause()
     this.media.remove()
     this.revokeSrc()

--- a/src/player.ts
+++ b/src/player.ts
@@ -86,9 +86,10 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   }
 
   protected destroy() {
-    this.media.pause()
-
+    
     if (this.isExternalMedia) return
+    
+    this.media.pause()
     this.media.remove()
     this.revokeSrc()
     this.media.src = ''


### PR DESCRIPTION
## Short description
In today's solution the playback audio will pause on calling destroy() for instances using external media. 
We probably dont need this for the external media's.

This is a PR which stems from this [discussion](https://github.com/katspaugh/wavesurfer.js/discussions/3190)



## Implementation details
Moved the called pause-function after the early return for external media :
```jsx
// previously this was called before the below early return
// this.media.pause()
if (this.isExternalMedia) return
this.media.pause() // now called after
```

## How to test it
Create a audio element thats shared globally between n + 1 WaveSurfer instances, then try playing the audio for one of the instances and destroy one of the wavesurfers. The audio will be paused.  



## Checklist
* [ ] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved media destruction logic to handle external media sources more accurately.
	- Refined media pause behavior during player destruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->