### PR TITLE
Fix(Hover plugin): wheel listener removal

### DIFF
--- a/src/plugins/hover.ts
+++ b/src/plugins/hover.ts
@@ -97,7 +97,7 @@ class HoverPlugin extends BasePlugin<HoverPluginEvents, HoverPluginOptions> {
     this.unsubscribe = () => {
       container.removeEventListener('pointermove', this.onPointerMove)
       container.removeEventListener('pointerleave', this.onPointerLeave)
-      container.removeEventListener('wheel', this.onPointerLeave)
+      container.removeEventListener('wheel', this.onPointerMove)
     }
   }
 


### PR DESCRIPTION
## Summary
- fix unsubscribe handler to remove the `wheel` event listener using the correct callback

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: cypress not found)*