### PR TITLE
fix(Spectrogram): make the web worker FFT timeout configurable

### DIFF
--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -355,8 +355,10 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
       this.worker.terminate()
       this.worker = null
     }
+    const error = new Error('Spectrogram plugin destroyed')
     this.workerPromises.forEach((promise) => {
       if (promise.timer) clearTimeout(promise.timer)
+      promise.reject(error)
     })
     this.workerPromises.clear()
 

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -112,6 +112,12 @@ export type SpectrogramPluginOptions = {
   maxCanvasWidth?: number
   /** Use web worker for FFT calculations (default: false) */
   useWebWorker?: boolean
+  /**
+   * Max time in milliseconds to wait for the web worker FFT result before the calculation is
+   * rejected (and falls back to the main thread). Set to 0 to disable the timeout. Only used when
+   * useWebWorker is true. (default: 30000)
+   */
+  workerTimeout?: number
 }
 
 export type SpectrogramPluginEvents = BasePluginEvents & {
@@ -148,7 +154,9 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
   // Web worker support
   private useWebWorker: boolean = false
   private worker: Worker | null = null
-  private workerPromises: Map<string, { resolve: Function; reject: Function }> = new Map()
+  private workerTimeout = 30000
+  private workerPromises: Map<string, { resolve: Function; reject: Function; timer?: ReturnType<typeof setTimeout> }> =
+    new Map()
 
   // Performance optimization properties
   private cachedFrequencies: Uint8Array[][] | null = null
@@ -185,6 +193,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
 
     // Web worker option (disabled by default)
     this.useWebWorker = options.useWebWorker === true
+    this.workerTimeout = options.workerTimeout ?? 30000
 
     // Set up color map using shared utility
     this.colorMap = setupColorMap(options.colorMap)
@@ -246,6 +255,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
           const promise = this.workerPromises.get(id)
           if (promise) {
             this.workerPromises.delete(id)
+            if (promise.timer) clearTimeout(promise.timer)
             if (error) {
               promise.reject(new Error(error))
             } else {
@@ -345,6 +355,10 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
       this.worker.terminate()
       this.worker = null
     }
+    this.workerPromises.forEach((promise) => {
+      if (promise.timer) clearTimeout(promise.timer)
+    })
+    this.workerPromises.clear()
 
     this.cachedFrequencies = null
     this.cachedResampledData = null
@@ -837,35 +851,43 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
 
     // Create promise for worker response
     const promise = new Promise<Uint8Array[][]>((resolve, reject) => {
-      this.workerPromises.set(id, { resolve, reject })
+      // Set timeout to avoid hanging; workerTimeout === 0 disables it
+      const timer =
+        this.workerTimeout > 0
+          ? setTimeout(() => {
+              if (this.workerPromises.has(id)) {
+                this.workerPromises.delete(id)
+                reject(new Error('Worker timeout'))
+              }
+            }, this.workerTimeout)
+          : undefined
+      this.workerPromises.set(id, { resolve, reject, timer })
 
-      // Set timeout to avoid hanging
-      setTimeout(() => {
-        if (this.workerPromises.has(id)) {
-          this.workerPromises.delete(id)
-          reject(new Error('Worker timeout'))
-        }
-      }, 30000) // 30 second timeout
-    })
-
-    // Send message to worker
-    this.worker.postMessage({
-      type: 'calculateFrequencies',
-      id,
-      audioData,
-      options: {
-        startTime: 0,
-        endTime: buffer.duration,
-        sampleRate: buffer.sampleRate,
-        fftSamples: this.fftSamples,
-        windowFunc: this.windowFunc,
-        alpha: this.alpha,
-        noverlap,
-        scale: this.scale,
-        gainDB: this.gainDB,
-        rangeDB: this.rangeDB,
-        splitChannels: this.options.splitChannels || false,
-      },
+      // Send message to worker; if dispatch fails synchronously, settle and clean up immediately
+      try {
+        this.worker.postMessage({
+          type: 'calculateFrequencies',
+          id,
+          audioData,
+          options: {
+            startTime: 0,
+            endTime: buffer.duration,
+            sampleRate: buffer.sampleRate,
+            fftSamples: this.fftSamples,
+            windowFunc: this.windowFunc,
+            alpha: this.alpha,
+            noverlap,
+            scale: this.scale,
+            gainDB: this.gainDB,
+            rangeDB: this.rangeDB,
+            splitChannels: this.options.splitChannels || false,
+          },
+        })
+      } catch (error) {
+        if (timer) clearTimeout(timer)
+        this.workerPromises.delete(id)
+        reject(error)
+      }
     })
 
     return promise


### PR DESCRIPTION
## Short description

Resolves #4325. The spectrogram web-worker FFT had a hardcoded 30s timeout; on long files the worker is aborted and the plugin falls back to a synchronous main-thread FFT that freezes the page. This adds a `workerTimeout` option so the wait can be scaled to the file length or disabled, with no change in default behaviour.

## Implementation details

- Add `workerTimeout?: number` to `SpectrogramPluginOptions` — default `30000` (unchanged behaviour), `0` disables the timeout. Only used when `useWebWorker` is `true`.
- `calculateFrequenciesWithWorker()` uses the option instead of the literal `30000`, and skips the timer entirely when it is `0`.
- Store the timer handle on the pending-promise record and clear it when the request settles (`onmessage`) and in `destroy()`, so a timer can't outlive its request — relevant once the timeout can be disabled.
- No default/behaviour change for existing users; no API removed.

## How to test it

Register the spectrogram with `useWebWorker: true` on a long recording whose worker FFT exceeds the timeout:

- With the default (`30000`) the worker is aborted after 30s and the FFT is recomputed on the main thread — the page freezes until it finishes (current behaviour).
- With `workerTimeout: 0` (or a higher value) the worker FFT runs to completion and the page stays responsive.

## Screenshots

N/A (timing/responsiveness change).

## Checklist
* [ ] This PR is covered by e2e tests — the timeout/worker timing isn't deterministically testable in the cypress suite; verified manually with long files. Happy to add a test if you'd like a particular shape.
* [x] It introduces no breaking API changes
