### PR TITLE
fix(Regions): the region was not added during ​the​ resize

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -633,14 +633,16 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
 
       const unsubscribeScroll = this.wavesurfer.on('scroll', renderIfVisible)
       const unsubscribeZoom = this.wavesurfer.on('zoom', renderIfVisible)
+      const unsubscribeResize = this.wavesurfer.on('resize', renderIfVisible);
 
       // Only push the unsubscribe functions, not the once() return values
-      this.subscriptions.push(unsubscribeScroll, unsubscribeZoom)
+      this.subscriptions.push(unsubscribeScroll, unsubscribeZoom, unsubscribeResize)
 
       // Clean up subscriptions when region is removed
       region.once('remove', () => {
         unsubscribeScroll()
         unsubscribeZoom()
+        unsubscribeResize()
       })
     }, 0)
   }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -14,6 +14,7 @@ type RendererEvents = {
   scroll: [relativeStart: number, relativeEnd: number, scrollLeft: number, scrollRight: number]
   render: []
   rendered: []
+  resize: []
 }
 
 class Renderer extends EventEmitter<RendererEvents> {
@@ -123,6 +124,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     if (width === this.lastContainerWidth && this.options.height !== 'auto') return
     this.lastContainerWidth = width
     this.reRender()
+    this.emit('resize')
   }
 
   private initDrag() {

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -142,6 +142,8 @@ export type WaveSurferEvents = {
   destroy: []
   /** When source file is unable to be fetched, decoded, or an error is thrown by media element */
   error: [error: Error]
+  /** When audio container resizing */
+  resize: [];
 }
 
 class WaveSurfer extends Player<WaveSurferEvents> {
@@ -317,6 +319,11 @@ class WaveSurfer extends Player<WaveSurferEvents> {
       this.renderer.on('dragend', (relativeX) => {
         this.emit('dragend', relativeX)
       }),
+
+      // Resize
+      this.renderer.on('resize', () => {
+        this.emit('resize');
+      })
     )
 
     // Drag


### PR DESCRIPTION
## Short description
## Resolves

Since regions are dynamically added to or removed from the container, when the container's visible area changes, the regions will not be re-added to the container unless events such as `zoom` or `scroll` are triggered.

## Implementation details

## How to test it

## Screenshots

https://github.com/user-attachments/assets/2b6068d0-fd58-49a5-af46-9dff228950ac

## Checklist
* [ ] This PR is covered by e2e tests
* [ ] It introduces no breaking API changes
