### PR TITLE
make regions zIndex higher than envelope

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -488,7 +488,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         left: '0',
         width: '100%',
         height: '100%',
-        zIndex: '3',
+        zIndex: '5',
         pointerEvents: 'none',
       },
     })


### PR DESCRIPTION
## Short description
Resolves #3665

## Implementation details
Changes the z-index of regions so they work with envelope

## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the z-index of the regions container to improve visual layering and element stacking order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->