### PR TITLE
fix(Spectrogram): close ImageBitmap when its canvas is removed before it resolves

### DIFF
--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -782,14 +782,16 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
         // Remove from pending set
         this.pendingBitmaps.delete(bitmapPromise)
 
-        // Check if canvas is still valid before drawing
-        if (ctx.canvas.parentNode) {
-          const drawHeight = (height * rMax1) / rMax
-          const drawY = yOffset + height * (1 - rMax1 / rMax)
+        try {
+          // Check if canvas is still valid before drawing
+          if (ctx.canvas.parentNode) {
+            const drawHeight = (height * rMax1) / rMax
+            const drawY = yOffset + height * (1 - rMax1 / rMax)
 
-          ctx.drawImage(bitmap, 0, drawY, canvasWidth, drawHeight)
-
-          // Clean up bitmap to free memory
+            ctx.drawImage(bitmap, 0, drawY, canvasWidth, drawHeight)
+          }
+        } finally {
+          // Clean up bitmap to free memory, even if the canvas was removed before it resolved
           if ('close' in bitmap) {
             bitmap.close()
           }


### PR DESCRIPTION
## Short description

Resolves #4323

## Implementation details

In the regular `SpectrogramPlugin`, `drawSpectrogramSegment()` rasterises each chunk with `createImageBitmap()` and, in the promise callback, only called `bitmap.close()` inside the `if (ctx.canvas.parentNode)` guard. When the canvas was removed before the bitmap resolved — a zoom re-render (`drawSpectrogram()` runs `clearCanvases()` first), unregistering the plugin, or `destroy()` (which only does `pendingBitmaps.clear()` and never closes resolved bitmaps) — the resolved `ImageBitmap` was neither drawn nor closed, so its resources waited on GC instead of being released.

This moves the cleanup into a `finally`: the `drawImage` stays guarded by `ctx.canvas.parentNode`, but the bitmap is always closed once it resolves (and also if `drawImage` itself throws). No API or behavior change when the canvas is present.

The `WindowedSpectrogramPlugin` already closes unconditionally, so it was not affected.

## How to test it

Register the (non-windowed) `SpectrogramPlugin` on a longer audio file and zoom/toggle the spectrogram rapidly while chunks are rendering. With a memory profiler, bitmaps that resolve after their canvas was removed are now closed immediately rather than retained until a later GC. There is no visual change.

## Screenshots

n/a

## Checklist

* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
