### PR TITLE
Accept MediaTrackConstraints when starting mic

### DIFF
--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -25,10 +25,7 @@ export type RecordPluginOptions = {
   mediaRecorderTimeslice?: number
 }
 
-export type RecordPluginDeviceOptions = {
-  /** The device ID of the microphone to use */
-  deviceId?: string | { exact: string }
-}
+export type RecordPluginDeviceOptions = MediaTrackConstraints
 
 export type RecordPluginEvents = BasePluginEvents & {
   /** Fires when the recording starts */
@@ -215,7 +212,7 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     let stream: MediaStream
     try {
       stream = await navigator.mediaDevices.getUserMedia({
-        audio: options?.deviceId ? { deviceId: options.deviceId } : true,
+        audio: options ?? true,
       })
     } catch (err) {
       throw new Error('Error accessing the microphone: ' + (err as Error).message)


### PR DESCRIPTION
## Short description
I think specifying the device only as options for the microphone is a bit too limited. 
I have the problem that on some devices, noise suppresion is active and there is currently no way to deactivate this with wavesurfer.js recorder plugin. 
Usually it would be done like this: 
```js
navigator.mediaDevices.getUserMedia({
  audio: {
    autoGainControl: false,
    channelCount: 2,
    echoCancellation: false,
    latency: 0,
    noiseSuppression: false,
    sampleRate: 48000,
    sampleSize: 16,
    volume: 1.0
  }
});
```

## Implementation details
Used the dom type `MediaTrackConstraints` directly instead of a custom type that mimics it partially.

## How to test it


## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
