### PR TITLE
Feat(Regions): Add a `region-initialized` event that triggers early

### DIFF
--- a/cypress/e2e/regions.cy.js
+++ b/cypress/e2e/regions.cy.js
@@ -168,10 +168,15 @@ describe('WaveSurfer Regions plugin tests', () => {
       expect(regions.getRegions().length).to.equal(0)
 
       regions.addRegion({
-        stat: 3,
+        start: 3,
         end: 8,
         content: 'Region',
         color: 'rgba(0, 100, 0, 0.2)',
+      })
+
+      let regionInitializedEventCalled = false
+      regions.on('region-initialized', () => {
+        regionInitializedEventCalled = true
       })
 
       expect(regions.getRegions().length).to.equal(1)
@@ -191,6 +196,7 @@ describe('WaveSurfer Regions plugin tests', () => {
       })
       win.wavesurfer.getWrapper().dispatchEvent(pointerDownEvent)
       win.document.dispatchEvent(pointerMoveEvent)
+      expect(regionInitializedEventCalled).to.be.true
       win.document.dispatchEvent(pointerUpEvent)
 
       // It shouldn't trigger a click

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -12,7 +12,7 @@ import createElement from '../dom.js'
 export type RegionsPluginOptions = undefined
 
 export type RegionsPluginEvents = BasePluginEvents & {
-  /** When a new region is initialized */
+  /** When a new region is initialized but not rendered yet */
   'region-initialized': [region: Region]
   /** When a region is created */
   'region-created': [region: Region]

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -12,6 +12,8 @@ import createElement from '../dom.js'
 export type RegionsPluginOptions = undefined
 
 export type RegionsPluginEvents = BasePluginEvents & {
+  /** When a new region is initialized */
+  'region-initialized': [region: Region]
   /** When a region is created */
   'region-created': [region: Region]
   /** When a region is being updated */
@@ -356,7 +358,7 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
 
   /** Set the HTML content of the region */
   public setContent(content: RegionParams['content']) {
-  
+
     this.content?.remove()
     if (!content) {
       this.content = undefined
@@ -619,7 +621,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       region.on('content-changed', () => {
         this.emit('region-content-changed', region)
       }),
-     
+
       // Remove the region from the list when it's removed
       region.once('remove', () => {
         regionSubscriptions.forEach((unsubscribe) => unsubscribe())
@@ -642,6 +644,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     const duration = this.wavesurfer.getDuration()
     const numberOfChannels = this.wavesurfer?.getDecodedData()?.numberOfChannels
     const region = new SingleRegion(options, duration, numberOfChannels)
+    this.emit('region-initialized', region)
 
     if (!duration) {
       this.subscriptions.push(
@@ -703,6 +706,9 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
           duration,
           numberOfChannels,
         )
+
+        this.emit('region-initialized', region)
+
         // Just add it to the DOM for now
         this.regionsContainer.appendChild(region.element)
       },


### PR DESCRIPTION
## Short description
Right now `region-created`` only triggers when the
user lifts their moust, which means it's not possible
to get any callbacks or events of their selection until
that moment. This new event triggers immediatly, allowing
developers to hook onto events, or do things like change
the color, add a number inside etc..

## Implementation details
I created a new event so existing code doesn't break.

## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
