### PR TITLE
fix(Spectrogram): use the same window alpha defaults in the worker and main thread

### DIFF
--- a/src/__tests__/spectrogram-worker.test.ts
+++ b/src/__tests__/spectrogram-worker.test.ts
@@ -1,0 +1,118 @@
+import FFT from '../fft.js'
+import '../plugins/spectrogram-worker.js'
+
+type WorkerOptions = {
+  startTime: number
+  endTime: number
+  sampleRate: number
+  fftSamples: number
+  windowFunc: string
+  alpha?: number
+  noverlap: number
+  scale: 'linear' | 'logarithmic' | 'mel' | 'bark' | 'erb'
+  gainDB: number
+  rangeDB: number
+  splitChannels: boolean
+}
+
+const SAMPLE_RATE = 8000
+const GAIN_DB = 20
+const RANGE_DB = 80
+
+/** A 1 kHz sine, long enough for several FFT frames */
+function makeSine(length: number): Float32Array {
+  const signal = new Float32Array(length)
+  for (let i = 0; i < length; i++) {
+    signal[i] = Math.sin((2 * Math.PI * 1000 * i) / SAMPLE_RATE)
+  }
+  return signal
+}
+
+/** Dispatch a message to the worker handler and return its response synchronously */
+function runWorker(signal: Float32Array, options: WorkerOptions): Uint8Array[][] {
+  const postMessage = jest.fn()
+  ;(self as any).postMessage = postMessage
+  ;(self as any).onmessage({
+    data: { type: 'calculateFrequencies', id: 'test', audioData: [signal], options },
+  })
+  const response = postMessage.mock.calls[0][0]
+  expect(response.error).toBeUndefined()
+  return response.result
+}
+
+/** The main-thread computation from spectrogram.ts getFrequencies(), linear scale */
+function mainThreadFrequencies(
+  signal: Float32Array,
+  fftSamples: number,
+  windowFunc: string,
+  alpha: number | undefined,
+): Uint8Array[] {
+  const fft = new (FFT as any)(fftSamples, SAMPLE_RATE, windowFunc, alpha)
+
+  const noverlap = Math.round(fftSamples * 0.5)
+  const hopSize = Math.max(Math.max(64, fftSamples * 0.25), fftSamples - noverlap)
+
+  const frames: Uint8Array[] = []
+  for (let sample = 0; sample + fftSamples < signal.length; sample += hopSize) {
+    const spectrum = fft.calculateSpectrum(signal.slice(sample, sample + fftSamples))
+    const freqBins = new Uint8Array(spectrum.length)
+    for (let j = 0; j < spectrum.length; j++) {
+      const magnitude = spectrum[j] > 1e-12 ? spectrum[j] : 1e-12
+      const valueDB = 20 * Math.log10(magnitude)
+      if (valueDB < -(GAIN_DB + RANGE_DB)) {
+        freqBins[j] = 0
+      } else if (valueDB > -GAIN_DB) {
+        freqBins[j] = 255
+      } else {
+        freqBins[j] = Math.round(((valueDB + GAIN_DB) / RANGE_DB) * 255)
+      }
+    }
+    frames.push(freqBins)
+  }
+  return frames
+}
+
+function workerOptions(signal: Float32Array, fftSamples: number, windowFunc: string, alpha?: number): WorkerOptions {
+  return {
+    startTime: 0,
+    endTime: signal.length / SAMPLE_RATE,
+    sampleRate: SAMPLE_RATE,
+    fftSamples,
+    windowFunc,
+    alpha,
+    noverlap: Math.round(fftSamples * 0.5),
+    scale: 'linear',
+    gainDB: GAIN_DB,
+    rangeDB: RANGE_DB,
+    splitChannels: false,
+  }
+}
+
+describe('spectrogram worker', () => {
+  it('uses the same default window alpha as the main thread when alpha is not set', () => {
+    const fftSamples = 512
+    const signal = makeSine(4000)
+
+    const workerResult = runWorker(signal, workerOptions(signal, fftSamples, 'gauss'))
+    const mainResult = mainThreadFrequencies(signal, fftSamples, 'gauss', undefined)
+
+    expect(workerResult[0].length).toBe(mainResult.length)
+    expect(mainResult.some((frame) => frame.some((value) => value > 0))).toBe(true)
+    workerResult[0].forEach((frame: Uint8Array, i: number) => {
+      expect(Array.from(frame)).toEqual(Array.from(mainResult[i]))
+    })
+  })
+
+  it('honors an explicitly set alpha', () => {
+    const fftSamples = 256
+    const signal = makeSine(4000)
+
+    const workerResult = runWorker(signal, workerOptions(signal, fftSamples, 'gauss', 0.4))
+    const mainResult = mainThreadFrequencies(signal, fftSamples, 'gauss', 0.4)
+
+    expect(workerResult[0].length).toBe(mainResult.length)
+    workerResult[0].forEach((frame: Uint8Array, i: number) => {
+      expect(Array.from(frame)).toEqual(Array.from(mainResult[i]))
+    })
+  })
+})

--- a/src/plugins/spectrogram-worker.ts
+++ b/src/plugins/spectrogram-worker.ts
@@ -83,7 +83,7 @@ function calculateFrequencies(audioChannels: Float32Array[], options: WorkerMess
 
   // Initialize FFT (reuse if possible for performance)
   if (!fft || fft.bufferSize !== fftSamples) {
-    fft = new (FFT as any)(fftSamples, sampleRate, windowFunc, alpha || 0.16)
+    fft = new (FFT as any)(fftSamples, sampleRate, windowFunc, alpha)
   }
 
   // Create filter bank based on scale using centralized function


### PR DESCRIPTION
## Short description

The spectrogram worker builds its FFT with `alpha || 0.16`, so a `gauss` spectrogram rendered with `useWebWorker: true` uses a 0.16 window width while the main thread uses the FFT's own gauss default of 0.25 (`fft.ts`) — the same options produce two visibly different images depending on where the FFT runs. 0.16 is blackman's default, misapplied to every window function. This passes `alpha` through untouched so the per-window defaults in `fft.ts` apply identically on both paths.

## Implementation details

- One line in `spectrogram-worker.ts`: drop the `|| 0.16` coercion at the FFT construction. Both plugins that use this worker (`spectrogram.ts` and `spectrogram-windowed.ts`) already send `alpha` through unmodified, and the main-thread paths already construct `FFT` with the raw option, so this is worker/main parity only.
- Output changes for `gauss` worker users who never set `alpha` — it starts matching the main-thread/documented behavior. For `gauss`, explicit falsy values (`alpha: 0`, `NaN`) also now resolve to the same FFT default the main thread applies to them. Alpha validation itself is untouched and worth a separate discussion.
- New jest suite (`src/__tests__/spectrogram-worker.test.ts`) drives the worker's `onmessage` handler in-process and asserts byte-exact parity with the main-thread compute path. The default-gauss case fails without the fix; a second case pins explicit-alpha pass-through.

## How to test it

Render the same file twice with `windowFunc: 'gauss'` and no `alpha`, once with `useWebWorker: true` and once without — before the fix the two spectrograms differ, after the fix they are pixel-identical (verified via canvas `toDataURL` comparison in Chrome). And `npm run test:unit`.

## Screenshots

`examples/audio/demo.wav`, `windowFunc: 'gauss'`, `scale: 'linear'`, no `alpha` set:

| | |
|---|---|
| main thread (unchanged) | ![main thread](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-worker-alpha/gauss-main-thread.png) |
| worker, before | ![worker before](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-worker-alpha/gauss-worker-before.png) |
| worker, after (matches main thread) | ![worker after](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-worker-alpha/gauss-worker-after.png) |

## Checklist
* [ ] This PR is covered by e2e tests — the spectrogram e2e suite is currently disabled (`xdescribe`), so the numeric behavior is covered by the new jest suite instead.
* [x] It introduces no breaking API changes
