### PR TITLE
Clear subscriptions array to avoid memory leaks

### DIFF
--- a/examples/minimap-leak.js
+++ b/examples/minimap-leak.js
@@ -1,0 +1,54 @@
+// Plugin leak test
+
+// Instructions:
+// 1. Load the page and press the "Reload" button several times
+// 2. Open the Memory tab in Chrome DevTools
+// 3. Take a heap snapshot
+// 4. Look for "MinimapPlugin" in the snapshot - there should be only one instance of it
+// 4. Look for "WaveSurfer" in the snapshot - there should be only two instances of it
+
+
+import WaveSurfer from 'wavesurfer.js'
+import Minimap from 'wavesurfer.js/dist/plugins/minimap.esm.js'
+
+// Create an instance of WaveSurfer
+const ws = WaveSurfer.create({
+  container: '#waveform',
+  waveColor: 'rgb(200, 0, 200)',
+  progressColor: 'rgb(100, 0, 100)',
+  url: '/examples/audio/audio.wav',
+  minPxPerSec: 100,
+  hideScrollbar: true,
+  autoCenter: false,
+})
+
+function createMinimapPlugin() {
+  return Minimap.create({
+    height: 20,
+    waveColor: '#ddd',
+    progressColor: '#999',
+  })
+}
+
+let minimapPlugin = createMinimapPlugin()
+ws.registerPlugin(minimapPlugin)
+
+ws.on('interaction', () => {
+  ws.play()
+})
+
+document.querySelector('#reload').onclick = async (e) => {
+  minimapPlugin.destroy()
+  minimapPlugin = createMinimapPlugin()
+  ws.registerPlugin(minimapPlugin)
+}
+
+/*
+<html>
+  <div id="waveform"></div>
+  <button id="reload">Reload</button>
+  <p>
+    📖 <a href="https://wavesurfer.xyz/docs/classes/plugins_minimap.MinimapPlugin">Minimap plugin docs</a>
+  </p>
+</html>
+*/

--- a/index.html
+++ b/index.html
@@ -153,6 +153,7 @@
           <li><a href="#timeline.js">Timeline</a></li>
           <li><a href="#timeline-custom.js">Timeline x2</a></li>
           <li><a href="#minimap.js">Minimap</a></li>
+          <li><a href="#minimap-leak.js">Minimap Leak Test</a></li>
           <li><a href="#envelope.js">Envelope</a></li>
           <li><a href="#spectrogram.js">Spectrogram</a></li>
           <li><a href="#record.js">Record</a></li>

--- a/src/base-plugin.ts
+++ b/src/base-plugin.ts
@@ -34,6 +34,7 @@ export class BasePlugin<EventTypes extends BasePluginEvents, Options> extends Ev
   public destroy() {
     this.emit('destroy')
     this.subscriptions.forEach((unsubscribe) => unsubscribe())
+    this.subscriptions = []
   }
 }
 

--- a/src/base-plugin.ts
+++ b/src/base-plugin.ts
@@ -34,7 +34,6 @@ export class BasePlugin<EventTypes extends BasePluginEvents, Options> extends Ev
   public destroy() {
     this.emit('destroy')
     this.subscriptions.forEach((unsubscribe) => unsubscribe())
-    this.subscriptions = []
   }
 }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -388,11 +388,9 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.plugins.push(plugin)
 
     // Unregister plugin on destroy
-    this.subscriptions.push(
-      plugin.once('destroy', () => {
-        this.plugins = this.plugins.filter((p) => p !== plugin)
-      }),
-    )
+    plugin.once('destroy', () => {
+      this.plugins = this.plugins.filter((p) => p !== plugin)
+    })
 
     return plugin
   }


### PR DESCRIPTION
## Short description
I have observed memory leaks when using the minimap plugin. 

In my application, I reuse the same wavesurfer instance and create a new MinimapPlugin each time I load new audio data. I also call destroy() on the old MinimapPlugin. Despite this, I see memory being leaked that was created from the minimap plugin. 

Perhaps this reuse of an instance with different plugins is not an intended use-case in which case this PR is moot.

## Implementation details
I found that the problem is with the following code:

    this.subscriptions.push(
       plugin.once('destroy', () => {
         this.plugins = this.plugins.filter((p) => p !== plugin)
       }),
    )

When the plugin is destroyed, there is still a reference to it in the `subscriptions` array. 

I could not find a good way to remove the entry in `subscriptions` so I opted for not adding it there at all. The drawback is that `unregister()` on the event will not be called. This could lead to a plugin calling the destroy handler after the wavesurfer instance was destroyed, but that seems harmless.

## How to test it
1. Load the `minimap-leak` example and press the "Reload" button several times
2. Open the Memory tab in Chrome DevTools
3. Take a heap snapshot
4. Look for "MinimapPlugin" in the snapshot - there should be only one instance of it
5. Look for "WaveSurfer" in the snapshot - there should be only two instances of it


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
