### PR TITLE
getContent method and region-content-changed event created

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -28,6 +28,8 @@ export type RegionsPluginEvents = BasePluginEvents & {
   'region-in': [region: Region]
   /** When playback leaves a region */
   'region-out': [region: Region]
+  /** When region content is changed */
+  'region-content-changed': [previusRegion: Region, region: Region]
 }
 
 export type RegionEvents = {
@@ -47,6 +49,8 @@ export type RegionEvents = {
   over: [event: MouseEvent]
   /** Mouse leave */
   leave: [event: MouseEvent]
+  /** content changed */
+  'content-changed': [previusRegion: Region]
 }
 
 export type RegionParams = {
@@ -339,6 +343,17 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     this.emit('play', stopAtEnd && this.end !== this.start ? this.end : undefined)
   }
 
+  /** Get Content as html or string */
+  public getContent(asHTML: boolean = false) : string | HTMLElement | undefined {
+    if (asHTML) {
+      return this.content || undefined
+    }
+    if (this.element instanceof HTMLElement) {
+      return this.content?.innerHTML || undefined
+    }
+    return ''
+  }
+
   /** Set the HTML content of the region */
   public setContent(content: RegionParams['content']) {
     this.content?.remove()
@@ -363,6 +378,7 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     }
     this.content.setAttribute('part', 'region-content')
     this.element.appendChild(this.content)
+    this.emit('content-changed', this);
   }
 
   /** Update the region's options */
@@ -599,7 +615,9 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       region.on('dblclick', (e) => {
         this.emit('region-double-clicked', region, e)
       }),
-
+      region.on('content-changed', (previusRegion: Region) => {
+        this.emit('region-content-changed', previusRegion, region)
+      }),
       // Remove the region from the list when it's removed
       region.once('remove', () => {
         regionSubscriptions.forEach((unsubscribe) => unsubscribe())

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -29,7 +29,7 @@ export type RegionsPluginEvents = BasePluginEvents & {
   /** When playback leaves a region */
   'region-out': [region: Region]
   /** When region content is changed */
-  'region-content-changed': [previusRegion: Region, region: Region]
+  'region-content-changed': [region: Region]
 }
 
 export type RegionEvents = {
@@ -50,7 +50,7 @@ export type RegionEvents = {
   /** Mouse leave */
   leave: [event: MouseEvent]
   /** content changed */
-  'content-changed': [previusRegion: Region]
+  'content-changed': []
 }
 
 export type RegionParams = {
@@ -356,6 +356,7 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
 
   /** Set the HTML content of the region */
   public setContent(content: RegionParams['content']) {
+  
     this.content?.remove()
     if (!content) {
       this.content = undefined
@@ -378,7 +379,7 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     }
     this.content.setAttribute('part', 'region-content')
     this.element.appendChild(this.content)
-    this.emit('content-changed', this);
+    this.emit('content-changed');
   }
 
   /** Update the region's options */
@@ -615,9 +616,10 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       region.on('dblclick', (e) => {
         this.emit('region-double-clicked', region, e)
       }),
-      region.on('content-changed', (previusRegion: Region) => {
-        this.emit('region-content-changed', previusRegion, region)
+      region.on('content-changed', () => {
+        this.emit('region-content-changed', region)
       }),
+     
       // Remove the region from the list when it's removed
       region.once('remove', () => {
         regionSubscriptions.forEach((unsubscribe) => unsubscribe())


### PR DESCRIPTION
## Short description
Resolves #

## Implementation details
 -  implemented `getContent(asHTML:bool)`. it bring possibility to get content as HTML or just String value.
 - `region-content-changed`  RegionPlugin event:  It fires always `setContent(value)` is called.

## How to test it
 - Create a Region
 - Implement `region-content-changed` event on `RegionPlugin`.
 - using `region.getContent()` should  bring content value as string.
 - passing asHTML param  as true to `region.getContent()` method, it should return HTMLElement string.
 - using `region.setContent()` should fires `region-content-changed` event.
 - 
## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
