### PR TITLE
Allow aborting loading audio

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -418,7 +418,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     return this.plugins
   }
 
-  private async loadAudio(url: string, blob?: Blob, channelData?: WaveSurferOptions['peaks'], duration?: number) {
+  private async loadAudio(url: string, blob?: Blob, channelData?: WaveSurferOptions['peaks'], duration?: number, signal?: AbortSignal) {
     this.emit('load', url)
 
     if (!this.options.media && this.isPlaying()) this.pause()
@@ -434,6 +434,8 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       }
       const onProgress = (percentage: number) => this.emit('loading', percentage)
       blob = await Fetcher.fetchBlob(url, onProgress, fetchParams)
+      signal?.throwIfAborted()
+
       const overridenMimeType = this.options.blobMimeType
       if (overridenMimeType) {
         blob = new Blob([blob], { type: overridenMimeType })
@@ -454,6 +456,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
         )
       }
     })
+    signal?.throwIfAborted()
 
     // Set the duration if the player is a WebAudioPlayer without a URL
     if (!url && !blob) {
@@ -468,7 +471,9 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       this.decodedData = Decoder.createBuffer(channelData, audioDuration || 0)
     } else if (blob) {
       const arrayBuffer = await blob.arrayBuffer()
+      signal?.throwIfAborted()
       this.decodedData = await Decoder.decode(arrayBuffer, this.options.sampleRate)
+      signal?.throwIfAborted()
     }
 
     if (this.decodedData) {
@@ -480,9 +485,9 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   }
 
   /** Load an audio file by URL, with optional pre-decoded audio data */
-  public async load(url: string, channelData?: WaveSurferOptions['peaks'], duration?: number) {
+  public async load(url: string, channelData?: WaveSurferOptions['peaks'], duration?: number, signal?: AbortSignal) {
     try {
-      return await this.loadAudio(url, undefined, channelData, duration)
+      return await this.loadAudio(url, undefined, channelData, duration, signal)
     } catch (err) {
       this.emit('error', err as Error)
       throw err
@@ -490,9 +495,9 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   }
 
   /** Load an audio blob */
-  public async loadBlob(blob: Blob, channelData?: WaveSurferOptions['peaks'], duration?: number) {
+  public async loadBlob(blob: Blob, channelData?: WaveSurferOptions['peaks'], duration?: number, signal?: AbortSignal) {
     try {
-      return await this.loadAudio('', blob, channelData, duration)
+      return await this.loadAudio('', blob, channelData, duration, signal)
     } catch (err) {
       this.emit('error', err as Error)
       throw err


### PR DESCRIPTION
## Short description
This change makes loadAudio optionally take an AbortSignal which can be used to abort loading.
We use this to prevent a race condition where the wrong audio might be loading into wavesurfer.

## Implementation details
Passing through an AbortSignal. After any async call it needs to be checked with `throwIfAborted`. Not my favorite, but is effective.

## How to test it
Easiest is to add some delays in `loadAudio` and then try aborting.

Add manual delays throughout loadAudio with:
```
await new Promise((r) => setTimeout(r, 5000))
```

Then call loadAudio passing in a signal and aborting it.

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the audio playback experience by enabling the ability to cancel ongoing audio loading operations.
	- Improved error handling ensures that if an audio load is interrupted, the system responds more promptly and smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->