### PR TITLE
fix: stop playback exactly at the requested stop position

### DIFF
--- a/src/__tests__/wavesurfer.test.ts
+++ b/src/__tests__/wavesurfer.test.ts
@@ -186,6 +186,22 @@ describe('WaveSurfer public methods', () => {
     expect((ws as any).stopAtPosition).toBe(4)
   })
 
+  test('pauses and clamps time to the exact stop position when playback overshoots it', async () => {
+    const ws = createWs()
+    const media = ws.getMediaElement()
+    Object.defineProperty(media, 'paused', { configurable: true, value: false })
+    await ws.play(1, 2)
+
+    // Simulate the clock overshooting the stop position between timer ticks
+    media.currentTime = 2.013
+    const timer = getTimer()
+    const tick = timer.on.mock.calls.find(([event]: [string]) => event === 'tick')[1]
+    tick()
+
+    expect(media.pause).toHaveBeenCalled()
+    expect(ws.getCurrentTime()).toBe(2)
+  })
+
   test('playPause toggles play and pause', async () => {
     const ws = createWs()
     const media = ws.getMediaElement()

--- a/src/__tests__/webaudio.test.ts
+++ b/src/__tests__/webaudio.test.ts
@@ -235,6 +235,38 @@ describe('WebAudioPlayer', () => {
       expect(endedSpy).toHaveBeenCalledTimes(1)
     })
 
+    test('stopAt schedules the stop scaled by playback rate', () => {
+      const { audioContext, bufferSource } = createMockAudioContext()
+      const player = new WebAudioPlayer(audioContext)
+      ;(player as any).buffer = createMockBuffer(10)
+      ;(player as any)._playbackRate = 2
+
+      audioContext.currentTime = 100
+      player.play()
+
+      // At 2x rate, stopping at media time 5 takes only 2.5s of real time
+      player.stopAt(5)
+
+      expect(bufferSource.stop).toHaveBeenCalledWith(102.5)
+    })
+
+    test('stopAt reports exactly the stop position after the buffer ends', () => {
+      const { audioContext, bufferSource } = createMockAudioContext()
+      const player = new WebAudioPlayer(audioContext)
+      ;(player as any).buffer = createMockBuffer(10)
+
+      audioContext.currentTime = 100
+      player.play()
+      player.stopAt(5)
+
+      // The 'ended' event fires with some latency after the actual stop
+      audioContext.currentTime = 105.03
+      const endedListener = bufferSource.addEventListener.mock.calls.find(([type]) => type === 'ended')?.[1]
+      endedListener?.()
+
+      expect(player.currentTime).toBe(5)
+    })
+
     test('does not emit ended when currentTime is beyond tolerance threshold from duration', () => {
       const { audioContext, triggerOnended } = createMockAudioContext()
       const player = new WebAudioPlayer(audioContext)

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -263,7 +263,10 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
           // Pause audio when it reaches the stopAtPosition
           if (this.stopAtPosition != null && this.isPlaying() && currentTime >= this.stopAtPosition) {
+            // The timer may overshoot the stop position, so clamp the time back to it
+            const stopAt = this.stopAtPosition
             this.pause()
+            this.setTime(stopAt)
           }
         }
       }),

--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -210,7 +210,9 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
   }
 
   stopAt(timeSeconds: number) {
-    const delay = timeSeconds - this.currentTime
+    // The stop is scheduled on the AudioContext clock, so convert the remaining
+    // media time to real time via the playback rate
+    const delay = (timeSeconds - this.currentTime) / this._playbackRate
     const currentBufferNode = this.bufferNode
     currentBufferNode?.stop(this.audioContext.currentTime + delay)
 
@@ -220,6 +222,10 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
         if (currentBufferNode === this.bufferNode) {
           this.bufferNode = null
           this.pause()
+          // The 'ended' event fires with some latency, so clamp the reported
+          // position to the exact stop time
+          this.playbackPosition = Math.min(timeSeconds, this.duration)
+          this.emit('timeupdate')
         }
       },
       { once: true },


### PR DESCRIPTION
## Problem

Playing a region (or any `play(start, end)`) never ended at exactly the requested position (#4297, #3994):

- **WebAudio backend:** `stopAt` scheduled the stop on the AudioContext clock using a *media-time* delay, so with a non-1x `playbackRate` the stop landed at the wrong moment (at 2x it stopped twice as late as requested). Additionally, when the buffer ended, `playbackPosition` was recomputed from the clock at event-dispatch time, so the reported end position jittered by a few milliseconds on every play.
- **Media-element backend:** the 16ms progress timer always overshoots `stopAtPosition` before pausing, and the overshot time was kept.

## Fix

- Scale the scheduled stop delay by the playback rate.
- Clamp the reported position to the exact stop time once the buffer ends.
- Clamp the media element's time back to `stopAtPosition` after pausing, so `region.play()` ends deterministically at `region.end`.

## Tests

Added unit tests for all three behaviors (written first, failing against the old code).

Fixes #4297
Fixes #3994

🤖 Generated with [Claude Code](https://claude.com/claude-code)