### PR TITLE
docs(overview): add concise guide for AI agents

### DIFF
--- a/AI_OVERVIEW.md
+++ b/AI_OVERVIEW.md
@@ -1,0 +1,26 @@
+# Repository Overview for AI Agents
+
+This document gives a condensed view of the project structure and build process so that AI tools (like Codex) can reason about the codebase without scanning every file.
+
+## Project Structure
+
+- **`src/`** – TypeScript source files for the library. The entry point is [`wavesurfer.ts`](../src/wavesurfer.ts). Other files implement features such as the player, plugins, and utilities.
+- **`examples/`** – Stand‑alone demos used for manual testing and documentation. Each example is an HTML page importing the library and demonstrating a specific feature.
+- **`cypress/`** – End‑to‑end and visual regression tests powered by Cypress. Tests live in `cypress/e2e` and snapshots reside in `cypress/snapshots`.
+- **`scripts/`** – Helper scripts for cleaning the build directory and creating new plugins.
+- **Root config files** – `package.json` defines the build, lint, and test commands. TypeScript configuration is in `tsconfig.json`, and linting rules are in `.eslintrc` and `.prettierrc`.
+
+## Common Tasks
+
+- **Install dependencies**: `yarn`
+- **Run the dev server**: `yarn start` (compiles TypeScript in watch mode and serves examples on <http://localhost:9090>)
+- **Build for production**: `yarn build`
+- **Run lint checks**: `yarn lint`
+- **Run Cypress tests**: `yarn cypress`
+
+## Contribution Notes
+
+- Follow the coding conventions in [`AGENTS.md`](../AGENTS.md).
+- Do not commit generated files from `dist/` or `node_modules/`.
+
+This overview should help an AI agent quickly locate relevant source files and scripts without traversing the entire repository.


### PR DESCRIPTION
## Short description
Adds a brief `AI_OVERVIEW.md` with project structure and common commands. This should help AI tools understand the repository layout without scanning every file.

## Implementation details
- New `AI_OVERVIEW.md` summarises key directories, commands, and contribution notes
- Formatted with Prettier

## How to test it
Open `AI_OVERVIEW.md` and verify the information is correct. Run `yarn lint` (fails with `Invalid option '--ext'`).

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes

------
https://chatgpt.com/codex/tasks/task_b_685aa6730260832f953626d8a5164928