### PR TITLE
Chore: fix action version in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: E2E tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/yarn
 
@@ -26,7 +26,7 @@ jobs:
           browser: chrome
           record: false
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots


### PR DESCRIPTION
Fixes this:
<img width="1017" alt="Screenshot 2025-02-11 at 15 30 00" src="https://github.com/user-attachments/assets/b47ed293-590d-4b10-acb7-122e184977a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration workflows for end-to-end testing to leverage the latest tool versions, enhancing overall efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->