### PR TITLE
Fix(timer): revert breaking change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cypress/downloads
 cypress/videos
 cypress/**/__diff_output__/
 .env
+coverage/

--- a/src/__tests__/timer.test.ts
+++ b/src/__tests__/timer.test.ts
@@ -16,15 +16,4 @@ describe('Timer', () => {
     timer.start()
     expect(tick).toHaveBeenCalledTimes(2)
   })
-
-  test('stop unsubscribes', () => {
-    const timer = new Timer()
-    const tick = jest.fn()
-    timer.on('tick', tick)
-    timer.start()
-    timer.stop()
-    tick.mockClear()
-    ;(timer as any).emit('tick')
-    expect(tick).not.toHaveBeenCalled()
-  })
 })

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -18,7 +18,6 @@ class Timer extends EventEmitter<TimerEvents> {
 
   stop() {
     this.unsubscribe()
-    this.unAll()
   }
 
   destroy() {


### PR DESCRIPTION
## Short description
Resolves #4119

## Implementation details
There was an unintended change in timer.ts when adding unit tests. It's now reverted.