### PR TITLE
fix: fix position jump on playback rate change

### DIFF
--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -24,7 +24,7 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
   private gainNode: GainNode
   private bufferNode: AudioBufferSourceNode | null = null
   private playStartTime = 0
-  private playedDuration = 0
+  private playbackPosition = 0
   private _muted = false
   private _playbackRate = 1
   private _duration: number | undefined = undefined
@@ -110,10 +110,10 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
     this.bufferNode.playbackRate.value = this._playbackRate
     this.bufferNode.connect(this.gainNode)
 
-    let currentPos = this.playedDuration
+    let currentPos = this.playbackPosition
     if (currentPos >= this.duration || currentPos < 0) {
       currentPos = 0
-      this.playedDuration = 0
+      this.playbackPosition = 0
     }
 
     this.bufferNode.start(this.audioContext.currentTime, currentPos)
@@ -130,7 +130,7 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
   private _pause() {
     this.paused = true
     this.bufferNode?.stop()
-    this.playedDuration += (this.audioContext.currentTime - this.playStartTime) * this._playbackRate
+    this.playbackPosition += (this.audioContext.currentTime - this.playStartTime) * this._playbackRate
   }
 
   async play() {
@@ -183,14 +183,14 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
 
   get currentTime() {
     return this.paused
-      ? this.playedDuration
-      : this.playedDuration + (this.audioContext.currentTime - this.playStartTime) * this._playbackRate
+      ? this.playbackPosition
+      : this.playbackPosition + (this.audioContext.currentTime - this.playStartTime) * this._playbackRate
   }
   set currentTime(value) {
     const wasPlaying = !this.paused
 
     if (wasPlaying) this._pause()
-    this.playedDuration = value
+    this.playbackPosition = value
     if (wasPlaying) this._play()
 
     this.emit('seeking')


### PR DESCRIPTION
## Short description

This PR fixes a bug where currentTime returns an incorrect value when playbackRate is modified, causing the progress tracking to jump abnormally.

## Implementation details

- Buffer-based playbackPosition: Renamed playedDuration to playbackPosition and refactored the logic to store the absolute offset in the audio buffer (in seconds) rather than cumulative wall-clock time.
- Improved currentTime Logic: Updated the currentTime getter to calculate the position as playbackPosition + (elapsed_time * playbackRate). This ensures that the tracked progress is independent of past rate changes.
- Accurate Rate Transitions: The playbackRate setter now snapshots the current playbackPosition by momentarily pausing and resuming. This maintains a seamless progress flow even during rapid rate changes, such as DJ deck adjustments.
- Direct Seek Assignment: The currentTime setter now assigns the target value directly to playbackPosition, eliminating incorrect rate-based scaling during seek operations.

## How to test it

1. Initialize WaveSurfer with the WebAudio backend.
2. Change the playbackRate while the audio is playing (example: call wavesurfer.setPlaybackRate(1.2)).
3. Verify: The progress tracking does not jump forward or backward and stays perfectly in sync with the audio.
4. Perform a seek operation and verify it lands on the correct second regardless of the current playbackRate.

## Screenshots

Here are videos changing playback rate dynamically:

Before:

https://github.com/user-attachments/assets/b45df7fb-7eaf-43a2-a21c-95aacfda4383

After:

https://github.com/user-attachments/assets/00e8e1a4-490c-467c-bb6c-37ea660ecfa0

## Checklist
* [ ] This PR is covered by e2e tests
* [X] It introduces no breaking API changes
