### PR TITLE
fix: accept container elements from other realms (iframes)

### DIFF
--- a/src/__tests__/dom.test.ts
+++ b/src/__tests__/dom.test.ts
@@ -1,4 +1,23 @@
-import createElement from '../dom.js'
+import createElement, { isHTMLElement } from '../dom.js'
+
+describe('isHTMLElement', () => {
+  test('accepts elements from the current realm', () => {
+    expect(isHTMLElement(document.createElement('div'))).toBe(true)
+  })
+
+  test('accepts element-like objects from another realm (e.g. an iframe)', () => {
+    const foreign = { nodeType: 1, style: {} }
+    expect(isHTMLElement(foreign)).toBe(true)
+  })
+
+  test('rejects non-elements', () => {
+    expect(isHTMLElement(null)).toBe(false)
+    expect(isHTMLElement(undefined)).toBe(false)
+    expect(isHTMLElement('#container')).toBe(false)
+    expect(isHTMLElement({})).toBe(false)
+    expect(isHTMLElement(document.createTextNode('text'))).toBe(false)
+  })
+})
 
 describe('createElement', () => {
   test('creates DOM structure', () => {

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -66,6 +66,11 @@ describe('Renderer', () => {
     jest.clearAllMocks()
   })
 
+  test('parentFromOptionsContainer accepts an element from another realm (e.g. an iframe)', () => {
+    const foreign = { nodeType: 1, style: {} } as unknown as HTMLElement
+    expect((renderer as any).parentFromOptionsContainer(foreign)).toBe(foreign)
+  })
+
   test('parentFromOptionsContainer returns element and throws', () => {
     expect((renderer as any).parentFromOptionsContainer(container)).toBe(container)
     expect((renderer as any).parentFromOptionsContainer('#root')).toBe(container)

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -41,4 +41,18 @@ export function createElement(tagName: string, content?: TreeNode, container?: N
   return el
 }
 
+/**
+ * Check if a value is an HTML element, including elements from other realms
+ * (e.g. an iframe), for which `instanceof HTMLElement` returns false
+ */
+export function isHTMLElement(value: unknown): value is HTMLElement {
+  if (value instanceof HTMLElement) return true
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Node).nodeType === Node.ELEMENT_NODE &&
+    typeof (value as HTMLElement).style === 'object'
+  )
+}
+
 export default createElement

--- a/src/plugins/minimap.ts
+++ b/src/plugins/minimap.ts
@@ -4,7 +4,7 @@
 
 import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
 import WaveSurfer, { type WaveSurferOptions } from '../wavesurfer.js'
-import createElement from '../dom.js'
+import createElement, { isHTMLElement } from '../dom.js'
 
 export type MinimapPluginOptions = {
   overlayColor?: string
@@ -79,7 +79,7 @@ class MinimapPlugin extends BasePlugin<MinimapPluginEvents, MinimapPluginOptions
     if (this.options.container) {
       if (typeof this.options.container === 'string') {
         this.container = document.querySelector(this.options.container) as HTMLElement
-      } else if (this.options.container instanceof HTMLElement) {
+      } else if (isHTMLElement(this.options.container)) {
         this.container = this.options.container
       }
       this.container?.appendChild(this.minimapWrapper)

--- a/src/plugins/spectrogram-windowed.ts
+++ b/src/plugins/spectrogram-windowed.ts
@@ -8,7 +8,7 @@
 // @ts-nocheck
 
 import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
-import createElement from '../dom.js'
+import createElement, { isHTMLElement } from '../dom.js'
 // Import centralized FFT functionality
 import FFT, {
   hzToScale,
@@ -246,7 +246,7 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
         if (el instanceof HTMLElement) {
           this.container = el
         }
-      } else if (this.options.container instanceof HTMLElement) {
+      } else if (isHTMLElement(this.options.container)) {
         this.container = this.options.container
       }
     }

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -37,7 +37,7 @@ import FFT, {
  * Spectrogram plugin for wavesurfer.
  */
 import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
-import createElement from '../dom.js'
+import createElement, { isHTMLElement } from '../dom.js'
 
 // Import the worker using rollup-plugin-web-worker-loader
 import SpectrogramWorker from 'web-worker:./spectrogram-worker.ts'
@@ -282,7 +282,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
         if (el instanceof HTMLElement) {
           this.container = el
         }
-      } else if (this.options.container instanceof HTMLElement) {
+      } else if (isHTMLElement(this.options.container)) {
         this.container = this.options.container
       }
     }

--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -3,7 +3,7 @@
  */
 
 import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
-import createElement from '../dom.js'
+import createElement, { isHTMLElement } from '../dom.js'
 import { effect } from '../reactive/store.js'
 
 export type TimelinePluginOptions = {
@@ -79,7 +79,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     }
 
     let container = this.wavesurfer.getWrapper()
-    if (this.options.container instanceof HTMLElement) {
+    if (isHTMLElement(this.options.container)) {
       container = this.options.container
     } else if (typeof this.options.container === 'string') {
       const el = document.querySelector(this.options.container)

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,4 +1,5 @@
 import EventEmitter from './event-emitter.js'
+import { isHTMLElement } from './dom.js'
 import * as utils from './renderer-utils.js'
 import type { WaveSurferOptions } from './wavesurfer.js'
 import { createDragStream } from './reactive/drag-stream.js'
@@ -74,7 +75,7 @@ class Renderer extends EventEmitter<RendererEvents> {
     let parent
     if (typeof container === 'string') {
       parent = document.querySelector(container) satisfies HTMLElement | null
-    } else if (container instanceof HTMLElement) {
+    } else if (isHTMLElement(container)) {
       parent = container
     }
 


### PR DESCRIPTION
## Problem

All container checks used `instanceof HTMLElement`, which returns false for elements created in another realm — e.g. when rendering into an iframe via [react-frame-component](https://github.com/ryanseddon/react-frame-component). Passing such an element as `container` threw "Container not found" with no workaround, since the string-selector fallback queries the wrong `document` too (#4205).

## Fix

Add a cross-realm `isHTMLElement` helper in `dom.ts` (falls back to a `nodeType`/`style` duck-type check when `instanceof` fails) and use it for every user-provided container check: renderer, timeline, minimap, and both spectrogram plugins.

## Tests

Added unit tests for the helper and for `parentFromOptionsContainer` accepting a foreign-realm element (written first, failing against the old code).

Fixes #4205

🤖 Generated with [Claude Code](https://claude.com/claude-code)