### PR TITLE
fix(timeline): remove notch listeners on redraw

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -56,6 +56,7 @@ export type TimelinePluginEvents = BasePluginEvents & {
 
 class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOptions> {
   private timelineWrapper: HTMLElement
+  private unsubscribeNotches: (() => void)[] = []
   protected options: TimelinePluginOptions & typeof defaultOptions
 
   constructor(options?: TimelinePluginOptions) {
@@ -102,6 +103,8 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
 
   /** Unmount */
   public destroy() {
+    this.unsubscribeNotches.forEach((unsubscribe) => unsubscribe())
+    this.unsubscribeNotches = []
     this.timelineWrapper.remove()
     super.destroy()
   }
@@ -170,7 +173,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
 
     renderIfVisible(scrollLeft, scrollRight)
 
-    this.subscriptions.push(
+    this.unsubscribeNotches.push(
       this.wavesurfer.on('scroll', (_start, _end, scrollLeft, scrollRight) => {
         renderIfVisible(scrollLeft, scrollRight)
       }),
@@ -178,6 +181,9 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
   }
 
   private initTimeline() {
+    this.unsubscribeNotches.forEach((unsubscribe) => unsubscribe())
+    this.unsubscribeNotches = []
+
     const duration = this.wavesurfer?.getDuration() ?? this.options.duration ?? 0
     const pxPerSec = (this.wavesurfer?.getWrapper().scrollWidth || this.timelineWrapper.scrollWidth) / duration
     const timeInterval = this.options.timeInterval ?? this.defaultTimeInterval(pxPerSec)


### PR DESCRIPTION
## Short description
Prevent growing memory usage when using the Timeline plugin by removing the per-notch scroll listeners on each redraw.

Resolves #4156.

## Implementation details
A new `unsubscribeNotches` array stores unsubscribe callbacks for notch scroll handlers. These callbacks are executed before rebuilding the timeline and on plugin destruction so old listeners do not accumulate.

## How to test it
- Run `yarn lint` (fails due to existing lint issues)
- Build the example with the Timeline and Zoom plugins and repeatedly zoom in/out – memory usage no longer grows.

## Checklist
- [ ] Updated tests
- [ ] Updated documentation
- [x] Ran `yarn lint` *(fails)*


------
https://chatgpt.com/codex/tasks/task_b_687b3f24d198832fb6e8fd51dfdc3226