### PR TITLE
Updating an event listener in the example docs

### DIFF
--- a/examples/events.js
+++ b/examples/events.js
@@ -27,7 +27,7 @@ wavesurfer.on('ready', (duration) => {
 })
 
 /** When visible waveform is drawn */
-wavesurfer.on('redrawcomplete', () => {
+wavesurfer.on('redraw', () => {
   console.log('Redraw began')
 })
 


### PR DESCRIPTION
Resolves: Updates an event listener in the example documentation

I think `redraw` event listener should be the one that needs to triggered when visible waveform is drawn onto screen, isn't it ?





## Checklist
* [x] This PR is covered by e2e tests
<img width="822" alt="image" src="https://github.com/user-attachments/assets/7ace4658-259f-496f-b167-4a3da89815bb" />

* [x] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the audio waveform update mechanism to ensure more accurate and timely visual feedback for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->