### PR TITLE
fix: prevent multi-touch from permanently blocking drag interactions

### DIFF
--- a/src/__tests__/drag-stream.test.ts
+++ b/src/__tests__/drag-stream.test.ts
@@ -1,0 +1,129 @@
+import { createDragStream, type DragEvent } from '../reactive/drag-stream.js'
+import { effect } from '../reactive/store.js'
+
+describe('createDragStream', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockReturnValue({
+        matches: false,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      }),
+    })
+    if (typeof window.PointerEvent === 'undefined') {
+      class FakePointerEvent extends MouseEvent {
+        constructor(type: string, props: any) {
+          super(type, props)
+        }
+      }
+      // @ts-expect-error
+      window.PointerEvent = FakePointerEvent
+      // @ts-expect-error
+      global.PointerEvent = FakePointerEvent
+    }
+  })
+
+  const pointerEvent = (type: string, props: { clientX?: number; clientY?: number; pointerId?: number }) => {
+    const e = new PointerEvent(type, props)
+    Object.defineProperty(e, 'pointerId', { value: props.pointerId ?? 0, configurable: true })
+    return e
+  }
+
+  const setup = () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    jest.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    })
+    const stream = createDragStream(el, { threshold: 0 })
+    const events: DragEvent[] = []
+    const unsubscribe = effect(() => {
+      const drag = stream.signal.value
+      if (drag) events.push(drag)
+    }, [stream.signal])
+    return {
+      el,
+      events,
+      cleanup: () => {
+        unsubscribe()
+        stream.cleanup()
+        el.remove()
+      },
+    }
+  }
+
+  test('emits start, move and end on a simple drag', () => {
+    const { el, events, cleanup } = setup()
+
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 }))
+    document.dispatchEvent(pointerEvent('pointermove', { clientX: 20, clientY: 20, pointerId: 1 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 20, clientY: 20, pointerId: 1 }))
+
+    expect(events.map((e) => e.type)).toEqual(['start', 'move', 'end'])
+
+    cleanup()
+  })
+
+  test('drag still works after a two-finger touch', () => {
+    const { el, events, cleanup } = setup()
+
+    // Two-finger tap: the second finger lifts before the first
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 }))
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 50, clientY: 10, pointerId: 2 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 50, clientY: 10, pointerId: 2 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 10, clientY: 10, pointerId: 1 }))
+
+    // A subsequent single-finger drag should work
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 3 }))
+    document.dispatchEvent(pointerEvent('pointermove', { clientX: 30, clientY: 10, pointerId: 3 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 3 }))
+
+    expect(events.map((e) => e.type)).toEqual(['start', 'move', 'end'])
+
+    cleanup()
+  })
+
+  test('a second finger lifting does not end the first pointer drag', () => {
+    const { el, events, cleanup } = setup()
+
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 }))
+    document.dispatchEvent(pointerEvent('pointermove', { clientX: 20, clientY: 10, pointerId: 1 }))
+
+    // A second finger touches and lifts mid-drag
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 50, clientY: 10, pointerId: 2 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 50, clientY: 10, pointerId: 2 }))
+
+    // The first finger continues dragging and lifts
+    document.dispatchEvent(pointerEvent('pointermove', { clientX: 30, clientY: 10, pointerId: 1 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 1 }))
+
+    expect(events.map((e) => e.type)).toEqual(['start', 'move', 'move', 'end'])
+
+    cleanup()
+  })
+
+  test('only the dragging pointer moves the drag', () => {
+    const { el, events, cleanup } = setup()
+
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 }))
+    document.dispatchEvent(pointerEvent('pointermove', { clientX: 20, clientY: 10, pointerId: 1 }))
+
+    // Moves from an untracked pointer are ignored
+    document.dispatchEvent(pointerEvent('pointermove', { clientX: 90, clientY: 90, pointerId: 7 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 1 }))
+
+    expect(events.map((e) => e.type)).toEqual(['start', 'move', 'end'])
+    expect(events[1].x).toBe(20)
+
+    cleanup()
+  })
+})

--- a/src/__tests__/draggable.test.ts
+++ b/src/__tests__/draggable.test.ts
@@ -22,6 +22,45 @@ describe('makeDraggable', () => {
       global.PointerEvent = FakePointerEvent
     }
   })
+  test('drag still works after a two-finger touch', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    jest.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    })
+    const pointerEvent = (type: string, props: { clientX: number; clientY: number; pointerId: number }) => {
+      const e = new PointerEvent(type, props)
+      Object.defineProperty(e, 'pointerId', { value: props.pointerId, configurable: true })
+      return e
+    }
+    const onDrag = jest.fn()
+    const unsubscribe = makeDraggable(el, onDrag, undefined, undefined, 0)
+
+    // Two-finger tap: the second finger lifts before the first
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 }))
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 50, clientY: 10, pointerId: 2 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 50, clientY: 10, pointerId: 2 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 10, clientY: 10, pointerId: 1 }))
+
+    // A subsequent single-finger drag should work
+    el.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 3 }))
+    document.dispatchEvent(pointerEvent('pointermove', { clientX: 30, clientY: 10, pointerId: 3 }))
+    document.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 3 }))
+
+    expect(onDrag).toHaveBeenCalled()
+
+    unsubscribe()
+    el.remove()
+  })
+
   test('invokes callbacks on drag', () => {
     const el = document.createElement('div')
     document.body.appendChild(el)

--- a/src/draggable.ts
+++ b/src/draggable.ts
@@ -20,18 +20,21 @@ export function makeDraggable(
 
   const onPointerDown = (event: PointerEvent) => {
     if (event.button !== mouseButton) return
+    if (activePointers.has(event.pointerId)) return
 
     activePointers.set(event.pointerId, event)
     if (activePointers.size > 1) {
       return
     }
 
+    const dragPointerId = event.pointerId
     let startX = event.clientX
     let startY = event.clientY
     let isDragging = false
     const touchStartTime = Date.now()
 
     const onPointerMove = (event: PointerEvent) => {
+      if (event.pointerId !== dragPointerId) return
       if (event.defaultPrevented || activePointers.size > 1) {
         return
       }
@@ -63,8 +66,11 @@ export function makeDraggable(
     }
 
     const onPointerUp = (event: PointerEvent) => {
-      activePointers.delete(event.pointerId)
-      if (isDragging) {
+      // Only react to pointers that started on the element
+      if (!activePointers.delete(event.pointerId)) return
+
+      // Only the pointer that started the drag can end it
+      if (event.pointerId === dragPointerId && isDragging) {
         const x = event.clientX
         const y = event.clientY
         const rect = element.getBoundingClientRect()
@@ -72,11 +78,14 @@ export function makeDraggable(
 
         onEnd?.(x - left, y - top)
       }
-      unsubscribeDocument()
+
+      // Keep listening until all pointers are released
+      if (activePointers.size === 0) {
+        unsubscribeDocument()
+      }
     }
 
     const onPointerLeave = (e: PointerEvent) => {
-      activePointers.delete(e.pointerId)
       if (!e.relatedTarget || e.relatedTarget === document.documentElement) {
         onPointerUp(e)
       }

--- a/src/reactive/drag-stream.ts
+++ b/src/reactive/drag-stream.ts
@@ -61,12 +61,14 @@ export function createDragStream(
 
   const onPointerDown = (event: PointerEvent) => {
     if (event.button !== mouseButton) return
+    if (activePointers.has(event.pointerId)) return
 
     activePointers.set(event.pointerId, event)
     if (activePointers.size > 1) {
       return
     }
 
+    const dragPointerId = event.pointerId
     let startX = event.clientX
     let startY = event.clientY
     let isDragging = false
@@ -76,6 +78,7 @@ export function createDragStream(
     const { left, top } = rect
 
     const onPointerMove = (event: PointerEvent) => {
+      if (event.pointerId !== dragPointerId) return
       if (event.defaultPrevented || activePointers.size > 1) {
         return
       }
@@ -116,8 +119,11 @@ export function createDragStream(
     }
 
     const onPointerUp = (event: PointerEvent) => {
-      activePointers.delete(event.pointerId)
-      if (isDragging) {
+      // Only react to pointers that started on the element
+      if (!activePointers.delete(event.pointerId)) return
+
+      // Only the pointer that started the drag can end it
+      if (event.pointerId === dragPointerId && isDragging) {
         const x = event.clientX
         const y = event.clientY
 
@@ -128,11 +134,14 @@ export function createDragStream(
           y: y - top,
         })
       }
-      unsubscribeDocument()
+
+      // Keep listening until all pointers are released
+      if (activePointers.size === 0) {
+        unsubscribeDocument()
+      }
     }
 
     const onPointerLeave = (e: PointerEvent) => {
-      activePointers.delete(e.pointerId)
       if (!e.relatedTarget || e.relatedTarget === document.documentElement) {
         onPointerUp(e)
       }


### PR DESCRIPTION
## Problem

A two-finger touch on the waveform permanently broke all interaction (#4020), and multi-touch misbehaved with region drag/resize and `enableDragSelection` (#3780, related: #4137):

1. The first finger registers document-level pointer listeners. When a **second** finger lifted, `onPointerUp` ran `unsubscribeDocument()` while the first finger was still down.
2. The first pointer's release was then never observed, so it stayed in `activePointers` forever. Every subsequent single-finger touch made `activePointers.size > 1`, blocking all dragging and seeking until page reload.
3. A second finger lifting also emitted a spurious `end` for the first finger's drag, and any `pointerout` (which fires when moving across child elements mid-drag) silently dropped the tracked pointer.

## Fix

Track the pointer that initiated the drag (`dragPointerId`):

- Only that pointer's moves drive the drag; other pointers' moves are ignored.
- Only that pointer's release emits `end`.
- Document listeners are removed only once **all** tracked pointers are released.
- `pointerout` no longer drops tracked pointers (only a true leave of the document releases them).

Applied to both `createDragStream` (used by the renderer and regions) and the deprecated `makeDraggable`.

## Tests

Added regression tests (written first, failing against the old code): drag works after a two-finger tap, a second finger lifting doesn't end the first finger's drag, and untracked pointers can't move a drag.

Fixes #4020
Fixes #3780

🤖 Generated with [Claude Code](https://claude.com/claude-code)