### PR TITLE
feat(Regions): expose regions-container for external styling

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -525,6 +525,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
 
   private initRegionsContainer(): HTMLElement {
     return createElement('div', {
+      part: 'regions-container',
       style: {
         position: 'absolute',
         top: '0',


### PR DESCRIPTION
## Short description
Exposes the div that containts regions for external styling outside of the shadow dom.


## Implementation details
I've added the part attribute to when you create the div. 

This lets you target the container with 
```
#waveform ::part(regions-container) {
    // Your css here
}
```

## How to test it

You can try it with `yarn start` and make some changes to `#waveform ::part(regions-container)`.

## Screenshots


https://github.com/user-attachments/assets/7da09a15-b9f7-4636-979a-b1da9cedcae5



## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
