### PR TITLE
Fix negative offset causing Rangeerror.

### DIFF
--- a/cypress/e2e/webaudio.cy.js
+++ b/cypress/e2e/webaudio.cy.js
@@ -1,80 +1,94 @@
-import WebAudioPlayer from '../src/webaudio';
+import WebAudioPlayer from '../../dist/webaudio.js';
 
 describe('WebAudioPlayer', () => {
-    let player;
-    let mockAudioContext;
-    let mockBufferNode;
-    let mockGainNode;
-    
-    beforeEach(() => {
-        mockBufferNode = {
-            buffer: null,
-            connect: jest.fn(),
-            disconnect: jest.fn(),
-            start: jest.fn(),
-            stop: jest.fn(),
-            playbackRate: { value: 1 },
-            onended: null,
-        };
-        
-        mockGainNode = {
-            connect: jest.fn(),
-            gain: { value: 1 },
-        };
-        
-        mockAudioContext = {
-            currentTime: 0,
-            createBufferSource: jest.fn().mockReturnValue(mockBufferNode),
-            createGain: jest.fn().mockReturnValue(mockGainNode),
-            destination: {},
-        };
-        
-        player = new WebAudioPlayer(mockAudioContext)
-        
-        // Set up a buffer to enable playback
-        const mockBuffer = { duration: 10 }
-        ;(player as any).buffer = mockBuffer })
-        
-        describe('_play method', () => { it('should reset position when currentPos is negative', async () => {
-            // Set up negative position
-            player.playbackRate = -1;
-            player.currentTime = 5;
-            
-            // Trigger _play through play()
-            await player.play();
-            
-            // Verify position was reset
-            expect(player.currentTime).toBe(0);
-            expect(mockBufferNode.start).toHaveBeenCalledWith(0, 0)
-        })
-        
-        it('should reset position when currentPos exceeds duration', async () => {
-            // Set position beyond duration
-            player.currentTime = 15;
-            await player.play();
-            
-            // Verify position was reset
-            expect(player.currentTime).toBe(0);
-            expect(mockBufferNode.start).toHaveBeenCalledWith(0, 0);
-        })
-        
-        it('should maintain position when within valid range', async () => {
-            const validTime = 5;
-            player.currentTime = validTime;
-            await player.play()
-            
-            // Verify position was maintained
-            expect(mockBufferNode.start).toHaveBeenCalledWith(0, validTime);
-        })
-        
-        it('should handle playback rate changes correctly', async () => {
-            player.currentTime = 2;
-            player.playbackRate = 2;
-            await player.play()
-            
-            // currentPos should be 4 (2 * 2)
-            expect(mockBufferNode.start).toHaveBeenCalledWith(0, 4);
-            expect(mockBufferNode.playbackRate.value).toBe(2);
-        })
-    }) 
-})
+  beforeEach(() => {
+    cy.window().then((win) => {
+      // Create fresh mock objects for each test
+      const mockBufferNode = {
+        buffer: null,
+        connect: cy.stub(),
+        disconnect: cy.stub(),
+        start: cy.stub(),
+        stop: cy.stub(),
+        playbackRate: { value: 1 },
+        onended: null,
+      };
+
+      const mockGainNode = {
+        connect: cy.stub(),
+        gain: { value: 1 },
+      };
+
+      const mockAudioContext = {
+        currentTime: 0,
+        createBufferSource: cy.stub().returns(mockBufferNode),
+        createGain: cy.stub().returns(mockGainNode),
+        destination: {},
+      };
+
+      // Create a fresh WebAudioPlayer instance
+      const player = new WebAudioPlayer(mockAudioContext);
+      win.WebAudioPlayer = player; // Attach to window for Cypress access
+
+      // Set up a mock buffer for playback
+      const mockBuffer = { duration: 10 };
+      player.buffer = mockBuffer;
+
+      // Store objects as Cypress aliases for easy access
+      cy.wrap(player).as('player');
+      cy.wrap(mockBufferNode.start).as('startStub');
+    });
+  });
+
+  describe('_play method', () => {
+    it('should reset position when currentPos is negative', () => {
+      cy.get('@player').then((player) => {
+        player.playbackRate = 1;
+        player.currentTime = -1;
+
+        return player.play().then(() => {
+          // Verify position was reset
+          expect(player.currentTime).to.equal(0);
+          cy.get('@startStub').should('have.been.calledWith', 0, 0);
+        });
+      });
+    });
+
+    it('should reset position when currentPos exceeds duration', () => {
+      cy.get('@player').then((player) => {
+        player.currentTime = 15;
+
+        return player.play().then(() => {
+          // Verify position was reset
+          expect(player.currentTime).to.equal(0);
+          cy.get('@startStub').should('have.been.calledWith', 0, 0);
+        });
+      });
+    });
+
+    it('should maintain position when within valid range', () => {
+      cy.get('@player').then((player) => {
+        const validTime = 5;
+        player.currentTime = validTime;
+
+        return player.play().then(() => {
+          // Verify position was maintained
+          cy.get('@startStub').should('have.been.calledWith', 0, validTime);
+        });
+      });
+    });
+
+    it('should handle playback rate changes correctly', () => {
+      cy.get('@player').then((player) => {
+        player.currentTime = 2;
+        player.playbackRate = 2;
+
+        return player.play().then(() => {
+          // currentPos should be 4 (2 * 2)
+          cy.get('@startStub').should('have.been.calledWith', 0, 4);
+          expect(player.bufferNode.playbackRate.value).to.equal(2);
+        });
+      });
+    });
+  });
+});

--- a/cypress/e2e/webaudio.cy.js
+++ b/cypress/e2e/webaudio.cy.js
@@ -1,10 +1,10 @@
 import WebAudioPlayer from '../src/webaudio';
 
 describe('WebAudioPlayer', () => {
-    let player: WebAudioPlayer
-    let mockAudioContext: jest.Mocked<AudioContext>
-    let mockBufferNode: jest.Mocked<AudioBufferSourceNode>
-    let mockGainNode: jest.Mocked<GainNode>
+    let player;
+    let mockAudioContext;
+    let mockBufferNode;
+    let mockGainNode;
     
     beforeEach(() => {
         mockBufferNode = {
@@ -15,24 +15,24 @@ describe('WebAudioPlayer', () => {
             stop: jest.fn(),
             playbackRate: { value: 1 },
             onended: null,
-        } as unknown as jest.Mocked<AudioBufferSourceNode>
+        };
         
         mockGainNode = {
             connect: jest.fn(),
             gain: { value: 1 },
-        } as unknown as jest.Mocked<GainNode>
+        };
         
         mockAudioContext = {
             currentTime: 0,
             createBufferSource: jest.fn().mockReturnValue(mockBufferNode),
             createGain: jest.fn().mockReturnValue(mockGainNode),
-            destination: {} as AudioDestinationNode,
-        } as unknown as jest.Mocked<AudioContext>
+            destination: {},
+        };
         
         player = new WebAudioPlayer(mockAudioContext)
         
         // Set up a buffer to enable playback
-        const mockBuffer = { duration: 10 } as AudioBuffer
+        const mockBuffer = { duration: 10 }
         ;(player as any).buffer = mockBuffer })
         
         describe('_play method', () => { it('should reset position when currentPos is negative', async () => {

--- a/cypress/e2e/webaudio.cy.js
+++ b/cypress/e2e/webaudio.cy.js
@@ -1,0 +1,80 @@
+import WebAudioPlayer from '../src/webaudio';
+
+describe('WebAudioPlayer', () => {
+    let player: WebAudioPlayer
+    let mockAudioContext: jest.Mocked<AudioContext>
+    let mockBufferNode: jest.Mocked<AudioBufferSourceNode>
+    let mockGainNode: jest.Mocked<GainNode>
+    
+    beforeEach(() => {
+        mockBufferNode = {
+            buffer: null,
+            connect: jest.fn(),
+            disconnect: jest.fn(),
+            start: jest.fn(),
+            stop: jest.fn(),
+            playbackRate: { value: 1 },
+            onended: null,
+        } as unknown as jest.Mocked<AudioBufferSourceNode>
+        
+        mockGainNode = {
+            connect: jest.fn(),
+            gain: { value: 1 },
+        } as unknown as jest.Mocked<GainNode>
+        
+        mockAudioContext = {
+            currentTime: 0,
+            createBufferSource: jest.fn().mockReturnValue(mockBufferNode),
+            createGain: jest.fn().mockReturnValue(mockGainNode),
+            destination: {} as AudioDestinationNode,
+        } as unknown as jest.Mocked<AudioContext>
+        
+        player = new WebAudioPlayer(mockAudioContext)
+        
+        // Set up a buffer to enable playback
+        const mockBuffer = { duration: 10 } as AudioBuffer
+        ;(player as any).buffer = mockBuffer })
+        
+        describe('_play method', () => { it('should reset position when currentPos is negative', async () => {
+            // Set up negative position
+            player.playbackRate = -1;
+            player.currentTime = 5;
+            
+            // Trigger _play through play()
+            await player.play();
+            
+            // Verify position was reset
+            expect(player.currentTime).toBe(0);
+            expect(mockBufferNode.start).toHaveBeenCalledWith(0, 0)
+        })
+        
+        it('should reset position when currentPos exceeds duration', async () => {
+            // Set position beyond duration
+            player.currentTime = 15;
+            await player.play();
+            
+            // Verify position was reset
+            expect(player.currentTime).toBe(0);
+            expect(mockBufferNode.start).toHaveBeenCalledWith(0, 0);
+        })
+        
+        it('should maintain position when within valid range', async () => {
+            const validTime = 5;
+            player.currentTime = validTime;
+            await player.play()
+            
+            // Verify position was maintained
+            expect(mockBufferNode.start).toHaveBeenCalledWith(0, validTime);
+        })
+        
+        it('should handle playback rate changes correctly', async () => {
+            player.currentTime = 2;
+            player.playbackRate = 2;
+            await player.play()
+            
+            // currentPos should be 4 (2 * 2)
+            expect(mockBufferNode.start).toHaveBeenCalledWith(0, 4);
+            expect(mockBufferNode.playbackRate.value).toBe(2);
+        })
+    }) 
+})

--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -98,7 +98,7 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
     this.bufferNode.connect(this.gainNode)
 
     let currentPos = this.playedDuration * this._playbackRate
-    if (currentPos >= this.duration) {
+    if (currentPos >= this.duration || currentPos < 0) {
       currentPos = 0
       this.playedDuration = 0
     }


### PR DESCRIPTION
## Short description
Fix an issue where a rangeerror occured given a negative offset, causing execution of the 'start' method on AudioBufferSourceNode to fail.

## Implementation details
Added guard to check if given offset is negative, and if so, reset to 0 before invoking start method on audioContext.

## How to test it
Click at the start of waveform and drag around a bit, sometimes resulting in aforementioned issue.

## Screenshots


## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced audio playback reliability by refining how playback timing is managed, ensuring smoother handling when unexpected timing values occur.
- **Tests**
	- Introduced a new test suite for the `WebAudioPlayer` class, covering various playback scenarios to ensure correct behavior under different conditions, including handling negative playback positions and exceeding audio duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->