### PR TITLE
Fix ts tests generics

### DIFF
--- a/src/__tests__/event-emitter.test.ts
+++ b/src/__tests__/event-emitter.test.ts
@@ -3,6 +3,7 @@ import EventEmitter from '../event-emitter.js'
 interface Events {
   foo: [number]
   bar: []
+  [key: string]: unknown[]
 }
 
 describe('EventEmitter', () => {

--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -1,6 +1,8 @@
 import Player from '../player.js'
 
-interface Events {}
+interface Events {
+  [key: string]: unknown[]
+}
 
 describe('Player', () => {
   const createMedia = () => {
@@ -35,7 +37,7 @@ describe('Player', () => {
 
   test('setTime clamps to duration', () => {
     const media = createMedia()
-    media.duration = 10
+    Object.defineProperty(media, 'duration', { configurable: true, value: 10 })
     const player = new Player<Events>({ media })
     player.setTime(-1)
     expect(player.getCurrentTime()).toBe(0)


### PR DESCRIPTION
## Summary
- fix generic event interface in tests
- allow setting duration in Player test

## Testing
- `yarn test:unit` *(fails: matchMedia is not defined, etc.)*