### PR TITLE
Apply barHeight after normalization

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -465,7 +465,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     let vScale = options.barHeight || 1
     if (options.normalize) {
       const max = Array.from(channelData[0]).reduce((max, value) => Math.max(max, Math.abs(value)), 0)
-      vScale = max ? 1 / max : 1
+      vScale = max ? vScale / max : vScale
     }
 
     // Render waveform as bars


### PR DESCRIPTION
## Short description

When calculating the vScale parameter, the barHeight option was previously ignored when normalization was set to true. This change allows users to specify the (abs) value of the largest peak to a different value than 1.0 when normalizing their waveforms.


## Implementation details

```
// using the previous value set by barHeight option instead of 1
vScale = max ? vScale / max : vScale
```

## How to test it

You can try it with yarn start and by setting both the normalize and barHeight options simultaneously.

## Screenshots

## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
