### PR TITLE
fix(Record): clear media element source when no URL is provided

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -75,7 +75,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
 
     // Reset the media element, otherwise it keeps the previous source
     if (src) {
-      this.media.src = ''
+      this.media.removeAttribute('src')
     }
 
     try {
@@ -90,7 +90,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     this.media.pause()
     this.media.remove()
     this.revokeSrc()
-    this.media.src = ''
+    this.media.removeAttribute('src')
     // Load resets the media element to its initial state
     this.media.load()
   }

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -451,8 +451,13 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       }
     }
 
-    // Set the mediaelement source
-    this.setSrc(url, blob)
+    if (url == '') {
+      // If no URL is provided, clear the mediaelement source
+      this.getMediaElement().removeAttribute('src')
+    } else {
+      // Set the mediaelement source
+      this.setSrc(url, blob)
+    }
 
     // Wait for the audio duration
     const audioDuration = await new Promise<number>((resolve) => {


### PR DESCRIPTION
## Short description
Resolves #4039

Fixes the continuous warning logging on Firefox 

## Implementation details
Instead of setting `src` to `''` when loading the data from record plugin to wavesurfer, the `src` attribute is removed. 
I also updated other places where `src` was set to `''` as the media element interprets it as relative path.

I left the `''` URL being passed to `load`, but maybe passing `null` instead would be safer. Let me know if I should change that.

## How to test it
Start recording with record plugin on Firefox on the record example page

## Screenshots
<img width="1762" alt="Screenshot 2025-06-21 at 20 44 23" src="https://github.com/user-attachments/assets/d6e42650-a98a-4f1f-ade7-64e1629089ff" />
Before the fix:
<img width="1762" alt="Screenshot 2025-06-21 at 20 45 07" src="https://github.com/user-attachments/assets/4dcfee5c-dfb7-4068-acc7-258b77722fb7" />

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
