### PR TITLE
[Fix] [Timeline] Make sure that first tick on left edge is drawing

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -152,7 +152,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     const renderIfVisible = (scrollLeft: number, scrollRight: number) => {
       if (!this.wavesurfer) return
       const width = element.clientWidth
-      const isVisible = start > scrollLeft && start + width < scrollRight
+      const isVisible = start >= scrollLeft && start + width < scrollRight
 
       if (isVisible === wasVisible) return
       wasVisible = isVisible


### PR DESCRIPTION
## Short description

Currently, when a timeline is displayed, the first major tick is not rendered. This occurs due to an edge case where the time value is zero, and the plugin's rendering condition uses a strict inequality (`>`) instead of a non-strict one (`>=`).

## Implementation details

Changed the comparison operator from `>` to `>=` to ensure the first major tick at time zero is rendered.

## How to test it

This issue is demonstrable in the existing examples. Please refer to them for testing.

## Screenshots

Observe the lower-left corner of the timeline.

Before:
![image](https://github.com/user-attachments/assets/0224d34c-6be5-442a-bd8f-d3a739fbc07c)

After:
![image](https://github.com/user-attachments/assets/b45e9c1b-1930-49e2-b261-3f1fa023d386)


## Checklist
* [+] This PR is covered by e2e tests
* [+] It introduces no breaking API changes
