### PR TITLE
Fix(Firefox): add polygon percentage units

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -763,7 +763,7 @@ class Renderer extends EventEmitter<RendererEvents> {
   renderProgress(progress: number, isPlaying?: boolean) {
     if (isNaN(progress)) return
     const percents = progress * 100
-    this.canvasWrapper.style.clipPath = `polygon(${percents}% 0, 100% 0, 100% 100%, ${percents}% 100%)`
+    this.canvasWrapper.style.clipPath = `polygon(${percents}% 0%, 100% 0%, 100% 100%, ${percents}% 100%)`
     this.progressWrapper.style.width = `${percents}%`
     this.cursor.style.left = `${percents}%`
     this.cursor.style.transform = `translateX(-${Math.round(percents) === 100 ? this.options.cursorWidth : 0}px)`


### PR DESCRIPTION
## Short description
Resolves #4111

## Implementation details
I've added % units to appease Firefox.