### PR TITLE
fix(Regions): update region duration on reload

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -477,6 +477,13 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     }
     this.wavesurfer.getWrapper().appendChild(this.regionsContainer)
 
+    // Update region durations when a new audio file is loaded
+    this.subscriptions.push(
+      this.wavesurfer.on('ready', (duration) => {
+        this.regions.forEach((region) => region._setTotalDuration(duration))
+      }),
+    )
+
     let activeRegions: Region[] = []
     this.subscriptions.push(
       this.wavesurfer.on('timeupdate', (currentTime) => {


### PR DESCRIPTION
## Short description
Ensure existing regions update their internal `totalDuration` when a new audio file is loaded.

Resolves #4173.

## Implementation details
Adds a `ready` event listener in `RegionsPlugin.onInit` that updates all regions with the new duration via `_setTotalDuration`.

## How to test it
1. Run `yarn lint`.
2. Load audio, create a region, then reload a different length audio and resize the region. The region's updates should use the new duration correctly.

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes

------
https://chatgpt.com/codex/tasks/task_b_688138a4fc7c832fb50c4a7b6e73ae31