### PR TITLE
fix region overlap detection code

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -639,16 +639,20 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     setTimeout(() => {
       // Check that the label doesn't overlap with other labels
       // If it does, push it down until it doesn't
+      // only check regions that are before us in the list -- otherwise
+      // both overlapping regions will try to move down away from each other.
       const div = region.content as HTMLElement
       const box = div.getBoundingClientRect()
 
-      const overlap = this.regions
+      const regionIndex = this.regions.indexOf(region)
+
+      const overlap = this.regions.slice(0, regionIndex)
         .map((reg) => {
           if (reg === region || !reg.content) return 0
 
           const otherBox = reg.content.getBoundingClientRect()
           if (box.left < otherBox.left + otherBox.width && otherBox.left < box.left + box.width) {
-            return otherBox.height
+            return otherBox.height + 2
           }
           return 0
         })


### PR DESCRIPTION
## Short description

If calls to addRegion() came in all at once, we'd end up in a situation where all overlapping regions moved themselves to avoid each other (because they were all working with the same list of regions). This is incorrect, the first region shouldn't move at all.  We leverage the ordering of the `regions` array to ensure that only the later overlapping regions move.

And I added 2 pixels of room because it just looks nicer.

## Screenshots

before:
<img width="965" height="236" alt="Screenshot 2026-01-03 at 10 48 35 AM" src="https://github.com/user-attachments/assets/6ac6e814-bf3c-47df-abc3-1b3eee840ea2" />

after:
<img width="947" height="219" alt="Screenshot 2026-01-03 at 10 48 44 AM" src="https://github.com/user-attachments/assets/ab4cf201-a340-4ec4-9314-c55b1b27f4f9" />
