### PR TITLE
fix: bar width clamping and add test

### DIFF
--- a/cypress/e2e/options.cy.js
+++ b/cypress/e2e/options.cy.js
@@ -394,6 +394,23 @@ describe('WaveSurfer options tests', () => {
     })
   })
 
+  it('should not create an extra canvas when using bars with normalize', (done) => {
+    cy.window().then((win) => {
+      const wavesurfer = win.WaveSurfer.create({
+        container: id,
+        url: '../../examples/audio/demo.wav',
+        barWidth: 2,
+        normalize: true,
+      })
+
+      wrapReady(wavesurfer).then(() => {
+        const canvases = wavesurfer.getWrapper().querySelectorAll('canvas')
+        expect(canvases.length).to.equal(2)
+        done()
+      })
+    })
+  })
+
   it('should use height', (done) => {
     cy.window().then((win) => {
       const wavesurfer = win.WaveSurfer.create({

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -548,7 +548,16 @@ class Renderer extends EventEmitter<RendererEvents> {
       if (drawnIndexes[index]) return
       drawnIndexes[index] = true
       const offset = index * singleCanvasWidth
-      const clampedWidth = Math.min(totalWidth - offset, singleCanvasWidth)
+      let clampedWidth = Math.min(totalWidth - offset, singleCanvasWidth)
+
+      // Clamp the width to the bar grid to avoid empty canvases at the end
+      if (options.barWidth || options.barGap) {
+        const barWidth = options.barWidth || 0.5
+        const barGap = options.barGap || barWidth / 2
+        const totalBarWidth = barWidth + barGap
+        clampedWidth = Math.floor(clampedWidth / totalBarWidth) * totalBarWidth
+      }
+
       if (clampedWidth <= 0) return
       const data = channelData.map((channel) => {
         const start = Math.floor((offset / totalWidth) * channel.length)


### PR DESCRIPTION
Resolves #4041

## Summary
- clamp canvas size with barWidth + barGap grid
- avoid creating canvases with zero width
- add Cypress regression test for bars + normalize option