### PR TITLE
Fix: prevent race condition in stopAt method

### DIFF
--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -134,13 +134,16 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
 
   stopAt(timeSeconds: number) {
     const delay = timeSeconds - this.currentTime
-    this.bufferNode?.stop(this.audioContext.currentTime + delay)
+    const currentBufferNode = this.bufferNode
+    currentBufferNode?.stop(this.audioContext.currentTime + delay)
 
-    this.bufferNode?.addEventListener(
+    currentBufferNode?.addEventListener(
       'ended',
       () => {
-        this.bufferNode = null
-        this.pause()
+        if (currentBufferNode === this.bufferNode) {
+          this.bufferNode = null
+          this.pause()
+        }
       },
       { once: true },
     )


### PR DESCRIPTION
## Short description
The current implementation of `stopAt` in WebAudioPlayer has a race condition when the method is called multiple times in quick succession. Previously, this would cause the player to enter an incorrect state because event listeners from previous calls would still execute `this.pause()` even after a new playback had started.

Related: #4066 


## Implementation details
- Modified the `stopAt` method to capture the current buffer node in a local variable
- Added a conditional check within the `'ended'` event listener to ensure `this.pause()` is only called if the buffer node that triggered the event is still the active one

## How to test it
- Play audio with both start and end times specified using `backend: 'WebAudio'` option
- Click region multiple times in quick succession

## Screenshots
This video shows how to trigger the bug.
https://github.com/user-attachments/assets/64ab94c7-56af-462d-b556-f116ec25ec82



## Checklist
* [x] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
![image](https://github.com/user-attachments/assets/097e1aa2-d32e-41fd-84b1-a5bb31135be5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the reliability of audio playback controls, ensuring that stopping audio functions consistently even during rapid state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->