### PR TITLE
fix(Record): prevent waveform jitter in scrolling mode

### DIFF
--- a/src/renderer-utils.ts
+++ b/src/renderer-utils.ts
@@ -310,10 +310,12 @@ export function calculateVerticalScale({
   channelData,
   barHeight,
   normalize,
+  maxPeak,
 }: {
   channelData: ChannelData
   barHeight?: WaveSurferOptions['barHeight']
   normalize?: WaveSurferOptions['normalize']
+  maxPeak?: WaveSurferOptions['maxPeak']
 }): number {
   const baseScale = barHeight || 1
   if (!normalize) return baseScale
@@ -321,11 +323,14 @@ export function calculateVerticalScale({
   const firstChannel = channelData[0]
   if (!firstChannel || firstChannel.length === 0) return baseScale
 
-  let max = 0
-  for (let i = 0; i < firstChannel.length; i++) {
-    const value = firstChannel[i] ?? 0
-    const magnitude = Math.abs(value)
-    if (magnitude > max) max = magnitude
+  // Use fixed max peak if provided, otherwise calculate from data
+  let max = maxPeak ?? 0
+  if (!maxPeak) {
+    for (let i = 0; i < firstChannel.length; i++) {
+      const value = firstChannel[i] ?? 0
+      const magnitude = Math.abs(value)
+      if (magnitude > max) max = magnitude
+    }
   }
 
   if (!max) return baseScale

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -430,6 +430,7 @@ class Renderer extends EventEmitter<RendererEvents> {
       channelData,
       barHeight: options.barHeight,
       normalize: options.normalize,
+      maxPeak: options.maxPeak,
     })
 
     if (utils.shouldRenderBars(options)) {

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -68,6 +68,8 @@ export type WaveSurferOptions = {
   splitChannels?: Array<Partial<WaveSurferOptions> & { overlay?: boolean }>
   /** Stretch the waveform to the full height */
   normalize?: boolean
+  /** Use a fixed max peak value for normalization instead of calculating from the current data */
+  maxPeak?: number
   /** The list of plugins to initialize on start */
   plugins?: GenericPlugin[]
   /** Custom render function */


### PR DESCRIPTION
Resolves #3844.

## Short description
Fixes the jittering/dancing waveform issue in the Record plugin's scrolling mode.

## Implementation details

The jitter was caused by storing and rendering raw time-domain audio samples (rapid oscillations) instead of peak values (amplitude envelope). 

**Root cause:**
- Scrolling mode was storing ~240,000 raw audio samples per 5-second window
- These samples represent instantaneous amplitude oscillating at audio frequency
- Pixel-to-sample mapping captured different parts of oscillations on each render
- Result: Visual jitter as waveform peaks varied wildly

**Solution:**
1. Added `maxPeak` option to `WaveSurferOptions` for fixed normalization scale
2. Modified Record plugin to store peak values (one per frame) instead of raw samples
3. Reduced data window from `sampleRate × duration` to `FPS × duration` (500 vs 240,000 values)
4. Applied smaller FFT size (32) for responsive peak detection
5. Set fixed `maxPeak = 1` to prevent vertical scale changes during recording

## How to test it

1. Run the record example: `npm start` and open the record example
2. Enable "Scrolling waveform" mode
3. Start recording with audio input (speak or play music)
4. Observe the waveform scrolling smoothly without jittering or vertical scale changes

**Expected behavior:** Smooth amplitude envelope scrolling from right to left with stable vertical scale.

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
  - New `maxPeak` option is optional and backward compatible
  - Only affects Record plugin scrolling mode behavior