### PR TITLE
fix(player): ensure WebAudio supports removeAttribute

### DIFF
--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -229,6 +229,32 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
     }
     return channels
   }
+
+  /**
+   * Imitate `HTMLElement.removeAttribute` for compatibility with `Player`.
+   */
+  public removeAttribute(attrName: string) {
+    switch (attrName) {
+      case 'src':
+        this.src = ''
+        break
+      case 'playbackRate':
+        this.playbackRate = 0
+        break
+      case 'currentTime':
+        this.currentTime = 0
+        break
+      case 'duration':
+        this.duration = 0
+        break
+      case 'volume':
+        this.volume = 0
+        break
+      case 'muted':
+        this.muted = false
+        break
+    }
+  }
 }
 
 export default WebAudioPlayer


### PR DESCRIPTION
## Short description
Fixes a crash when calling `empty()` with the `WebAudio` backend.

Resolves #4161.

## Implementation details
Adds a `removeAttribute` method to `WebAudioPlayer` so that `Player` can reset the media source without errors.

## How to test it
- `yarn lint`
- `yarn test:unit`

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes

------
https://chatgpt.com/codex/tasks/task_b_687b3ac2e414832fb6a094729f2c306c