### PR TITLE
Fix: center cursor at high levels of zoom

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -689,7 +689,7 @@ class Renderer extends EventEmitter<RendererEvents> {
       // Keep the cursor centered when playing
       const center = progressWidth - scrollLeft - middle
       if (isPlaying && this.options.autoCenter && center > 0) {
-        this.scrollContainer.scrollLeft += Math.min(center, 10)
+        this.scrollContainer.scrollLeft += center
       }
     }
 


### PR DESCRIPTION
## Short description

At high zoom levels the centering of the progress bar doesn't keep up with the scrolling. 
Instead the progress bar gets to the end of the container then jumps back to the middle

## Implementation details
This was happening because the amount the cursor can jump was limited when centering.
I've removed this limit.


## How to test it

Zoom in to a waveform fully and press play

## Screenshots

Before:

https://github.com/user-attachments/assets/8583ee6a-6274-4b30-b319-aa49d92bca36

After:


https://github.com/user-attachments/assets/5f170538-0867-4579-8b0a-9af57fb61118




## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
