### PR TITLE
fix(Envelope): guard update for hidden containers

### DIFF
--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -259,8 +259,14 @@ class Polyline extends EventEmitter<{
 
   update() {
     const { svg } = this
-    const aspectRatioX = svg.viewBox.baseVal.width / svg.clientWidth
-    const aspectRatioY = svg.viewBox.baseVal.height / svg.clientHeight
+    // Skip the update if the container is hidden
+    const { clientWidth, clientHeight } = svg
+    if (!clientWidth || !clientHeight) {
+      return
+    }
+
+    const aspectRatioX = svg.viewBox.baseVal.width / clientWidth
+    const aspectRatioY = svg.viewBox.baseVal.height / clientHeight
     const circles = svg.querySelectorAll('ellipse')
 
     circles.forEach((circle) => {


### PR DESCRIPTION
## Short description
Resolves #3856

## Implementation details
- do not update drag point radii when the SVG container has zero width or height

## How to test it
- run an example using the Envelope plugin
- hide and show the waveform element
- observe that no `Invalid value for <ellipse>` warnings appear

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes

------
https://chatgpt.com/codex/tasks/task_b_687e0275a698832f98dea56d15de1f04