### PR TITLE
Fix: loadBlob URL setting

### DIFF
--- a/src/event-emitter.ts
+++ b/src/event-emitter.ts
@@ -1,7 +1,7 @@
 export type GeneralEventTypes = {
   // the name of the event and the data it dispatches with
   // e.g. 'entryCreated': [count: 1]
-  [EventName: string]: unknown[] // eslint-disable-line @typescript-eslint/no-explicit-any
+  [EventName: string]: unknown[]
 }
 
 type EventListener<EventTypes extends GeneralEventTypes, EventName extends keyof EventTypes> = (

--- a/src/player.ts
+++ b/src/player.ts
@@ -68,14 +68,16 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   }
 
   protected setSrc(url: string, blob?: Blob) {
-    const src = this.getSrc()
-    if (url && src === url) return // no need to change the source
+    const prevSrc = this.getSrc()
+    if (url && prevSrc === url) return // no need to change the source
 
     this.revokeSrc()
     const newSrc = blob instanceof Blob && (this.canPlayType(blob.type) || !url) ? URL.createObjectURL(blob) : url
 
     // Reset the media element, otherwise it keeps the previous source
-    this.media.removeAttribute('src')
+    if (prevSrc) {
+      this.media.removeAttribute('src')
+    }
 
     if (newSrc || url) {
       try {

--- a/src/player.ts
+++ b/src/player.ts
@@ -69,19 +69,20 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
 
   protected setSrc(url: string, blob?: Blob) {
     const src = this.getSrc()
-    if (url && src === url) return
+    if (url && src === url) return // no need to change the source
+
     this.revokeSrc()
     const newSrc = blob instanceof Blob && (this.canPlayType(blob.type) || !url) ? URL.createObjectURL(blob) : url
 
     // Reset the media element, otherwise it keeps the previous source
-    if (src) {
-      this.media.removeAttribute('src')
-    }
+    this.media.removeAttribute('src')
 
-    try {
-      this.media.src = newSrc
-    } catch {
-      this.media.src = url
+    if (newSrc || url) {
+      try {
+        this.media.src = newSrc
+      } catch {
+        this.media.src = url
+      }
     }
   }
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -451,13 +451,8 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       }
     }
 
-    if (url == '') {
-      // If no URL is provided, clear the mediaelement source
-      this.getMediaElement().removeAttribute('src')
-    } else {
-      // Set the mediaelement source
-      this.setSrc(url, blob)
-    }
+    // Set the mediaelement source
+    this.setSrc(url, blob)
 
     // Wait for the audio duration
     const audioDuration = await new Promise<number>((resolve) => {


### PR DESCRIPTION
## Short description
Resolves #4128

## Implementation details
`setSrc` is now always called but it doesn't set the URL to an empty string.