### PR TITLE
test(renderer): add renderer util unit tests

### DIFF
--- a/src/__tests__/renderer-utils.test.ts
+++ b/src/__tests__/renderer-utils.test.ts
@@ -1,0 +1,429 @@
+import {
+  MAX_CANVAS_WIDTH,
+  MAX_NODES,
+  calculateBarHeights,
+  calculateBarRenderConfig,
+  calculateBarSegments,
+  calculateLinePaths,
+  calculateScrollPercentages,
+  calculateSingleCanvasWidth,
+  calculateVerticalScale,
+  calculateWaveformLayout,
+  clampToUnit,
+  clampWidthToBarGrid,
+  getLazyRenderRange,
+  getPixelRatio,
+  getRelativePointerPosition,
+  resolveBarYPosition,
+  resolveChannelHeight,
+  resolveColorValue,
+  shouldClearCanvases,
+  shouldRenderBars,
+  sliceChannelData,
+} from '../renderer-utils.js'
+import type { WaveSurferOptions } from '../wavesurfer.js'
+
+describe('renderer-utils', () => {
+  describe('clampToUnit', () => {
+    it('clamps numbers to the [0, 1] range', () => {
+      expect(clampToUnit(-0.5)).toBe(0)
+      expect(clampToUnit(0.3)).toBe(0.3)
+      expect(clampToUnit(1.8)).toBe(1)
+    })
+  })
+
+  describe('calculateBarRenderConfig', () => {
+    const options: WaveSurferOptions = {
+      container: document.createElement('div'),
+      barWidth: 2,
+      barGap: 1,
+      barRadius: 3,
+    }
+
+    it('derives spacing values and scaling information', () => {
+      const config = calculateBarRenderConfig({
+        width: 100,
+        height: 50,
+        length: 10,
+        options,
+        pixelRatio: 2,
+      })
+
+      expect(config).toEqual({
+        halfHeight: 25,
+        barWidth: 4,
+        barGap: 2,
+        barRadius: 3,
+        barIndexScale: 100 / ((4 + 2) * 10),
+        barSpacing: 6,
+      })
+    })
+  })
+
+  describe('calculateBarHeights', () => {
+    it('returns rounded heights and ensures total height is at least 1', () => {
+      expect(
+        calculateBarHeights({
+          maxTop: 0.5,
+          maxBottom: 0.25,
+          halfHeight: 20,
+          vScale: 1,
+        }),
+      ).toEqual({ topHeight: 10, totalHeight: 15 })
+
+      expect(
+        calculateBarHeights({
+          maxTop: 0,
+          maxBottom: 0,
+          halfHeight: 20,
+          vScale: 1,
+        }),
+      ).toEqual({ topHeight: 0, totalHeight: 1 })
+    })
+  })
+
+  describe('resolveBarYPosition', () => {
+    const baseArgs = {
+      halfHeight: 20,
+      topHeight: 10,
+      totalHeight: 20,
+      canvasHeight: 40,
+    }
+
+    it('positions bars relative to alignment', () => {
+      expect(
+        resolveBarYPosition({
+          barAlign: 'top',
+          ...baseArgs,
+        }),
+      ).toBe(0)
+
+      expect(
+        resolveBarYPosition({
+          barAlign: 'bottom',
+          ...baseArgs,
+        }),
+      ).toBe(20)
+
+      expect(
+        resolveBarYPosition({
+          barAlign: undefined,
+          ...baseArgs,
+        }),
+      ).toBe(10)
+    })
+  })
+
+  describe('calculateBarSegments', () => {
+    const options: WaveSurferOptions = {
+      container: document.createElement('div'),
+    }
+
+    it('aggregates bar segments across the channel data', () => {
+      const { barIndexScale, barSpacing, barWidth, halfHeight } = calculateBarRenderConfig({
+        width: 6,
+        height: 20,
+        length: 6,
+        options,
+        pixelRatio: 1,
+      })
+      const segments = calculateBarSegments({
+        channelData: [
+          new Float32Array([0.2, -0.4, 0.6, -0.8, 1, -1]),
+          new Float32Array([0.1, -0.2, 0.3, -0.4, 0.5, -0.6]),
+        ],
+        barIndexScale,
+        barSpacing,
+        barWidth,
+        halfHeight,
+        vScale: 1,
+        canvasHeight: 40,
+        barAlign: undefined,
+      })
+
+      expect(segments).toEqual([
+        { x: 0, y: 8, width: 1, height: 3 },
+        { x: 1, y: 6, width: 1, height: 6 },
+        { x: 2, y: 4, width: 1, height: 9 },
+        { x: 3, y: 2, width: 1, height: 12 },
+        { x: 4, y: 0, width: 1, height: 15 },
+        { x: 5, y: 0, width: 1, height: 16 },
+      ])
+    })
+  })
+
+  describe('getRelativePointerPosition', () => {
+    it('returns pointer coordinates as relative offsets', () => {
+      const rect = {
+        left: 10,
+        top: 20,
+        width: 200,
+        height: 100,
+      } as DOMRect
+      expect(getRelativePointerPosition(rect, 110, 70)).toEqual([0.5, 0.5])
+    })
+  })
+
+  describe('resolveChannelHeight', () => {
+    it('returns numeric height when provided', () => {
+      expect(
+        resolveChannelHeight({
+          optionsHeight: 150,
+          parentHeight: 0,
+          numberOfChannels: 2,
+        }),
+      ).toBe(150)
+    })
+
+    it('splits height across channels when auto with overlays disabled', () => {
+      const splitChannels: NonNullable<WaveSurferOptions['splitChannels']> = [{ overlay: false }, { overlay: false }]
+      expect(
+        resolveChannelHeight({
+          optionsHeight: 'auto',
+          optionsSplitChannels: splitChannels,
+          parentHeight: 200,
+          numberOfChannels: 2,
+        }),
+      ).toBe(100)
+    })
+
+    it('falls back to default height when invalid', () => {
+      expect(
+        resolveChannelHeight({
+          optionsHeight: 'invalid' as never,
+          parentHeight: 0,
+          numberOfChannels: 2,
+          defaultHeight: 75,
+        }),
+      ).toBe(75)
+    })
+  })
+
+  describe('getPixelRatio', () => {
+    it('never returns less than 1', () => {
+      expect(getPixelRatio(undefined)).toBe(1)
+      expect(getPixelRatio(0.5)).toBe(1)
+      expect(getPixelRatio(2)).toBe(2)
+    })
+  })
+
+  describe('shouldRenderBars', () => {
+    const options: WaveSurferOptions = { container: document.createElement('div') }
+
+    it('returns true when any bar option is configured', () => {
+      expect(shouldRenderBars({ ...options, barWidth: 1 })).toBe(true)
+      expect(shouldRenderBars({ ...options, barGap: 2 })).toBe(true)
+      expect(shouldRenderBars({ ...options, barAlign: 'top' })).toBe(true)
+    })
+
+    it('returns false when bars are not configured', () => {
+      expect(shouldRenderBars(options)).toBe(false)
+    })
+  })
+
+  describe('resolveColorValue', () => {
+    const canvas = document.createElement('canvas')
+
+    let createLinearGradient: jest.Mock
+    let addColorStop: jest.Mock
+
+    beforeEach(() => {
+      createLinearGradient = jest.fn(() => ({ addColorStop }))
+      addColorStop = jest.fn()
+
+      jest.spyOn(document, 'createElement').mockImplementation(() => canvas)
+      jest
+        .spyOn(canvas, 'getContext')
+        .mockImplementation(() => ({ createLinearGradient }) as unknown as CanvasRenderingContext2D)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('returns string values unchanged', () => {
+      expect(resolveColorValue('#000', 2)).toBe('#000')
+    })
+
+    it('falls back to default gray when gradient list is empty', () => {
+      expect(resolveColorValue([], 2)).toBe('#999')
+    })
+
+    it('uses the single color when gradient list has one item', () => {
+      expect(resolveColorValue(['#111'], 2)).toBe('#111')
+    })
+
+    it('creates a canvas gradient for multiple colors', () => {
+      const gradient = resolveColorValue(['#000', '#fff'], 2) as { addColorStop: jest.Mock }
+      expect(createLinearGradient).toHaveBeenCalledWith(0, 0, 0, 300)
+      expect(addColorStop).toHaveBeenCalledTimes(2)
+      expect(addColorStop).toHaveBeenNthCalledWith(1, 0, '#000')
+      expect(addColorStop).toHaveBeenNthCalledWith(2, 1, '#fff')
+      expect(gradient.addColorStop).toBe(addColorStop)
+    })
+  })
+
+  describe('calculateWaveformLayout', () => {
+    const baseArgs = {
+      duration: 2,
+      parentWidth: 300,
+      pixelRatio: 1,
+    }
+
+    it('uses parent width when not scrollable and fillParent is true', () => {
+      expect(calculateWaveformLayout({ ...baseArgs, minPxPerSec: 10, fillParent: true })).toEqual({
+        scrollWidth: 20,
+        isScrollable: false,
+        useParentWidth: true,
+        width: 300,
+      })
+    })
+
+    it('uses scroll width when waveform exceeds parent width', () => {
+      expect(calculateWaveformLayout({ ...baseArgs, minPxPerSec: 500, fillParent: true })).toEqual({
+        scrollWidth: 1000,
+        isScrollable: true,
+        useParentWidth: false,
+        width: 1000,
+      })
+    })
+  })
+
+  describe('clampWidthToBarGrid', () => {
+    const options: WaveSurferOptions = { container: document.createElement('div'), barWidth: 2, barGap: 1 }
+
+    it('returns original width when bars are disabled', () => {
+      expect(clampWidthToBarGrid(123, { container: document.createElement('div') })).toBe(123)
+    })
+
+    it('clamps width down to align with bar grid spacing', () => {
+      expect(clampWidthToBarGrid(10, options)).toBe(9)
+    })
+  })
+
+  describe('calculateSingleCanvasWidth', () => {
+    const options: WaveSurferOptions = { container: document.createElement('div'), barWidth: 2, barGap: 1 }
+
+    it('limits width by canvas cap, client size, and total width', () => {
+      expect(
+        calculateSingleCanvasWidth({
+          clientWidth: 9000,
+          totalWidth: 5000,
+          options,
+        }),
+      ).toBe(clampWidthToBarGrid(Math.min(MAX_CANVAS_WIDTH, 5000), options))
+    })
+  })
+
+  describe('sliceChannelData', () => {
+    it('returns proportional slices based on offset and width', () => {
+      const channel = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8])
+      const slices = sliceChannelData({
+        channelData: [channel, channel],
+        offset: 100,
+        clampedWidth: 50,
+        totalWidth: 200,
+      })
+
+      expect(slices[0]).toEqual(new Float32Array([5, 6]))
+      expect(slices[1]).toEqual(new Float32Array([5, 6]))
+    })
+  })
+
+  describe('shouldClearCanvases', () => {
+    it('clears when exceeding maximum nodes', () => {
+      expect(shouldClearCanvases(MAX_NODES)).toBe(false)
+      expect(shouldClearCanvases(MAX_NODES + 1)).toBe(true)
+    })
+  })
+
+  describe('getLazyRenderRange', () => {
+    it('returns surrounding canvas indices', () => {
+      expect(
+        getLazyRenderRange({
+          scrollLeft: 50,
+          totalWidth: 200,
+          numCanvases: 5,
+        }),
+      ).toEqual([0, 1, 2])
+    })
+
+    it('defaults to the first canvas when width is zero', () => {
+      expect(getLazyRenderRange({ scrollLeft: 0, totalWidth: 0, numCanvases: 3 })).toEqual([0])
+    })
+  })
+
+  describe('calculateVerticalScale', () => {
+    it('returns base scale when not normalizing', () => {
+      expect(
+        calculateVerticalScale({
+          channelData: [new Float32Array([0.5])],
+          barHeight: 2,
+          normalize: false,
+        }),
+      ).toBe(2)
+    })
+
+    it('normalizes against the maximum magnitude when requested', () => {
+      expect(
+        calculateVerticalScale({
+          channelData: [new Float32Array([0.25, -0.5])],
+          barHeight: 2,
+          normalize: true,
+        }),
+      ).toBe(4)
+    })
+  })
+
+  describe('calculateLinePaths', () => {
+    it('produces symmetrical paths for mirrored channel data', () => {
+      const [topPath, bottomPath] = calculateLinePaths({
+        channelData: [new Float32Array([0, 0.5, 1]), new Float32Array([0, 0.25, 0.75])],
+        width: 6,
+        height: 8,
+        vScale: 1,
+      })
+
+      expect(topPath[0]).toEqual({ x: 0, y: 4 })
+      expect(topPath[topPath.length - 1]).toEqual({ x: 6, y: 4 })
+      expect(bottomPath[0]).toEqual({ x: 0, y: 4 })
+      expect(bottomPath[bottomPath.length - 1]).toEqual({ x: 6, y: 4 })
+      expect(topPath).toEqual([
+        { x: 0, y: 4 },
+        { x: 0, y: 3 },
+        { x: 2, y: 2 },
+        { x: 4, y: 0 },
+        { x: 6, y: 4 },
+      ])
+      expect(bottomPath).toEqual([
+        { x: 0, y: 4 },
+        { x: 0, y: 5 },
+        { x: 2, y: 5 },
+        { x: 4, y: 7 },
+        { x: 6, y: 4 },
+      ])
+    })
+  })
+
+  describe('calculateScrollPercentages', () => {
+    it('returns zero percentages when scroll width is zero', () => {
+      expect(
+        calculateScrollPercentages({
+          scrollLeft: 0,
+          clientWidth: 100,
+          scrollWidth: 0,
+        }),
+      ).toEqual({ startX: 0, endX: 0 })
+    })
+
+    it('returns start and end ratios relative to scroll width', () => {
+      expect(
+        calculateScrollPercentages({
+          scrollLeft: 50,
+          clientWidth: 100,
+          scrollWidth: 400,
+        }),
+      ).toEqual({ startX: 0.125, endX: 0.375 })
+    })
+  })
+})

--- a/src/renderer-utils.ts
+++ b/src/renderer-utils.ts
@@ -1,0 +1,405 @@
+import type { WaveSurferOptions } from './wavesurfer.js'
+
+export type ChannelData = Array<Float32Array | number[]>
+
+export type BarSegment = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export type LinePath = Array<{ x: number; y: number }>
+
+export const DEFAULT_HEIGHT = 128
+
+export const MAX_CANVAS_WIDTH = 8000
+
+export const MAX_NODES = 10
+
+export function clampToUnit(value: number): number {
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
+export function calculateBarRenderConfig({
+  width,
+  height,
+  length,
+  options,
+  pixelRatio,
+}: {
+  width: number
+  height: number
+  length: number
+  options: WaveSurferOptions
+  pixelRatio: number
+}) {
+  const halfHeight = height / 2
+  const barWidth = options.barWidth ? options.barWidth * pixelRatio : 1
+  const barGap = options.barGap ? options.barGap * pixelRatio : options.barWidth ? barWidth / 2 : 0
+  const barRadius = options.barRadius || 0
+  const spacing = barWidth + barGap || 1
+  const barIndexScale = length > 0 ? width / spacing / length : 0
+
+  return {
+    halfHeight,
+    barWidth,
+    barGap,
+    barRadius,
+    barIndexScale,
+    barSpacing: spacing,
+  }
+}
+
+export function calculateBarHeights({
+  maxTop,
+  maxBottom,
+  halfHeight,
+  vScale,
+}: {
+  maxTop: number
+  maxBottom: number
+  halfHeight: number
+  vScale: number
+}): { topHeight: number; totalHeight: number } {
+  const topHeight = Math.round(maxTop * halfHeight * vScale)
+  const bottomHeight = Math.round(maxBottom * halfHeight * vScale)
+  const totalHeight = topHeight + bottomHeight || 1
+
+  return { topHeight, totalHeight }
+}
+
+export function resolveBarYPosition({
+  barAlign,
+  halfHeight,
+  topHeight,
+  totalHeight,
+  canvasHeight,
+}: {
+  barAlign: WaveSurferOptions['barAlign']
+  halfHeight: number
+  topHeight: number
+  totalHeight: number
+  canvasHeight: number
+}): number {
+  if (barAlign === 'top') return 0
+  if (barAlign === 'bottom') return canvasHeight - totalHeight
+  return halfHeight - topHeight
+}
+
+export function calculateBarSegments({
+  channelData,
+  barIndexScale,
+  barSpacing,
+  barWidth,
+  halfHeight,
+  vScale,
+  canvasHeight,
+  barAlign,
+}: {
+  channelData: ChannelData
+  barIndexScale: number
+  barSpacing: number
+  barWidth: number
+  halfHeight: number
+  vScale: number
+  canvasHeight: number
+  barAlign: WaveSurferOptions['barAlign']
+}): BarSegment[] {
+  const topChannel = channelData[0] || []
+  const bottomChannel = channelData[1] || topChannel
+  const length = topChannel.length
+
+  const segments: BarSegment[] = []
+
+  let prevX = 0
+  let maxTop = 0
+  let maxBottom = 0
+
+  for (let i = 0; i <= length; i++) {
+    const x = Math.round(i * barIndexScale)
+
+    if (x > prevX) {
+      const { topHeight, totalHeight } = calculateBarHeights({
+        maxTop,
+        maxBottom,
+        halfHeight,
+        vScale,
+      })
+
+      const y = resolveBarYPosition({
+        barAlign,
+        halfHeight,
+        topHeight,
+        totalHeight,
+        canvasHeight,
+      })
+
+      segments.push({
+        x: prevX * barSpacing,
+        y,
+        width: barWidth,
+        height: totalHeight,
+      })
+
+      prevX = x
+      maxTop = 0
+      maxBottom = 0
+    }
+
+    const magnitudeTop = Math.abs(topChannel[i] || 0)
+    const magnitudeBottom = Math.abs(bottomChannel[i] || 0)
+    if (magnitudeTop > maxTop) maxTop = magnitudeTop
+    if (magnitudeBottom > maxBottom) maxBottom = magnitudeBottom
+  }
+
+  return segments
+}
+
+export function getRelativePointerPosition(rect: DOMRect, clientX: number, clientY: number): [number, number] {
+  const x = clientX - rect.left
+  const y = clientY - rect.top
+  const relativeX = x / rect.width
+  const relativeY = y / rect.height
+  return [relativeX, relativeY]
+}
+
+export function resolveChannelHeight({
+  optionsHeight,
+  optionsSplitChannels,
+  parentHeight,
+  numberOfChannels,
+  defaultHeight = DEFAULT_HEIGHT,
+}: {
+  optionsHeight?: WaveSurferOptions['height']
+  optionsSplitChannels?: WaveSurferOptions['splitChannels']
+  parentHeight: number
+  numberOfChannels: number
+  defaultHeight?: number
+}): number {
+  if (optionsHeight == null) return defaultHeight
+  const numericHeight = Number(optionsHeight)
+  if (!isNaN(numericHeight)) return numericHeight
+  if (optionsHeight === 'auto') {
+    const height = parentHeight || defaultHeight
+    if (optionsSplitChannels?.every((channel) => !channel.overlay)) {
+      return height / numberOfChannels
+    }
+    return height
+  }
+  return defaultHeight
+}
+
+export function getPixelRatio(devicePixelRatio?: number): number {
+  return Math.max(1, devicePixelRatio || 1)
+}
+
+export function shouldRenderBars(options: WaveSurferOptions): boolean {
+  return Boolean(options.barWidth || options.barGap || options.barAlign)
+}
+
+export function resolveColorValue(
+  color: WaveSurferOptions['waveColor'],
+  devicePixelRatio: number,
+): string | CanvasGradient {
+  if (!Array.isArray(color)) return color || ''
+  if (color.length === 0) return '#999'
+  if (color.length < 2) return color[0] || ''
+
+  const canvasElement = document.createElement('canvas')
+  const ctx = canvasElement.getContext('2d') as CanvasRenderingContext2D
+  const gradientHeight = canvasElement.height * devicePixelRatio
+  const gradient = ctx.createLinearGradient(0, 0, 0, gradientHeight || devicePixelRatio)
+
+  const colorStopPercentage = 1 / (color.length - 1)
+  color.forEach((value, index) => {
+    gradient.addColorStop(index * colorStopPercentage, value)
+  })
+
+  return gradient
+}
+
+export function calculateWaveformLayout({
+  duration,
+  minPxPerSec = 0,
+  parentWidth,
+  fillParent,
+  pixelRatio,
+}: {
+  duration: number
+  minPxPerSec?: number
+  parentWidth: number
+  fillParent?: boolean
+  pixelRatio: number
+}) {
+  const scrollWidth = Math.ceil(duration * minPxPerSec)
+  const isScrollable = scrollWidth > parentWidth
+  const useParentWidth = Boolean(fillParent && !isScrollable)
+  const width = (useParentWidth ? parentWidth : scrollWidth) * pixelRatio
+
+  return {
+    scrollWidth,
+    isScrollable,
+    useParentWidth,
+    width,
+  }
+}
+
+export function clampWidthToBarGrid(width: number, options: WaveSurferOptions): number {
+  if (!shouldRenderBars(options)) return width
+  const barWidth = options.barWidth || 0.5
+  const barGap = options.barGap || barWidth / 2
+  const totalBarWidth = barWidth + barGap
+  if (totalBarWidth === 0) return width
+  return Math.floor(width / totalBarWidth) * totalBarWidth
+}
+
+export function calculateSingleCanvasWidth({
+  clientWidth,
+  totalWidth,
+  options,
+}: {
+  clientWidth: number
+  totalWidth: number
+  options: WaveSurferOptions
+}): number {
+  const baseWidth = Math.min(MAX_CANVAS_WIDTH, clientWidth, totalWidth)
+  return clampWidthToBarGrid(baseWidth, options)
+}
+
+export function sliceChannelData({
+  channelData,
+  offset,
+  clampedWidth,
+  totalWidth,
+}: {
+  channelData: ChannelData
+  offset: number
+  clampedWidth: number
+  totalWidth: number
+}): ChannelData {
+  return channelData.map((channel) => {
+    const start = Math.floor((offset / totalWidth) * channel.length)
+    const end = Math.floor(((offset + clampedWidth) / totalWidth) * channel.length)
+    return channel.slice(start, end)
+  })
+}
+
+export function shouldClearCanvases(currentNodeCount: number): boolean {
+  return currentNodeCount > MAX_NODES
+}
+
+export function getLazyRenderRange({
+  scrollLeft,
+  totalWidth,
+  numCanvases,
+}: {
+  scrollLeft: number
+  totalWidth: number
+  numCanvases: number
+}): number[] {
+  if (totalWidth === 0) return [0]
+  const viewPosition = scrollLeft / totalWidth
+  const startCanvas = Math.floor(viewPosition * numCanvases)
+  return [startCanvas - 1, startCanvas, startCanvas + 1]
+}
+
+export function calculateVerticalScale({
+  channelData,
+  barHeight,
+  normalize,
+}: {
+  channelData: ChannelData
+  barHeight?: WaveSurferOptions['barHeight']
+  normalize?: WaveSurferOptions['normalize']
+}): number {
+  const baseScale = barHeight || 1
+  if (!normalize) return baseScale
+
+  const firstChannel = channelData[0]
+  if (!firstChannel || firstChannel.length === 0) return baseScale
+
+  let max = 0
+  for (let i = 0; i < firstChannel.length; i++) {
+    const value = firstChannel[i] ?? 0
+    const magnitude = Math.abs(value)
+    if (magnitude > max) max = magnitude
+  }
+
+  if (!max) return baseScale
+  return baseScale / max
+}
+
+export function calculateLinePaths({
+  channelData,
+  width,
+  height,
+  vScale,
+}: {
+  channelData: ChannelData
+  width: number
+  height: number
+  vScale: number
+}): LinePath[] {
+  const halfHeight = height / 2
+  const primaryChannel = channelData[0] || []
+  const secondaryChannel = channelData[1] || primaryChannel
+  const channels = [primaryChannel, secondaryChannel]
+
+  return channels.map((channel, index) => {
+    const length = channel.length
+    const hScale = length ? width / length : 0
+    const baseY = halfHeight
+    const direction = index === 0 ? -1 : 1
+
+    const path: LinePath = [{ x: 0, y: baseY }]
+    let prevX = 0
+    let max = 0
+
+    for (let i = 0; i <= length; i++) {
+      const x = Math.round(i * hScale)
+
+      if (x > prevX) {
+        const heightDelta = Math.round(max * halfHeight * vScale) || 1
+        const y = baseY + heightDelta * direction
+        path.push({ x: prevX, y })
+        prevX = x
+        max = 0
+      }
+
+      const value = Math.abs(channel[i] || 0)
+      if (value > max) max = value
+    }
+
+    path.push({ x: prevX, y: baseY })
+
+    return path
+  })
+}
+
+export function calculateScrollPercentages({
+  scrollLeft,
+  clientWidth,
+  scrollWidth,
+}: {
+  scrollLeft: number
+  clientWidth: number
+  scrollWidth: number
+}): { startX: number; endX: number } {
+  if (scrollWidth === 0) {
+    return { startX: 0, endX: 0 }
+  }
+
+  const startX = scrollLeft / scrollWidth
+  const endX = (scrollLeft + clientWidth) / scrollWidth
+
+  return { startX, endX }
+}
+
+export function roundToHalfAwayFromZero(value: number): number {
+  const scaled = value * 2
+  const rounded = scaled < 0 ? Math.floor(scaled) : Math.ceil(scaled)
+  return rounded / 2
+}


### PR DESCRIPTION
## Short description
- Keep renderer utilities focused on pure helpers by moving waveform drawing back into the renderer.
- Update the renderer to import helper functions through the utils namespace for clearer usage.
- Extract additional renderer calculations into shared pure helpers for bar metrics, scaling, and scroll percentages.
- Precompute bar segments and line waveform paths via pure helpers consumed by the renderer drawing routines.
- Cover renderer utility helpers with unit tests.

## Implementation details
- Removed waveform drawing routines from `renderer-utils.ts`, leaving only pure calculations and selectors.
- Added local waveform rendering helpers to `renderer.ts` and updated all call sites to use `utils.<name>` for shared helpers.
- Added utility helpers for bar layout metrics, normalization scaling, scroll percentage calculation, and stable rounding; refactored renderer orchestration to use them.
- Introduced pure helpers to derive bar heights, positions, and line path sampling so canvas drawing functions iterate over precomputed data.
- Added Jest unit tests for each renderer utility covering layout math, sampling, and gradient resolution edge cases.

## How to test it
- yarn lint
- yarn test:unit src/__tests__/renderer-utils.test.ts

## Screenshots
N/A

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes

------
https://chatgpt.com/codex/tasks/task_b_68de9aa937ac832f8e465fca787d366e