### PR TITLE
fix(Renderer): fix cursor jump at end of playback

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -766,7 +766,9 @@ class Renderer extends EventEmitter<RendererEvents> {
     this.canvasWrapper.style.clipPath = `polygon(${percents}% 0%, 100% 0%, 100% 100%, ${percents}% 100%)`
     this.progressWrapper.style.width = `${percents}%`
     this.cursor.style.left = `${percents}%`
-    this.cursor.style.transform = `translateX(-${Math.round(percents) === 100 ? this.options.cursorWidth : 0}px)`
+    this.cursor.style.transform = this.options.cursorWidth
+      ? `translateX(-${progress * this.options.cursorWidth}px)`
+      : ''
 
     if (this.isScrollable && this.options.autoScroll) {
       this.scrollIntoView(progress, isPlaying)


### PR DESCRIPTION
## Short description

Fix cursor jump at end of playback.

## Implementation details

This issue was caused by sudden translateX changes.

I fixed it by making the translateX smoothly increase based on the progress value.

## How to test it

Setting `cursorWidth` to a larger value makes it more visible.

## Screenshots

Before:

![chrome_u3lTrAfiKJ](https://github.com/user-attachments/assets/460ce5e0-ae51-4c13-8664-d7d640f5464c)

After:

![chrome_62cGQEMQir](https://github.com/user-attachments/assets/24c3c98f-4cd8-44aa-8762-18dc7835a960)

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
