### PR TITLE
Fix: play(start, stop) with WebAudio backend not worked

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -584,6 +584,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       this.setTime(start)
     }
 
+    const playResult = await super.play()
     if (end != null) {
       if (this.media instanceof WebAudioPlayer) {
         this.media.stopAt(end)
@@ -592,7 +593,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       }
     }
 
-    return super.play()
+    return playResult
   }
 
   /** Play or pause the audio */


### PR DESCRIPTION
## Short description
Using `backend: 'WebAudio'` with the play(start, stop) feature doesn't work properly.
This PR fixes the issue while ensuring that the default `backend: 'MediaElement'` option continues to work correctly.

Related : #4014 


## Implementation details
- Move `media.stopAt()` call after `super.play()` to ensure `bufferNode` is initialized
- Ensure event listener for `ended` event can be properly registered

The problem occurs in the `stopAt` method where `bufferNode` is not yet initialized when called:
```javascript
stopAt(timeSeconds: number) {
  const delay = timeSeconds - this.currentTime
  this.bufferNode?.stop(this.audioContext.currentTime + delay)

  // The event listener won't be registered if bufferNode is not initialized yet
  this.bufferNode?.addEventListener(
    'ended',
    () => {
      this.pause()
    },
    { once: true },
  )
}
```

## How to test it
- Play audio with both start and end times specified using the WebAudio backend

## Screenshots

## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced asynchronous handling in playback operations to ensure outcomes are reliably captured before proceeding. This update contributes to a smoother and more consistent media experience for users, particularly during playback initiation. It also sets the stage for further improvements in performance and stability for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->