### PR TITLE
fix(regions): avoid listeners after removal

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -589,7 +589,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     }
 
     setTimeout(() => {
-      if (!this.wavesurfer) return
+      if (!this.wavesurfer || !region.element) return
       renderIfVisible()
 
       const unsubscribeScroll = this.wavesurfer.on('scroll', renderIfVisible)


### PR DESCRIPTION
## Short description
Prevent async subscription when a region is already removed.

## Implementation details
`virtualAppend()` now checks `region.element` inside the async callback. If the region was removed before the timeout executes, scroll and zoom listeners are no longer attached, preventing unused subscriptions from accumulating.

## How to test it
- `yarn lint` *(fails: existing issues in src/fft.ts)*

## Screenshots
N/A

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes

------
https://chatgpt.com/codex/tasks/task_b_687c8e2b5268832f8d87be52510c1de5