### PR TITLE
docs: Replace 'percent' with 'ration' in seekTo's comment for clarity

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -583,7 +583,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.emit('timeupdate', time)
   }
 
-  /** Seek to a percentage of audio as [0..1] (0 = beginning, 1 = end) */
+  /** Seek to a ratio of audio as [0..1] (0 = beginning, 1 = end) */
   public seekTo(progress: number) {
     const time = this.getDuration() * progress
     this.setTime(time)


### PR DESCRIPTION
## Short description
Clarify `seekTo` method documentation by replacing "percent" with "ratio" to avoid confusion, as the parameter expects a value in the range [0, 1], not [0, 100].

## Implementation details
* Updated the comment for the `seekTo` method in `src/wavesurfer.ts`.
* Changed "percentage" to "ratio" to improve clarity.
* No functional code changes; this is a documentation-only update.

## How to test it

## Screenshots


## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
