### PR TITLE
fix zoom.js example to use hideScrollbar

### DIFF
--- a/examples/zoom.js
+++ b/examples/zoom.js
@@ -34,7 +34,7 @@ wavesurfer.once('decode', () => {
 
 /*
 <html>
-  <label><input type="checkbox" checked value="scrollbar" /> Scroll bar</label>
+  <label><input type="checkbox" checked value="hideScrollbar" /> Scroll bar</label>
   <label><input type="checkbox" checked value="fillParent" /> Fill parent</label>
   <label><input type="checkbox" checked value="autoCenter" /> Auto center</label>
 


### PR DESCRIPTION
## Short description

When I used the zoom.js example, the setting 'Scroll bar' didn’t work, I wondered why, and it's just that the setting was not correct any more.

I upgraded the file according to the official doc https://wavesurfer.xyz/docs/types/wavesurfer.WaveSurferOptions#__type.hideScrollbar