### PR TITLE
fix(WaveSurfer): release plugin references on destroy

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -388,11 +388,11 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.plugins.push(plugin)
 
     // Unregister plugin on destroy
-    this.subscriptions.push(
-      plugin.once('destroy', () => {
-        this.plugins = this.plugins.filter((p) => p !== plugin)
-      }),
-    )
+    const unsubscribe = plugin.once('destroy', () => {
+      this.plugins = this.plugins.filter((p) => p !== plugin)
+      this.subscriptions = this.subscriptions.filter((fn) => fn !== unsubscribe)
+    })
+    this.subscriptions.push(unsubscribe)
 
     return plugin
   }


### PR DESCRIPTION
## Short description
Resolves #

## Implementation details
- remove unsubscribe functions from `subscriptions` when plugin `destroy` fires

## How to test it
- `yarn lint`

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes

------
https://chatgpt.com/codex/tasks/task_b_685a5e84f1ec832f8c5134f3496650c0