### PR TITLE
fix: allow message in .destroy

### DIFF
--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -674,7 +674,10 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     return this.renderer.exportImage(format, quality, type)
   }
 
-  /** Unmount wavesurfer */
+  /**
+   * Unmount wavesurfer
+   * @param message Optional message to pass to the abort signal when destroying. This can be used to provide a reason for the abort.
+   */
   public destroy(message?: string) {
     this.emit('destroy')
     this.abortController?.abort(message)

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -675,9 +675,9 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   }
 
   /** Unmount wavesurfer */
-  public destroy() {
+  public destroy(message?: string) {
     this.emit('destroy')
-    this.abortController?.abort()
+    this.abortController?.abort(message)
     this.plugins.forEach((plugin) => plugin.destroy())
     this.subscriptions.forEach((unsubscribe) => unsubscribe())
     this.unsubscribePlayerEvents()


### PR DESCRIPTION
Currently, aborting throws an error in console because no message was passed to abort, which is inside .destroy method (https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort#parameters)

## Implementation details
Added optional message prop to .destroy() method

In `src/wavesurfer.ts`
 ```tsx
 /** Unmount wavesurfer */
  public destroy(message?: string) {
    this.emit('destroy')
    this.abortController?.abort(message)
    this.plugins.forEach((plugin) => plugin.destroy())
    this.subscriptions.forEach((unsubscribe) => unsubscribe())
    this.unsubscribePlayerEvents()
    this.timer.destroy()
    this.renderer.destroy()
    super.destroy()
  }
```