### PR TITLE
Fix(Timeline): fix iteration over fractional time intervals

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -235,10 +235,10 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     for (let i = 0, notches = 0; i < duration; i += timeInterval, notches++) {
       const notch = notchEl.cloneNode() as HTMLElement
       const isPrimary =
-        (Math.round(i * 100) / 100) % primaryLabelInterval === 0 ||
+        Math.round(i * 100) % Math.round(primaryLabelInterval * 100) === 0 ||
         (primaryLabelSpacing && notches % primaryLabelSpacing === 0)
       const isSecondary =
-        (Math.round(i * 100) / 100) % secondaryLabelInterval === 0 ||
+        Math.round(i * 100) % Math.round(secondaryLabelInterval * 100) === 0 ||
         (secondaryLabelSpacing && notches % secondaryLabelSpacing === 0)
 
       if (isPrimary || isSecondary) {
@@ -251,7 +251,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
       const mode = isPrimary ? 'primary' : isSecondary ? 'secondary' : 'tick'
       notch.setAttribute('part', `timeline-notch timeline-notch-${mode}`)
 
-      const offset = (i + this.options.timeOffset) * pxPerSec
+      const offset = Math.round((i + this.options.timeOffset) * 100) / 100 * pxPerSec
       notch.style.left = `${offset}px`
       this.virtualAppend(offset, timeline, notch)
     }


### PR DESCRIPTION
## Short description
Resolves #4072

## Implementation details
Eliminate division by 100 when iterate through intervals to calculate primary and secondary interval correctly

## How to test it
#4072 shows timeline.js example with fractional intervals, this should fix the issue

## Screenshots
<img width="1171" alt="Screenshot 2025-03-27 at 03 55 25" src="https://github.com/user-attachments/assets/3350a5e2-17af-4cb0-a17f-7ae5de13fe80" />


## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the precision of timeline labels for a more consistent and clear display of intervals.
  - Updated calculations for label intervals and offsets to improve accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->