### PR TITLE
allow github builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "test": "cypress run --browser chrome",
     "test:unit": "jest --coverage",
     "serve": "npx live-server --port=9090 --no-browser --ignore='.*,src,cypress,scripts'",
-    "start": "npm run build:dev & npm run serve"
+    "start": "npm run build:dev & npm run serve",
+    "prepare": "npm run build"
   },
   "packageManager": "yarn@1.22.22",
   "devDependencies": {


### PR DESCRIPTION
i'm impatient and want to point my project at the wavesurfer.js main branch, but it doesn't worth without being able to call the `prepare` task