### PR TITLE
test(Renderer): add comprehensive unit tests

### DIFF
--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -1,0 +1,202 @@
+import Renderer from '../renderer.js'
+
+declare global {
+  interface Window {
+    HTMLCanvasElement: typeof HTMLCanvasElement
+  }
+}
+
+const createAudioBuffer = (channels: number[][], duration = 1): AudioBuffer => {
+  return {
+    duration,
+    length: channels[0].length,
+    sampleRate: channels[0].length / duration,
+    numberOfChannels: channels.length,
+    getChannelData: (i: number) => Float32Array.from(channels[i]),
+    copyFromChannel: jest.fn(),
+    copyToChannel: jest.fn(),
+  } as unknown as AudioBuffer
+}
+
+describe('Renderer', () => {
+  let container: HTMLDivElement
+  let renderer: Renderer
+  const originalGetContext = window.HTMLCanvasElement.prototype.getContext
+  const originalToDataURL = window.HTMLCanvasElement.prototype.toDataURL
+  const originalToBlob = window.HTMLCanvasElement.prototype.toBlob
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'devicePixelRatio', { value: 1, writable: true })
+
+    window.HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+      beginPath: jest.fn(),
+      rect: jest.fn(),
+      roundRect: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      closePath: jest.fn(),
+      fill: jest.fn(),
+      drawImage: jest.fn(),
+      fillRect: jest.fn(),
+      createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() })),
+      globalCompositeOperation: '',
+      canvas: { width: 100, height: 100 },
+    })) as any
+
+    window.HTMLCanvasElement.prototype.toDataURL = jest.fn(() => 'data:mock')
+    window.HTMLCanvasElement.prototype.toBlob = jest.fn(cb => cb(new Blob([''])))
+  })
+
+  afterAll(() => {
+    window.HTMLCanvasElement.prototype.getContext = originalGetContext
+    window.HTMLCanvasElement.prototype.toDataURL = originalToDataURL
+    window.HTMLCanvasElement.prototype.toBlob = originalToBlob
+  })
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    container.id = 'root'
+    document.body.appendChild(container)
+    renderer = new Renderer({ container })
+  })
+
+  afterEach(() => {
+    renderer.destroy()
+    container.remove()
+    jest.clearAllMocks()
+  })
+
+  test('parentFromOptionsContainer returns element and throws', () => {
+    expect((renderer as any).parentFromOptionsContainer(container)).toBe(container)
+    expect((renderer as any).parentFromOptionsContainer('#root')).toBe(container)
+    expect(() => (renderer as any).parentFromOptionsContainer('#missing')).toThrow()
+  })
+
+  test('initHtml creates shadow root', () => {
+    const [el, shadow] = (renderer as any).initHtml()
+    expect(el.shadowRoot).toBe(shadow)
+    expect(shadow.querySelector('.scroll')).not.toBeNull()
+  })
+
+  test('getHeight calculates values', () => {
+    ;(renderer as any).audioData = { numberOfChannels: 2 }
+    expect((renderer as any).getHeight(undefined, undefined)).toBe(128)
+    expect((renderer as any).getHeight(50, undefined)).toBe(50)
+    container.style.height = '200px'
+    expect((renderer as any).getHeight('auto', [{ overlay: false }])).toBe(64)
+  })
+
+  test('createDelay resolves after time', async () => {
+    jest.useFakeTimers()
+    const delay = (renderer as any).createDelay(10)
+    const spy = jest.fn()
+    const p = delay().then(spy)
+    jest.advanceTimersByTime(10)
+    await p
+    expect(spy).toHaveBeenCalled()
+    jest.useRealTimers()
+  })
+
+  test('convertColorValues supports gradients', () => {
+    const result = (renderer as any).convertColorValues(['red', 'blue'])
+    expect(typeof result).toBe('object')
+    expect(((renderer as any).convertColorValues('red'))).toBe('red')
+  })
+
+  test('getPixelRatio returns positive', () => {
+    window.devicePixelRatio = 2
+    expect((renderer as any).getPixelRatio()).toBe(2)
+  })
+
+  test('renderBarWaveform and renderLineWaveform draw on context', () => {
+    const ctx = (renderer as any).canvasWrapper.ownerDocument.createElement('canvas').getContext('2d') as any
+    const data = [new Float32Array([0, 0.5, -0.5]), new Float32Array([0, -0.5, 0.5])]
+    ;(renderer as any).renderBarWaveform(data, {}, ctx, 1)
+    expect(ctx.beginPath).toHaveBeenCalled()
+    ;(renderer as any).renderLineWaveform(data, {}, ctx, 1)
+    expect(ctx.lineTo).toHaveBeenCalled()
+  })
+
+  test('renderWaveform chooses rendering path', () => {
+    const ctx = document.createElement('canvas').getContext('2d') as any
+    const data = [new Float32Array([0, 1])]
+    const spyBar = jest.spyOn(renderer as any, 'renderBarWaveform')
+    const spyLine = jest.spyOn(renderer as any, 'renderLineWaveform')
+    ;(renderer as any).renderWaveform(data, { barWidth: 1 }, ctx)
+    expect(spyBar).toHaveBeenCalled()
+    ;(renderer as any).renderWaveform(data, {}, ctx)
+    expect(spyLine).toHaveBeenCalled()
+  })
+
+  test('renderSingleCanvas appends canvases', () => {
+    const canvasContainer = document.createElement('div')
+    const progressContainer = document.createElement('div')
+    const data = [new Float32Array([0, 1])]
+    ;(renderer as any).renderSingleCanvas(data, {}, 10, 10, 0, canvasContainer, progressContainer)
+    expect(canvasContainer.querySelector('canvas')).not.toBeNull()
+    expect(progressContainer.querySelector('canvas')).not.toBeNull()
+  })
+
+  test('renderMultiCanvas draws and subscribes', () => {
+    const canvasContainer = document.createElement('div')
+    const progressContainer = document.createElement('div')
+    const data = [new Float32Array([0, 1])] as any
+    Object.defineProperty((renderer as any).scrollContainer, 'clientWidth', { configurable: true, value: 200 })
+    ;(renderer as any).renderMultiCanvas(data, { barWidth: 1 }, 200, 10, canvasContainer, progressContainer)
+    expect(canvasContainer.querySelector('canvas')).not.toBeNull()
+  })
+
+  test('renderChannel creates containers', () => {
+    const data = [new Float32Array([0, 1])]
+    ;(renderer as any).renderChannel(data, {}, 10, 0)
+    expect((renderer as any).canvasWrapper.children.length).toBeGreaterThan(0)
+  })
+
+  test('render processes audio buffer', async () => {
+    const buffer = createAudioBuffer([[0, 0.5, -0.5]])
+    const spy = jest.fn()
+    renderer.on('render', spy)
+    await renderer.render(buffer)
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('reRender keeps scroll position', async () => {
+    const buffer = createAudioBuffer([[0, 0.5, -0.5]])
+    await renderer.render(buffer)
+    renderer.setScroll(10)
+    renderer.reRender()
+    expect(renderer.getScroll()).toBe(10)
+  })
+
+  test('zoom updates option', () => {
+    renderer.zoom(20)
+    expect((renderer as any).options.minPxPerSec).toBe(20)
+  })
+
+  test('scrollIntoView updates scroll', () => {
+    Object.defineProperty((renderer as any).scrollContainer, 'scrollWidth', { configurable: true, value: 100 })
+    Object.defineProperty((renderer as any).scrollContainer, 'clientWidth', { configurable: true, value: 50 })
+    renderer.renderProgress(0)
+    ;(renderer as any).scrollIntoView(0.8)
+    expect(renderer.getScroll()).toBeGreaterThanOrEqual(0)
+  })
+
+  test('renderProgress updates styles', () => {
+    renderer.renderProgress(0.5)
+    expect((renderer as any).progressWrapper.style.width).toBe('50%')
+  })
+
+  test('exportImage returns data', async () => {
+    const canvas = document.createElement('canvas')
+    ;(renderer as any).canvasWrapper.appendChild(canvas)
+    const urls = await renderer.exportImage('image/png', 1, 'dataURL')
+    expect(urls).toHaveLength(1)
+    const blobs = await renderer.exportImage('image/png', 1, 'blob')
+    expect(blobs).toHaveLength(1)
+  })
+
+  test('destroy cleans up', () => {
+    renderer.destroy()
+    expect(container.contains(renderer.getWrapper())).toBe(false)
+  })
+})


### PR DESCRIPTION
## Short description
Add jest unit tests for `renderer.ts` covering all public and private methods.

## Implementation details
- Created `renderer.test.ts` with canvas stubs so jsdom can execute rendering logic
- Tests exercise container resolution, waveform rendering helpers, scroll helpers and image export

## How to test it
- `yarn test:unit`

## Checklist
- [x] `yarn lint` *(fails: Invalid option `--ext`)*
- [x] `yarn test:unit`


------
https://chatgpt.com/codex/tasks/task_b_685aa5d74f3c832f94933549bd4e8f6f