### PR TITLE
fix(Spectrogram): reject pending worker promises when the worker errors

### DIFF
--- a/src/__tests__/spectrogram-worker-errors.test.ts
+++ b/src/__tests__/spectrogram-worker-errors.test.ts
@@ -1,0 +1,203 @@
+const mockWorkerInstances: any[] = []
+
+jest.mock(
+  'web-worker:./spectrogram-worker.ts',
+  () => ({
+    __esModule: true,
+    default: class MockSpectrogramWorker {
+      onmessage: ((e: { data: any }) => void) | null = null
+      onerror: ((e: Event) => void) | null = null
+      onmessageerror: ((e: Event) => void) | null = null
+      postMessage = jest.fn()
+      terminate = jest.fn()
+      constructor() {
+        mockWorkerInstances.push(this)
+      }
+    },
+  }),
+  { virtual: true },
+)
+
+import Spectrogram from '../plugins/spectrogram.js'
+import WindowedSpectrogram from '../plugins/spectrogram-windowed.js'
+
+const SAMPLE_RATE = 8000
+const LENGTH = 4096
+
+function makeBuffer(): AudioBuffer {
+  const data = new Float32Array(LENGTH)
+  for (let i = 0; i < LENGTH; i++) {
+    data[i] = Math.sin((2 * Math.PI * 440 * i) / SAMPLE_RATE)
+  }
+  return {
+    sampleRate: SAMPLE_RATE,
+    length: LENGTH,
+    duration: LENGTH / SAMPLE_RATE,
+    numberOfChannels: 1,
+    getChannelData: () => data,
+  } as unknown as AudioBuffer
+}
+
+/** Reports how a promise settled within `ms`, without waiting longer */
+function settledWithin(promise: Promise<unknown>, ms: number): Promise<'resolved' | 'rejected' | 'pending'> {
+  return Promise.race([
+    promise.then(
+      () => 'resolved' as const,
+      () => 'rejected' as const,
+    ),
+    new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), ms)),
+  ])
+}
+
+beforeAll(() => {
+  // jsdom has no Worker; the plugins only check its existence before using the bundled constructor
+  ;(globalThis as any).Worker = function Worker() {}
+})
+
+beforeEach(() => {
+  mockWorkerInstances.length = 0
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('SpectrogramPlugin worker error handling', () => {
+  function createPlugin(options: Record<string, unknown> = {}) {
+    const plugin = Spectrogram.create({ useWebWorker: true, noverlap: 256, scale: 'linear', ...options })
+    return { plugin: plugin as any, worker: mockWorkerInstances[mockWorkerInstances.length - 1] }
+  }
+
+  it('rejects the in-flight promise when the worker errors, even with workerTimeout: 0', async () => {
+    const { plugin, worker } = createPlugin({ workerTimeout: 0 })
+    const promise = plugin.calculateFrequenciesWithWorker(makeBuffer())
+    promise.catch(() => undefined)
+    expect(worker.postMessage).toHaveBeenCalledTimes(1)
+
+    worker.onerror(new Event('error'))
+
+    expect(await settledWithin(promise, 200)).toBe('rejected')
+    expect(plugin.workerPromises.size).toBe(0)
+    expect(worker.terminate).toHaveBeenCalled()
+    expect(plugin.worker).toBeNull()
+  })
+
+  it('clears the timeout timer when the worker errors', async () => {
+    const { plugin, worker } = createPlugin()
+    const clearTimeoutSpy = jest.spyOn(globalThis, 'clearTimeout')
+    const promise = plugin.calculateFrequenciesWithWorker(makeBuffer())
+
+    worker.onerror(new Event('error'))
+
+    await expect(promise).rejects.toThrow('Worker error')
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+
+  it('rejects the in-flight promise on a message deserialization error', async () => {
+    const { plugin, worker } = createPlugin({ workerTimeout: 0 })
+    const promise = plugin.calculateFrequenciesWithWorker(makeBuffer())
+    promise.catch(() => undefined)
+
+    worker.onmessageerror(new Event('messageerror'))
+
+    expect(await settledWithin(promise, 200)).toBe('rejected')
+    expect(plugin.workerPromises.size).toBe(0)
+    expect(plugin.worker).toBeNull()
+  })
+
+  it('falls back to the main thread immediately after a worker error', async () => {
+    const { plugin, worker } = createPlugin({ workerTimeout: 0 })
+    const promise = plugin.getFrequencies(makeBuffer())
+    expect(worker.postMessage).toHaveBeenCalledTimes(1)
+
+    worker.onerror(new Event('error'))
+
+    const frequencies = await promise
+    expect(frequencies.length).toBe(1)
+    expect(frequencies[0].length).toBeGreaterThan(0)
+    expect(frequencies[0][0]).toBeInstanceOf(Uint8Array)
+  })
+
+  it('rejects pending promises on destroy', async () => {
+    const { plugin } = createPlugin({ workerTimeout: 0 })
+    const promise = plugin.calculateFrequenciesWithWorker(makeBuffer())
+    promise.catch(() => undefined)
+
+    plugin.destroy()
+
+    await expect(promise).rejects.toThrow('Spectrogram plugin destroyed')
+    expect(plugin.workerPromises.size).toBe(0)
+  })
+})
+
+describe('WindowedSpectrogramPlugin worker error handling', () => {
+  function createPlugin(options: Record<string, unknown> = {}) {
+    const plugin = WindowedSpectrogram.create({ useWebWorker: true, noverlap: 256, scale: 'linear', ...options })
+    ;(plugin as any).buffer = makeBuffer()
+    return { plugin: plugin as any, worker: mockWorkerInstances[mockWorkerInstances.length - 1] }
+  }
+
+  it('rejects the in-flight promise when the worker errors instead of waiting out the timeout', async () => {
+    const { plugin, worker } = createPlugin()
+    const promise = plugin.calculateFrequenciesWithWorker(0, 0.25)
+    promise.catch(() => undefined)
+    expect(worker.postMessage).toHaveBeenCalledTimes(1)
+
+    worker.onerror(new Event('error'))
+
+    expect(await settledWithin(promise, 200)).toBe('rejected')
+    expect(plugin.workerPromises.size).toBe(0)
+    expect(worker.terminate).toHaveBeenCalled()
+    expect(plugin.worker).toBeNull()
+  })
+
+  it('rejects the in-flight promise on a message deserialization error', async () => {
+    const { plugin, worker } = createPlugin()
+    const promise = plugin.calculateFrequenciesWithWorker(0, 0.25)
+    promise.catch(() => undefined)
+
+    worker.onmessageerror(new Event('messageerror'))
+
+    expect(await settledWithin(promise, 200)).toBe('rejected')
+    expect(plugin.workerPromises.size).toBe(0)
+    expect(plugin.worker).toBeNull()
+  })
+
+  it('cleans up the pending request when postMessage throws synchronously', async () => {
+    const { plugin, worker } = createPlugin()
+    worker.postMessage.mockImplementation(() => {
+      throw new Error('DataCloneError')
+    })
+
+    const promise = plugin.calculateFrequenciesWithWorker(0, 0.25)
+
+    await expect(promise).rejects.toThrow('DataCloneError')
+    expect(plugin.workerPromises.size).toBe(0)
+  })
+
+  it('clears the timeout timer when a result arrives', async () => {
+    const { plugin, worker } = createPlugin()
+    const clearTimeoutSpy = jest.spyOn(globalThis, 'clearTimeout')
+    const promise = plugin.calculateFrequenciesWithWorker(0, 0.25)
+    const { id } = worker.postMessage.mock.calls[0][0]
+    const result = [[new Uint8Array([1, 2, 3])]]
+
+    worker.onmessage({ data: { type: 'frequenciesResult', id, result } })
+
+    await expect(promise).resolves.toEqual(result)
+    expect(plugin.workerPromises.size).toBe(0)
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+
+  it('rejects pending promises on destroy', async () => {
+    const { plugin } = createPlugin()
+    const promise = plugin.calculateFrequenciesWithWorker(0, 0.25)
+    promise.catch(() => undefined)
+
+    plugin.destroy()
+
+    await expect(promise).rejects.toThrow('Plugin destroyed')
+    expect(plugin.workerPromises.size).toBe(0)
+  })
+})

--- a/src/plugins/spectrogram-windowed.ts
+++ b/src/plugins/spectrogram-windowed.ts
@@ -140,7 +140,8 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
 
   // Web worker for FFT calculations
   private worker: Worker | null = null
-  private workerPromises: Map<string, { resolve: Function; reject: Function }> = new Map()
+  private workerPromises: Map<string, { resolve: Function; reject: Function; timer?: ReturnType<typeof setTimeout> }> =
+    new Map()
 
   static create(options?: WindowedSpectrogramPluginOptions) {
     return new WindowedSpectrogramPlugin(options || {})
@@ -210,6 +211,7 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
           const promise = this.workerPromises.get(id)
           if (promise) {
             this.workerPromises.delete(id)
+            if (promise.timer) clearTimeout(promise.timer)
             if (error) {
               promise.reject(new Error(error))
             } else {
@@ -221,13 +223,31 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
 
       this.worker.onerror = (error) => {
         console.warn('Spectrogram worker error, falling back to main thread:', error)
-        // Fallback to main thread calculation
-        this.worker = null
+        this.disposeWorker(new Error('Worker error'))
+      }
+
+      this.worker.onmessageerror = (event) => {
+        console.warn('Spectrogram worker message error, falling back to main thread:', event)
+        this.disposeWorker(new Error('Worker message error'))
       }
     } catch (error) {
       console.warn('Failed to initialize worker, falling back to main thread:', error)
       this.worker = null
     }
+  }
+
+  // Terminate the worker and reject in-flight requests so callers fall back to the main thread
+  // immediately instead of waiting out the 30s request timeout
+  private disposeWorker(error: Error) {
+    if (this.worker) {
+      this.worker.terminate()
+      this.worker = null
+    }
+    this.workerPromises.forEach((promise) => {
+      if (promise.timer) clearTimeout(promise.timer)
+      promise.reject(error)
+    })
+    this.workerPromises.clear()
   }
 
   onInit() {
@@ -820,35 +840,40 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
 
     // Create promise for worker response
     const promise = new Promise<Uint8Array[][]>((resolve, reject) => {
-      this.workerPromises.set(id, { resolve, reject })
-
       // Set timeout to avoid hanging
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         if (this.workerPromises.has(id)) {
           this.workerPromises.delete(id)
           reject(new Error('Worker timeout'))
         }
       }, 30000) // 30 second timeout
-    })
+      this.workerPromises.set(id, { resolve, reject, timer })
 
-    // Send message to worker
-    this.worker.postMessage({
-      type: 'calculateFrequencies',
-      id,
-      audioData,
-      options: {
-        startTime,
-        endTime,
-        sampleRate,
-        fftSamples: this.fftSamples,
-        windowFunc: this.windowFunc,
-        alpha: this.alpha,
-        noverlap,
-        scale: this.scale,
-        gainDB: this.gainDB,
-        rangeDB: this.rangeDB,
-        splitChannels: this.options.splitChannels || false,
-      },
+      // Send message to worker; if dispatch fails synchronously, settle and clean up immediately
+      try {
+        this.worker.postMessage({
+          type: 'calculateFrequencies',
+          id,
+          audioData,
+          options: {
+            startTime,
+            endTime,
+            sampleRate,
+            fftSamples: this.fftSamples,
+            windowFunc: this.windowFunc,
+            alpha: this.alpha,
+            noverlap,
+            scale: this.scale,
+            gainDB: this.gainDB,
+            rangeDB: this.rangeDB,
+            splitChannels: this.options.splitChannels || false,
+          },
+        })
+      } catch (error) {
+        clearTimeout(timer)
+        this.workerPromises.delete(id)
+        reject(error)
+      }
     })
 
     return promise
@@ -1183,17 +1208,8 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     this.stopProgressiveLoading()
     this.nextProgressiveSegmentTime = 0
 
-    // Clean up worker
-    if (this.worker) {
-      this.worker.terminate()
-      this.worker = null
-    }
-
-    // Clear any pending worker promises
-    for (const [id, promise] of this.workerPromises) {
-      promise.reject(new Error('Plugin destroyed'))
-    }
-    this.workerPromises.clear()
+    // Clean up worker and any pending worker promises
+    this.disposeWorker(new Error('Plugin destroyed'))
 
     this.clearAllSegments()
 

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -267,13 +267,31 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
 
       this.worker.onerror = (error) => {
         console.warn('Spectrogram worker error, falling back to main thread:', error)
-        // Fallback to main thread calculation
-        this.worker = null
+        this.disposeWorker(new Error('Worker error'))
+      }
+
+      this.worker.onmessageerror = (event) => {
+        console.warn('Spectrogram worker message error, falling back to main thread:', event)
+        this.disposeWorker(new Error('Worker message error'))
       }
     } catch (error) {
       console.warn('Failed to initialize worker, falling back to main thread:', error)
       this.worker = null
     }
+  }
+
+  // Terminate the worker and reject in-flight requests so callers fall back to the main thread
+  // immediately instead of waiting out the worker timeout (or hanging when it is disabled)
+  private disposeWorker(error: Error) {
+    if (this.worker) {
+      this.worker.terminate()
+      this.worker = null
+    }
+    this.workerPromises.forEach((promise) => {
+      if (promise.timer) clearTimeout(promise.timer)
+      promise.reject(error)
+    })
+    this.workerPromises.clear()
   }
 
   onInit() {
@@ -351,16 +369,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
     this.pendingBitmaps.clear()
 
     // Clean up worker
-    if (this.worker) {
-      this.worker.terminate()
-      this.worker = null
-    }
-    const error = new Error('Spectrogram plugin destroyed')
-    this.workerPromises.forEach((promise) => {
-      if (promise.timer) clearTimeout(promise.timer)
-      promise.reject(error)
-    })
-    this.workerPromises.clear()
+    this.disposeWorker(new Error('Spectrogram plugin destroyed'))
 
     this.cachedFrequencies = null
     this.cachedResampledData = null


### PR DESCRIPTION
## Short description

When the spectrogram web worker fires an `error`, both plugins only log a warning and null the worker reference — the in-flight FFT promise is left pending. The caller then waits out the full `workerTimeout` (30s by default) before the main-thread fallback starts, and with `workerTimeout: 0` (possible since #4326) it hangs forever, leaving the spectrogram blank. This change makes a worker error fail that worker instance and fall back immediately.

## Implementation details

- Both plugins route `onerror` — and a new `onmessageerror` handler — through a `disposeWorker()` helper: reject all in-flight requests (clearing their timeout timers), terminate the worker, null the reference. The caller's existing catch then starts the main-thread fallback right away; fallback semantics are otherwise unchanged. Terminating is a deliberate choice rather than something the browser does for us — an uncaught worker error doesn't kill the thread, but once the pending requests are rejected a late result has no promise target, so the errored instance is discarded instead of left computing in the background.
- `destroy()` now reuses the same helper with the same error messages as before — pure refactor, pinned by tests.
- The windowed plugin also gets the hardening the main plugin received in #4326 but this one never did: `postMessage` wrapped in try/catch (a synchronous dispatch failure previously leaked the pending request forever), and the 30s timeout handle is now stored and cleared when the request settles (previously every segment request left an uncancellable 30s timer running).
- New jest suite (`src/__tests__/spectrogram-worker-errors.test.ts`) loads both plugin modules with a mocked worker and covers: prompt rejection on `error`/`messageerror` including `workerTimeout: 0`, timer cleanup, immediate end-to-end main-thread fallback, destroy-time rejection (existing behavior, now pinned), and the windowed dispatch/timer cleanup paths. 8 of the 10 cases fail without the fix.

## How to test it

`npm run test:unit`. In a browser: create a spectrogram with `useWebWorker: true, workerTimeout: 0`, then kill the worker mid-request (terminate it and dispatch an error event on it). Before this change the spectrogram never renders; after it, the main-thread fallback renders immediately.

## Screenshots

After a mid-flight worker kill with `workerTimeout: 0` — previously this stayed blank forever, now the fallback renders:

![fallback render after worker error](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-worker-error/fallback-after-worker-error.png)

## Checklist
* [ ] This PR is covered by e2e tests — the spectrogram e2e suite is currently disabled (`xdescribe`); the error paths are covered by the new jest suite and were verified manually in Chrome.
* [x] It introduces no breaking API changes
