### PR TITLE
Fix(Regions): region can't be dragged when setting minLength

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -295,12 +295,14 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     const deltaSeconds = (dx / width) * this.totalDuration
     let newStart = !side || side === 'start' ? this.start + deltaSeconds : this.start
     let newEnd = !side || side === 'end' ? this.end + deltaSeconds : this.end
-
-    if (this.updatingSide && this.updatingSide !== side && startTime !== undefined) {
-      if (this.updatingSide === 'start') {
-        newStart = startTime
-      } else {
-        newEnd = startTime
+    const isRegionCreating = startTime !== undefined // startTime is passed when the region is creating.
+    if (isRegionCreating) {
+      if (this.updatingSide && this.updatingSide !== side) {
+        if (this.updatingSide === 'start') {
+          newStart = startTime
+        } else {
+          newEnd = startTime
+        }
       }
     }
 
@@ -309,8 +311,8 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     const length = newEnd - newStart
 
     this.updatingSide = side
-
-    if (newStart <= newEnd && length >= this.minLength && length <= this.maxLength) {
+    const resizeValid = length >= this.minLength && length <= this.maxLength
+    if (newStart <= newEnd && (resizeValid || isRegionCreating)) {
       this.start = newStart
       this.end = newEnd
 

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -295,7 +295,7 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     const deltaSeconds = (dx / width) * this.totalDuration
     let newStart = !side || side === 'start' ? this.start + deltaSeconds : this.start
     let newEnd = !side || side === 'end' ? this.end + deltaSeconds : this.end
-    const isRegionCreating = startTime !== undefined // startTime is passed when the region is creating.
+    const isRegionCreating = startTime !== undefined // startTime is passed when the region is being created.
     if (isRegionCreating) {
       if (this.updatingSide && this.updatingSide !== side) {
         if (this.updatingSide === 'start') {


### PR DESCRIPTION
## Short description
Resolves #

After setting a `minLength` for `RegionsPlugin.enableDragSelection`, if create a new region, the dragging operation might stop immediately. This happens because the region's length does **not satisfy** the condition `length >= this.minLength && length <= this.maxLength`. According to the documentation, the `minLength` parameter appears to be primarily intended for resize operations, so it should be avoided during the initial creation.

## Implementation details


## How to test it


## Screenshots

https://github.com/user-attachments/assets/dab43d3d-17fb-45c2-89b7-d3ab6a4eb49a

## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
