### PR TITLE
feat(Spectrogram): decouple FFT size from the analysis window (fftSize option)

### DIFF
--- a/examples/spectrogram.js
+++ b/examples/spectrogram.js
@@ -62,6 +62,10 @@ ws.registerPlugin(
     // Overlap between FFT windows:
     // noverlap: null,    // Auto-calculated by default, or set manually
     //
+    // Zero-padded FFT length (power of 2, >= fftSamples):
+    // fftSize: 4096,     // Interpolates extra frequency bins for a smoother image without
+    //                    // changing the analysis window, hop, or time resolution
+    //
     // Maximum canvas width for performance:
     // maxCanvasWidth: 30000,  // Split large spectrograms into multiple canvases
   }),
@@ -116,6 +120,7 @@ ws.on('spectrogram-click', (relativeX) => {
     <h4>Performance Settings</h4>
     <ul>
       <li><code>fftSamples: 1024</code> - FFT resolution (512, 1024, 2048, 4096)</li>
+      <li><code>fftSize: 4096</code> - Optional zero-padded FFT length for smoother frequency interpolation</li>
       <li><code>useWebWorker: true</code> - Use web worker for faster processing</li>
       <li><code>maxCanvasWidth: 30000</code> - Split large spectrograms into multiple canvases</li>
       <li><code>noverlap: null</code> - Overlap between FFT windows (auto-calculated)</li>

--- a/src/__tests__/fft.test.ts
+++ b/src/__tests__/fft.test.ts
@@ -1,4 +1,4 @@
-import {
+import FFT, {
   applyFilterBank,
   applySparseFilterBank,
   createFilterBankForScale,
@@ -16,6 +16,14 @@ function makeSpectrum(length: number, seed = 1): Float32Array {
     spectrum[i] = state / 2147483647
   }
   return spectrum
+}
+
+function makeSine(length: number, frequency: number, sampleRate: number): Float32Array {
+  const signal = new Float32Array(length)
+  for (let i = 0; i < length; i++) {
+    signal[i] = Math.sin((2 * Math.PI * frequency * i) / sampleRate)
+  }
+  return signal
 }
 
 describe('sparse filter bank', () => {
@@ -66,5 +74,76 @@ describe('sparse filter bank', () => {
     }
     expect(sparse[0].centerHz).toBeGreaterThanOrEqual(0)
     expect(sparse[sparse.length - 1].centerHz).toBeLessThanOrEqual(sampleRate / 2)
+  })
+})
+
+describe('FFT zero-padding (windowLength)', () => {
+  const SAMPLE_RATE = 16000
+
+  it('defaults windowLength to the buffer size with unchanged output', () => {
+    const signal = makeSine(512, 1000, SAMPLE_RATE)
+    const spectrum = new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined).calculateSpectrum(signal)
+    const spectrumExplicit = new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, 512).calculateSpectrum(signal)
+
+    expect(Array.from(spectrumExplicit)).toEqual(Array.from(spectrum))
+  })
+
+  it('keeps bin magnitudes calibrated when the window is zero-padded', () => {
+    // Sine on bin 8 of a 64-sample transform = bin 64 of a 512-sample transform
+    const frequency = (8 * SAMPLE_RATE) / 64
+    const signal = makeSine(64, frequency, SAMPLE_RATE)
+
+    const unpadded = new (FFT as any)(64, SAMPLE_RATE, 'hann', undefined).calculateSpectrum(signal)
+
+    const frame = new Float32Array(512)
+    frame.set(signal)
+    const padded = new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, 64).calculateSpectrum(frame)
+
+    // Without the bufferSize / windowLength window scaling this would be 8x (-18 dB) off
+    expect(padded.length).toBe(256)
+    expect(padded[64]).toBeCloseTo(unpadded[8], 5)
+  })
+
+  it('produces finite, correctly sized output for non-linear scales with a padded FFT', () => {
+    const fftSamples = 64
+    const fftSize = 512
+    const frame = new Float32Array(fftSize)
+    frame.set(makeSine(fftSamples, 1000, SAMPLE_RATE))
+    const spectrum = new (FFT as any)(fftSize, SAMPLE_RATE, 'hann', undefined, fftSamples).calculateSpectrum(frame)
+
+    for (const scale of SCALES) {
+      const filterBank = createSparseFilterBankForScale(scale, fftSize / 2, fftSize, SAMPLE_RATE)!
+      const mapped = applySparseFilterBank(spectrum, filterBank)
+      expect(mapped.length).toBe(fftSize / 2)
+      expect(Array.from(mapped).every(Number.isFinite)).toBe(true)
+    }
+  })
+
+  it('masks stale samples beyond the window with the zeroed window tail', () => {
+    const signal = makeSine(64, 1000, SAMPLE_RATE)
+    const fft = new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, 64)
+
+    const cleanFrame = new Float32Array(512)
+    cleanFrame.set(signal)
+    const staleFrame = new Float32Array(512).fill(0.5)
+    staleFrame.set(signal)
+
+    expect(Array.from(fft.calculateSpectrum(staleFrame))).toEqual(Array.from(fft.calculateSpectrum(cleanFrame)))
+  })
+
+  it('throws when windowLength exceeds the buffer size', () => {
+    expect(() => new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, 1024)).toThrow()
+  })
+
+  it('throws when windowLength is shorter than two samples', () => {
+    // Window formulas divide by (windowLength - 1): a one-sample window would yield NaN spectra
+    expect(() => new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, 1)).toThrow()
+  })
+
+  it('rejects explicit invalid windowLength values instead of coercing them', () => {
+    expect(() => new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, 0)).toThrow()
+    expect(() => new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, NaN)).toThrow()
+    expect(() => new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, 80.5)).toThrow()
+    expect(() => new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, -64)).toThrow()
   })
 })

--- a/src/__tests__/fft.test.ts
+++ b/src/__tests__/fft.test.ts
@@ -1,0 +1,70 @@
+import {
+  applyFilterBank,
+  applySparseFilterBank,
+  createFilterBankForScale,
+  createSparseFilterBankForScale,
+} from '../fft.js'
+
+const SCALES = ['mel', 'logarithmic', 'bark', 'erb'] as const
+
+/** Deterministic pseudo-random spectrum (LCG) so parity failures are reproducible */
+function makeSpectrum(length: number, seed = 1): Float32Array {
+  const spectrum = new Float32Array(length)
+  let state = seed
+  for (let i = 0; i < length; i++) {
+    state = (state * 48271) % 2147483647
+    spectrum[i] = state / 2147483647
+  }
+  return spectrum
+}
+
+describe('sparse filter bank', () => {
+  it.each(SCALES)('produces byte-identical output to the dense filter bank for %s scale', (scale) => {
+    for (const [fftSamples, sampleRate] of [
+      [512, 44100],
+      [512, 16000],
+      [1024, 48000],
+      [64, 8000],
+    ]) {
+      const numFilters = fftSamples / 2
+      const dense = createFilterBankForScale(scale, numFilters, fftSamples, sampleRate)
+      const sparse = createSparseFilterBankForScale(scale, numFilters, fftSamples, sampleRate)
+      const spectrum = makeSpectrum(fftSamples / 2)
+
+      const denseOut = applyFilterBank(spectrum, dense!)
+      const sparseOut = applySparseFilterBank(spectrum, sparse!)
+
+      expect(sparseOut.length).toBe(denseOut.length)
+      expect(Array.from(sparseOut)).toEqual(Array.from(denseOut))
+    }
+  })
+
+  it('returns null for linear scale, like the dense variant', () => {
+    expect(createSparseFilterBankForScale('linear', 256, 512, 44100)).toBeNull()
+    expect(createFilterBankForScale('linear', 256, 512, 44100)).toBeNull()
+  })
+
+  it.each(SCALES)('stores exactly one two-tap entry per output row for %s scale', (scale) => {
+    const numFilters = 256
+    const sparse = createSparseFilterBankForScale(scale, numFilters, 512, 44100)!
+
+    expect(sparse.length).toBe(numFilters)
+    for (const { lo, weightLo, weightHi, centerHz } of sparse) {
+      expect(Number.isInteger(lo)).toBe(true)
+      expect(Number.isFinite(weightLo)).toBe(true)
+      expect(Number.isFinite(weightHi)).toBe(true)
+      expect(Number.isFinite(centerHz)).toBe(true)
+    }
+  })
+
+  it.each(SCALES)('stores monotonically increasing center frequencies up to Nyquist for %s scale', (scale) => {
+    const sampleRate = 44100
+    const sparse = createSparseFilterBankForScale(scale, 256, 512, sampleRate)!
+
+    for (let i = 1; i < sparse.length; i++) {
+      expect(sparse[i].centerHz).toBeGreaterThan(sparse[i - 1].centerHz)
+    }
+    expect(sparse[0].centerHz).toBeGreaterThanOrEqual(0)
+    expect(sparse[sparse.length - 1].centerHz).toBeLessThanOrEqual(sampleRate / 2)
+  })
+})

--- a/src/__tests__/spectrogram-fft-size.test.ts
+++ b/src/__tests__/spectrogram-fft-size.test.ts
@@ -1,0 +1,187 @@
+jest.mock(
+  'web-worker:./spectrogram-worker.ts',
+  () => ({
+    __esModule: true,
+    default: class MockSpectrogramWorker {
+      onmessage: ((e: { data: any }) => void) | null = null
+      onerror: ((e: Event) => void) | null = null
+      postMessage = jest.fn()
+      terminate = jest.fn()
+    },
+  }),
+  { virtual: true },
+)
+
+import Spectrogram from '../plugins/spectrogram.js'
+import WindowedSpectrogram from '../plugins/spectrogram-windowed.js'
+import '../plugins/spectrogram-worker.js'
+
+const SAMPLE_RATE = 8000
+
+function makeSine(length: number): Float32Array {
+  const signal = new Float32Array(length)
+  for (let i = 0; i < length; i++) {
+    signal[i] = Math.sin((2 * Math.PI * 1000 * i) / SAMPLE_RATE)
+  }
+  return signal
+}
+
+/** Dispatch a message to the worker handler and return its response synchronously */
+function runWorker(signal: Float32Array, options: Record<string, unknown>): Uint8Array[][] {
+  const postMessage = jest.fn()
+  ;(self as any).postMessage = postMessage
+  ;(self as any).onmessage({
+    data: {
+      type: 'calculateFrequencies',
+      id: 'test',
+      audioData: [signal],
+      options: {
+        startTime: 0,
+        endTime: signal.length / SAMPLE_RATE,
+        sampleRate: SAMPLE_RATE,
+        windowFunc: 'hann',
+        scale: 'linear',
+        gainDB: 20,
+        rangeDB: 80,
+        splitChannels: false,
+        ...options,
+      },
+    },
+  })
+  const response = postMessage.mock.calls[0][0]
+  expect(response.error).toBeUndefined()
+  return response.result
+}
+
+describe.each([
+  ['SpectrogramPlugin', Spectrogram],
+  ['WindowedSpectrogramPlugin', WindowedSpectrogram],
+])('%s fftSize option validation', (_name, Plugin: any) => {
+  it('rejects a non-power-of-two fftSize', () => {
+    expect(() => Plugin.create({ fftSize: 500 })).toThrow(TypeError)
+  })
+
+  it('rejects a non-power-of-two fftSamples when fftSize is not set', () => {
+    expect(() => Plugin.create({ fftSamples: 333 })).toThrow(TypeError)
+  })
+
+  it('rejects fftSamples larger than fftSize', () => {
+    expect(() => Plugin.create({ fftSamples: 1024, fftSize: 512 })).toThrow(TypeError)
+  })
+
+  it('rejects a non-integer fftSamples when fftSize is set', () => {
+    expect(() => Plugin.create({ fftSamples: 80.5, fftSize: 512 })).toThrow(TypeError)
+  })
+
+  it('rejects a non-integer noverlap', () => {
+    expect(() => Plugin.create({ noverlap: 100.5 })).toThrow(TypeError)
+  })
+
+  it('rejects one-sample windows, whose window formulas would produce NaN spectra', () => {
+    expect(() => Plugin.create({ fftSamples: 1 })).toThrow(TypeError)
+    expect(() => Plugin.create({ fftSamples: 1, fftSize: 512 })).toThrow(TypeError)
+  })
+
+  it('rejects explicit invalid fftSamples values when fftSize is set', () => {
+    expect(() => Plugin.create({ fftSamples: 0, fftSize: 512 })).toThrow(TypeError)
+    expect(() => Plugin.create({ fftSamples: NaN, fftSize: 512 })).toThrow(TypeError)
+    expect(() => Plugin.create({ fftSamples: -64, fftSize: 512 })).toThrow(TypeError)
+  })
+
+  it('keeps the historical coercion of falsy fftSamples when fftSize is not set', () => {
+    expect(() => Plugin.create({ fftSamples: 0 })).not.toThrow()
+    expect(() => Plugin.create({ fftSamples: NaN })).not.toThrow()
+  })
+
+  it('rejects large non-powers-of-two that fool 32-bit bitwise checks', () => {
+    expect(() => Plugin.create({ fftSize: 2 ** 32 + 1 })).toThrow(TypeError)
+  })
+
+  it('accepts a non-power-of-two window once fftSize carries the transform length', () => {
+    expect(() => Plugin.create({ fftSamples: 80, fftSize: 512 })).not.toThrow()
+    expect(() => Plugin.create({ fftSamples: 333, fftSize: 512 })).not.toThrow()
+  })
+
+  it('accepts the defaults unchanged', () => {
+    expect(() => Plugin.create({})).not.toThrow()
+  })
+})
+
+describe('worker compute with fftSize', () => {
+  it('adds frequency bins without changing the frame count', () => {
+    const signal = makeSine(4000)
+    const noverlap = 32
+
+    const unpadded = runWorker(signal, { fftSamples: 64, noverlap })
+    const padded = runWorker(signal, { fftSamples: 64, fftSize: 512, noverlap })
+
+    expect(padded[0].length).toBe(unpadded[0].length)
+    expect(unpadded[0][0].length).toBe(32)
+    expect(padded[0][0].length).toBe(256)
+  })
+
+  it('produces identical output when fftSize equals fftSamples', () => {
+    const signal = makeSine(4000)
+
+    const implicit = runWorker(signal, { fftSamples: 512, noverlap: 256 })
+    const explicit = runWorker(signal, { fftSamples: 512, fftSize: 512, noverlap: 256 })
+
+    expect(explicit.length).toBe(implicit.length)
+    explicit[0].forEach((frame: Uint8Array, i: number) => {
+      expect(Array.from(frame)).toEqual(Array.from(implicit[0][i]))
+    })
+  })
+
+  it('renders non-linear scales with a padded FFT (no all-zero output)', () => {
+    const signal = makeSine(4000)
+    const result = runWorker(signal, { fftSamples: 64, fftSize: 512, noverlap: 32, scale: 'mel' })
+
+    expect(result[0][0].length).toBe(256)
+    expect(result[0].some((frame) => frame.some((value: number) => value > 0))).toBe(true)
+  })
+
+  it('uses integer hops for non-power-of-two windows', () => {
+    const fftSamples = 333
+    const signal = makeSine(3000)
+    const result = runWorker(signal, { fftSamples, fftSize: 512, noverlap: 400 })
+
+    // noverlap capped at floor(333 / 2) = 166 -> hop = max(max(64, ceil(83.25)), 333 - 166) = 167
+    const hop = 167
+    const expectedFrames = Math.floor((signal.length - fftSamples - 1) / hop) + 1
+    expect(result[0].length).toBe(expectedFrames)
+    expect(result[0][0].length).toBe(256)
+  })
+
+  it('skips a frame ending exactly at the last sample (pre-existing bound)', () => {
+    const signal = makeSine(1024)
+    const result = runWorker(signal, { fftSamples: 256, noverlap: 128 })
+
+    // hop = 128; a frame starting at 768 would end exactly at 1024 and is skipped by the < bound
+    expect(result[0].length).toBe(6)
+  })
+})
+
+describe('main-thread compute with fftSize', () => {
+  it('matches the worker output byte for byte on the default (no worker) path', async () => {
+    const signal = makeSine(4000)
+    const plugin: any = Spectrogram.create({ fftSamples: 64, fftSize: 512, noverlap: 32, scale: 'mel' })
+    const buffer = {
+      sampleRate: SAMPLE_RATE,
+      length: signal.length,
+      duration: signal.length / SAMPLE_RATE,
+      numberOfChannels: 1,
+      getChannelData: () => signal,
+    } as unknown as AudioBuffer
+
+    const mainResult = await plugin.getFrequencies(buffer)
+    const workerResult = runWorker(signal, { fftSamples: 64, fftSize: 512, noverlap: 32, scale: 'mel' })
+
+    expect(mainResult.length).toBe(1)
+    expect(mainResult[0].length).toBe(workerResult[0].length)
+    expect(mainResult[0][0].length).toBe(256)
+    expect(mainResult[0].some((frame: Uint8Array) => frame.some((value) => value > 0))).toBe(true)
+    mainResult[0].forEach((frame: Uint8Array, i: number) => {
+      expect(Array.from(frame)).toEqual(Array.from(workerResult[0][i]))
+    })
+  })
+})

--- a/src/fft.ts
+++ b/src/fft.ts
@@ -576,8 +576,15 @@ export function createWrapperClickHandler(wrapper: HTMLElement, emit: (event: st
 /**
  * Calculate FFT - Based on https://github.com/corbanbrook/dsp.js
  */
-function FFT(bufferSize: number, sampleRate: number, windowFunc: string, alpha: number) {
+function FFT(bufferSize: number, sampleRate: number, windowFunc: string, alpha: number, windowLength?: number) {
+  // Absent values default to the full buffer; explicit values are validated, not coerced
+  windowLength = windowLength ?? bufferSize
+  if (!Number.isInteger(windowLength) || windowLength < 2 || windowLength > bufferSize) {
+    // Every window formula divides by (windowLength - 1) and the table has bufferSize entries
+    throw Error('windowLength must be an integer between 2 and bufferSize')
+  }
   this.bufferSize = bufferSize
+  this.windowLength = windowLength
   this.sampleRate = sampleRate
   this.bandwidth = (2 / bufferSize) * (sampleRate / 2)
 
@@ -591,68 +598,79 @@ function FFT(bufferSize: number, sampleRate: number, windowFunc: string, alpha: 
 
   switch (windowFunc) {
     case 'bartlett':
-      for (let i = 0; i < bufferSize; i++) {
-        this.windowValues[i] = (2 / (bufferSize - 1)) * ((bufferSize - 1) / 2 - Math.abs(i - (bufferSize - 1) / 2))
+      for (let i = 0; i < windowLength; i++) {
+        this.windowValues[i] =
+          (2 / (windowLength - 1)) * ((windowLength - 1) / 2 - Math.abs(i - (windowLength - 1) / 2))
       }
       break
     case 'bartlettHann':
-      for (let i = 0; i < bufferSize; i++) {
+      for (let i = 0; i < windowLength; i++) {
         this.windowValues[i] =
-          0.62 - 0.48 * Math.abs(i / (bufferSize - 1) - 0.5) - 0.38 * Math.cos((Math.PI * 2 * i) / (bufferSize - 1))
+          0.62 - 0.48 * Math.abs(i / (windowLength - 1) - 0.5) - 0.38 * Math.cos((Math.PI * 2 * i) / (windowLength - 1))
       }
       break
     case 'blackman':
       alpha = alpha || 0.16
-      for (let i = 0; i < bufferSize; i++) {
+      for (let i = 0; i < windowLength; i++) {
         this.windowValues[i] =
           (1 - alpha) / 2 -
-          0.5 * Math.cos((Math.PI * 2 * i) / (bufferSize - 1)) +
-          (alpha / 2) * Math.cos((4 * Math.PI * i) / (bufferSize - 1))
+          0.5 * Math.cos((Math.PI * 2 * i) / (windowLength - 1)) +
+          (alpha / 2) * Math.cos((4 * Math.PI * i) / (windowLength - 1))
       }
       break
     case 'cosine':
-      for (let i = 0; i < bufferSize; i++) {
-        this.windowValues[i] = Math.cos((Math.PI * i) / (bufferSize - 1) - Math.PI / 2)
+      for (let i = 0; i < windowLength; i++) {
+        this.windowValues[i] = Math.cos((Math.PI * i) / (windowLength - 1) - Math.PI / 2)
       }
       break
     case 'gauss':
       alpha = alpha || 0.25
-      for (let i = 0; i < bufferSize; i++) {
+      for (let i = 0; i < windowLength; i++) {
         this.windowValues[i] = Math.pow(
           Math.E,
-          -0.5 * Math.pow((i - (bufferSize - 1) / 2) / ((alpha * (bufferSize - 1)) / 2), 2),
+          -0.5 * Math.pow((i - (windowLength - 1) / 2) / ((alpha * (windowLength - 1)) / 2), 2),
         )
       }
       break
     case 'hamming':
-      for (let i = 0; i < bufferSize; i++) {
-        this.windowValues[i] = 0.54 - 0.46 * Math.cos((Math.PI * 2 * i) / (bufferSize - 1))
+      for (let i = 0; i < windowLength; i++) {
+        this.windowValues[i] = 0.54 - 0.46 * Math.cos((Math.PI * 2 * i) / (windowLength - 1))
       }
       break
     case 'hann':
     case undefined:
-      for (let i = 0; i < bufferSize; i++) {
-        this.windowValues[i] = 0.5 * (1 - Math.cos((Math.PI * 2 * i) / (bufferSize - 1)))
+      for (let i = 0; i < windowLength; i++) {
+        this.windowValues[i] = 0.5 * (1 - Math.cos((Math.PI * 2 * i) / (windowLength - 1)))
       }
       break
     case 'lanczoz':
-      for (let i = 0; i < bufferSize; i++) {
+      for (let i = 0; i < windowLength; i++) {
         this.windowValues[i] =
-          Math.sin(Math.PI * ((2 * i) / (bufferSize - 1) - 1)) / (Math.PI * ((2 * i) / (bufferSize - 1) - 1))
+          Math.sin(Math.PI * ((2 * i) / (windowLength - 1) - 1)) / (Math.PI * ((2 * i) / (windowLength - 1) - 1))
       }
       break
     case 'rectangular':
-      for (let i = 0; i < bufferSize; i++) {
+      for (let i = 0; i < windowLength; i++) {
         this.windowValues[i] = 1
       }
       break
     case 'triangular':
-      for (let i = 0; i < bufferSize; i++) {
-        this.windowValues[i] = (2 / bufferSize) * (bufferSize / 2 - Math.abs(i - (bufferSize - 1) / 2))
+      for (let i = 0; i < windowLength; i++) {
+        this.windowValues[i] = (2 / windowLength) * (windowLength / 2 - Math.abs(i - (windowLength - 1) / 2))
       }
       break
     default:
       throw Error("No such window function '" + windowFunc + "'")
+  }
+
+  // When the window is shorter than the FFT, the remaining table entries stay zero (zero
+  // padding) and the live samples are scaled up so the 2 / bufferSize magnitude
+  // normalization in calculateSpectrum() remains calibrated
+  if (windowLength < bufferSize) {
+    const windowScale = bufferSize / windowLength
+    for (let i = 0; i < windowLength; i++) {
+      this.windowValues[i] *= windowScale
+    }
   }
 
   let limit = 1
@@ -766,7 +784,9 @@ function FFT(bufferSize: number, sampleRate: number, windowFunc: string, alpha: 
 
 // TypeScript declaration for FFT class
 export declare class FFT {
-  constructor(bufferSize: number, sampleRate: number, windowFunc: string, alpha: number)
+  constructor(bufferSize: number, sampleRate: number, windowFunc: string, alpha: number, windowLength?: number)
+  bufferSize: number
+  windowLength: number
   calculateSpectrum(buffer: Float32Array): Float32Array
 }
 

--- a/src/fft.ts
+++ b/src/fft.ts
@@ -128,6 +128,8 @@ export function applyFilterBank(fftPoints: Float32Array, filterBank: number[][])
 }
 
 // Centralized filter bank creation based on scale type
+// Superseded by createSparseFilterBankForScale/applySparseFilterBank below; kept exported
+// for compatibility
 export function createFilterBankForScale(
   scale: 'linear' | 'logarithmic' | 'mel' | 'bark' | 'erb',
   numFilters: number,
@@ -143,6 +145,82 @@ export function createFilterBankForScale(
       return createFilterBank(numFilters, fftSamples, sampleRate, hzToBark, barkToHz)
     case 'erb':
       return createFilterBank(numFilters, fftSamples, sampleRate, hzToErb, erbToHz)
+    case 'linear':
+    default:
+      return null // No filter bank for linear scale
+  }
+}
+
+/**
+ * One output row of a sparse frequency-scale filter bank. Every row produced by
+ * createFilterBank() has exactly two adjacent non-zero taps, so storing just those (plus the
+ * row's center frequency) lets the bank be applied in O(filters) instead of O(filters × bins).
+ */
+export interface SparseFilter {
+  /** Index of the lower of the two adjacent FFT bins (the upper tap is lo + 1) */
+  lo: number
+  /** Weight of the lower bin */
+  weightLo: number
+  /** Weight of the upper bin */
+  weightHi: number
+  /** Center frequency of this output row in Hz */
+  centerHz: number
+}
+
+function createSparseFilterBank(
+  numFilters: number,
+  fftSamples: number,
+  sampleRate: number,
+  hzToScaleFunc: (hz: number) => number,
+  scaleToHzFunc: (scale: number) => number,
+): SparseFilter[] {
+  const filterMin = hzToScaleFunc(0)
+  const filterMax = hzToScaleFunc(sampleRate / 2)
+  const filterBank: SparseFilter[] = new Array(numFilters)
+  const scale = sampleRate / fftSamples
+
+  for (let i = 0; i < numFilters; i++) {
+    const hz = scaleToHzFunc(filterMin + (i / numFilters) * (filterMax - filterMin))
+    const j = Math.floor(hz / scale)
+    const hzLow = j * scale
+    const hzHigh = (j + 1) * scale
+    const r = (hz - hzLow) / (hzHigh - hzLow)
+    filterBank[i] = { lo: j, weightLo: 1 - r, weightHi: r, centerHz: hz }
+  }
+  return filterBank
+}
+
+export function applySparseFilterBank(fftPoints: Float32Array, filterBank: SparseFilter[]): Float32Array {
+  const numFilters = filterBank.length
+  const logSpectrum = new Float32Array(numFilters)
+  for (let i = 0; i < numFilters; i++) {
+    const { lo, weightLo, weightHi } = filterBank[i]
+    if (lo >= 0 && lo < fftPoints.length) {
+      logSpectrum[i] = fftPoints[lo] * weightLo
+    }
+    if (lo + 1 >= 0 && lo + 1 < fftPoints.length) {
+      logSpectrum[i] += fftPoints[lo + 1] * weightHi
+    }
+  }
+  return logSpectrum
+}
+
+// Sparse equivalent of createFilterBankForScale: same rows, same weights, O(filters) apply
+export function createSparseFilterBankForScale(
+  scale: 'linear' | 'logarithmic' | 'mel' | 'bark' | 'erb',
+  numFilters: number,
+  fftSamples: number,
+  sampleRate: number,
+): SparseFilter[] | null {
+  switch (scale) {
+    case 'mel':
+      return createSparseFilterBank(numFilters, fftSamples, sampleRate, hzToMel, melToHz)
+    case 'logarithmic':
+      return createSparseFilterBank(numFilters, fftSamples, sampleRate, hzToLog, logToHz)
+    case 'bark':
+      return createSparseFilterBank(numFilters, fftSamples, sampleRate, hzToBark, barkToHz)
+    case 'erb':
+      return createSparseFilterBank(numFilters, fftSamples, sampleRate, hzToErb, erbToHz)
     case 'linear':
     default:
       return null // No filter bank for linear scale

--- a/src/plugins/spectrogram-windowed.ts
+++ b/src/plugins/spectrogram-windowed.ts
@@ -28,8 +28,18 @@ import SpectrogramWorker from 'web-worker:./spectrogram-worker.ts'
 export type WindowedSpectrogramPluginOptions = {
   /** Selector of element or element in which to render */
   container?: string | HTMLElement
-  /** Number of samples to fetch to FFT. Must be a power of 2. */
+  /** Number of samples per analysis window. Must be a power of 2, unless fftSize is set (then any integer from 2 to fftSize). */
   fftSamples?: number
+  /**
+   * Length of the zero-padded FFT, in samples. Must be a power of two, and at least fftSamples.
+   * When set, each fftSamples-long analysis window is zero-padded to fftSize before the FFT, which
+   * only adds interpolated frequency bins (fftSize / 2 in total) - it does not improve the true
+   * frequency resolution, and the time resolution (window and hop) is unchanged. Same split as
+   * win_length vs n_fft in librosa/scipy or AnalyserNode.fftSize. When fftSize is set, fftSamples
+   * may be any integer from 2 up to fftSize (the power-of-two requirement moves to fftSize).
+   * (default: fftSamples)
+   */
+  fftSize?: number
   /** Height of the spectrogram view in CSS pixels */
   height?: number
   /** Set to true to display frequency labels. */
@@ -97,6 +107,10 @@ interface FrequencySegment {
   canvas?: HTMLCanvasElement
 }
 
+// Exact for all safe-integer powers of two; deliberately not bitwise (Int32 truncation would
+// accept values like 2^32 + 1)
+const isPowerOfTwo = (value: number) => Number.isInteger(value) && value >= 2 && Number.isInteger(Math.log2(value))
+
 class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEvents, WindowedSpectrogramPluginOptions> {
   private container: HTMLElement
   private wrapper: HTMLElement
@@ -104,6 +118,7 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
   private canvasContainer: HTMLElement
   private colorMap: number[][]
   private fftSamples: WindowedSpectrogramPluginOptions['fftSamples']
+  private fftSize: WindowedSpectrogramPluginOptions['fftSize']
   private height: WindowedSpectrogramPluginOptions['height']
   private noverlap: WindowedSpectrogramPluginOptions['noverlap']
   private windowFunc: WindowedSpectrogramPluginOptions['windowFunc']
@@ -157,9 +172,30 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     this.colorMap = setupColorMap(options.colorMap)
 
     // FFT and processing options
-    this.fftSamples = options.fftSamples || 512
+    this.fftSize = options.fftSize
+    // With fftSize set, fftSamples is a validated analysis-window length: only absent values get
+    // the default. Without it, the historical coercion of falsy values is preserved.
+    this.fftSamples = this.fftSize != null ? (options.fftSamples ?? 512) : options.fftSamples || 512
     this.height = options.height || 200
     this.noverlap = options.noverlap || null // Will be calculated later based on canvas size, like normal plugin
+
+    // The transform length must be a power of two; with fftSize set, fftSamples is just the
+    // analysis window length and only needs to fit inside the transform
+    const fftLength = this.fftSize ?? this.fftSamples
+    if (!isPowerOfTwo(fftLength)) {
+      throw new TypeError(
+        `fftSize (or fftSamples when fftSize is not set) must be a power of two and at least 2, got ${fftLength}`,
+      )
+    }
+    if (
+      this.fftSize != null &&
+      (!Number.isInteger(this.fftSamples) || this.fftSamples < 2 || this.fftSamples > this.fftSize)
+    ) {
+      throw new TypeError(`fftSamples must be an integer between 2 and fftSize, got ${this.fftSamples}`)
+    }
+    if (options.noverlap != null && !Number.isInteger(options.noverlap)) {
+      throw new TypeError(`noverlap must be an integer number of samples, got ${options.noverlap}`)
+    }
     this.windowFunc = options.windowFunc || 'hann'
     this.alpha = options.alpha
     this.frequencyMin = options.frequencyMin || 0
@@ -179,10 +215,10 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     this.useWebWorker = options.useWebWorker === true && typeof window !== 'undefined'
 
     // Filter banks
-    this.numMelFilters = this.fftSamples / 2
-    this.numLogFilters = this.fftSamples / 2
-    this.numBarkFilters = this.fftSamples / 2
-    this.numErbFilters = this.fftSamples / 2
+    this.numMelFilters = fftLength / 2
+    this.numLogFilters = fftLength / 2
+    this.numBarkFilters = fftLength / 2
+    this.numErbFilters = fftLength / 2
 
     this.createWrapper()
     this.createCanvas()
@@ -860,6 +896,7 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
             endTime,
             sampleRate,
             fftSamples: this.fftSamples,
+            fftSize: this.fftSize,
             windowFunc: this.windowFunc,
             alpha: this.alpha,
             noverlap,
@@ -887,9 +924,10 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     const endSample = Math.floor(endTime * sampleRate)
     const channels = this.options.splitChannels ? this.buffer.numberOfChannels : 1
 
-    // Initialize FFT if needed
-    if (!this.fft) {
-      this.fft = new FFT(this.fftSamples, sampleRate, this.windowFunc, this.alpha)
+    // Initialize FFT if needed; the window covers fftSamples samples, zero-padded up to fftLength
+    const fftLength = this.fftSize ?? this.fftSamples
+    if (!this.fft || this.fft.bufferSize !== fftLength || this.fft.windowLength !== this.fftSamples) {
+      this.fft = new FFT(fftLength, sampleRate, this.windowFunc, this.alpha, this.fftSamples)
     }
 
     // Calculate noverlap like the normal plugin
@@ -902,10 +940,11 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
       noverlap = Math.max(0, Math.round(this.fftSamples - uniqueSamplesPerPx))
     }
 
-    // OPTIMIZATION: For windowed mode, reduce overlap to speed up processing
-    const maxOverlap = this.fftSamples * 0.5
+    // OPTIMIZATION: For windowed mode, reduce overlap to speed up processing; integer
+    // arithmetic so non-power-of-two windows cannot produce fractional frame starts
+    const maxOverlap = Math.floor(this.fftSamples / 2)
     noverlap = Math.min(noverlap, maxOverlap)
-    const minHopSize = Math.max(64, this.fftSamples * 0.25)
+    const minHopSize = Math.max(64, Math.ceil(this.fftSamples * 0.25))
     const hopSize = Math.max(minHopSize, this.fftSamples - noverlap)
 
     const frequencies: Uint8Array[][] = []
@@ -916,13 +955,16 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     // Create the filter bank once for all frames and channels
     const filterBank = this.getFilterBank(sampleRate)
 
+    // One reused frame buffer; the zero tail beyond fftSamples doubles as the FFT padding
+    const frame = new Float32Array(fftLength)
+
     for (let c = 0; c < channels; c++) {
       const channelData = this.buffer.getChannelData(c)
       const channelFreq: Uint8Array[] = []
 
       for (let sample = startSample; sample + this.fftSamples < endSample; sample += hopSize) {
-        const segment = channelData.slice(sample, sample + this.fftSamples)
-        let spectrum = this.fft.calculateSpectrum(segment)
+        frame.set(channelData.subarray(sample, sample + this.fftSamples))
+        let spectrum = this.fft.calculateSpectrum(frame)
         totalFFTs++
 
         // Apply filter bank if needed
@@ -1065,8 +1107,9 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
   }
 
   private getFilterBank(sampleRate: number) {
-    const numFilters = this.fftSamples / 2
-    return createSparseFilterBankForScale(this.scale, numFilters, this.fftSamples, sampleRate)
+    const fftLength = this.fftSize ?? this.fftSamples
+    const numFilters = fftLength / 2
+    return createSparseFilterBankForScale(this.scale, numFilters, fftLength, sampleRate)
   }
 
   private _onWrapperClick = (e: MouseEvent) => {

--- a/src/plugins/spectrogram-windowed.ts
+++ b/src/plugins/spectrogram-windowed.ts
@@ -13,8 +13,8 @@ import createElement, { isHTMLElement } from '../dom.js'
 import FFT, {
   hzToScale,
   scaleToHz,
-  createFilterBankForScale,
-  applyFilterBank,
+  createSparseFilterBankForScale,
+  applySparseFilterBank,
   setupColorMap,
   freqType,
   unitType,
@@ -913,6 +913,9 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     const fftStartTime = performance.now()
     let totalFFTs = 0
 
+    // Create the filter bank once for all frames and channels
+    const filterBank = this.getFilterBank(sampleRate)
+
     for (let c = 0; c < channels; c++) {
       const channelData = this.buffer.getChannelData(c)
       const channelFreq: Uint8Array[] = []
@@ -923,9 +926,8 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
         totalFFTs++
 
         // Apply filter bank if needed
-        const filterBank = this.getFilterBank(sampleRate)
         if (filterBank) {
-          spectrum = applyFilterBank(spectrum, filterBank)
+          spectrum = applySparseFilterBank(spectrum, filterBank)
         }
 
         // Convert to uint8 color indices
@@ -1062,9 +1064,9 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     this.segments.clear()
   }
 
-  private getFilterBank(sampleRate: number): number[][] | null {
+  private getFilterBank(sampleRate: number) {
     const numFilters = this.fftSamples / 2
-    return createFilterBankForScale(this.scale, numFilters, this.fftSamples, sampleRate)
+    return createSparseFilterBankForScale(this.scale, numFilters, this.fftSamples, sampleRate)
   }
 
   private _onWrapperClick = (e: MouseEvent) => {

--- a/src/plugins/spectrogram-worker.ts
+++ b/src/plugins/spectrogram-worker.ts
@@ -4,7 +4,7 @@
  */
 
 // Import centralized FFT functionality
-import FFT, { createFilterBankForScale, applyFilterBank } from '../fft.js'
+import FFT, { createSparseFilterBankForScale, applySparseFilterBank } from '../fft.js'
 
 // Global FFT instance (reused for performance)
 let fft: FFT | null = null
@@ -88,7 +88,7 @@ function calculateFrequencies(audioChannels: Float32Array[], options: WorkerMess
 
   // Create filter bank based on scale using centralized function
   const numFilters = fftSamples / 2 // Same as main thread
-  const filterBank = createFilterBankForScale(scale, numFilters, fftSamples, sampleRate)
+  const filterBank = createSparseFilterBankForScale(scale, numFilters, fftSamples, sampleRate)
 
   // Calculate hop size
   let actualNoverlap = noverlap || Math.max(0, Math.round(fftSamples * 0.5))
@@ -109,7 +109,7 @@ function calculateFrequencies(audioChannels: Float32Array[], options: WorkerMess
 
       // Apply filter bank if specified (same as main thread)
       if (filterBank) {
-        spectrum = applyFilterBank(spectrum, filterBank)
+        spectrum = applySparseFilterBank(spectrum, filterBank)
       }
 
       // Convert to uint8 color indices

--- a/src/plugins/spectrogram-worker.ts
+++ b/src/plugins/spectrogram-worker.ts
@@ -18,6 +18,7 @@ interface WorkerMessage {
     endTime: number
     sampleRate: number
     fftSamples: number
+    fftSize?: number
     windowFunc: string
     alpha?: number
     noverlap: number
@@ -68,6 +69,7 @@ function calculateFrequencies(audioChannels: Float32Array[], options: WorkerMess
     endTime,
     sampleRate,
     fftSamples,
+    fftSize,
     windowFunc,
     alpha,
     noverlap,
@@ -80,32 +82,38 @@ function calculateFrequencies(audioChannels: Float32Array[], options: WorkerMess
   const startSample = Math.floor(startTime * sampleRate)
   const endSample = Math.floor(endTime * sampleRate)
   const channels = splitChannels ? audioChannels.length : 1
+  const fftLength = fftSize ?? fftSamples
 
-  // Initialize FFT (reuse if possible for performance)
-  if (!fft || fft.bufferSize !== fftSamples) {
-    fft = new (FFT as any)(fftSamples, sampleRate, windowFunc, alpha)
+  // Initialize FFT (reuse if possible for performance); the window covers fftSamples samples,
+  // zero-padded up to fftLength
+  if (!fft || fft.bufferSize !== fftLength || fft.windowLength !== fftSamples) {
+    fft = new (FFT as any)(fftLength, sampleRate, windowFunc, alpha, fftSamples)
   }
 
   // Create filter bank based on scale using centralized function
-  const numFilters = fftSamples / 2 // Same as main thread
-  const filterBank = createSparseFilterBankForScale(scale, numFilters, fftSamples, sampleRate)
+  const numFilters = fftLength / 2 // Same as main thread
+  const filterBank = createSparseFilterBankForScale(scale, numFilters, fftLength, sampleRate)
 
-  // Calculate hop size
+  // Calculate hop size; integer arithmetic so non-power-of-two windows cannot produce
+  // fractional frame starts
   let actualNoverlap = noverlap || Math.max(0, Math.round(fftSamples * 0.5))
-  const maxOverlap = fftSamples * 0.5
+  const maxOverlap = Math.floor(fftSamples / 2)
   actualNoverlap = Math.min(actualNoverlap, maxOverlap)
-  const minHopSize = Math.max(64, fftSamples * 0.25)
+  const minHopSize = Math.max(64, Math.ceil(fftSamples * 0.25))
   const hopSize = Math.max(minHopSize, fftSamples - actualNoverlap)
 
   const frequencies: Uint8Array[][] = []
+
+  // One reused frame buffer; the zero tail beyond fftSamples doubles as the FFT padding
+  const frame = new Float32Array(fftLength)
 
   for (let c = 0; c < channels; c++) {
     const channelData = audioChannels[c]
     const channelFreq: Uint8Array[] = []
 
     for (let sample = startSample; sample + fftSamples < endSample; sample += hopSize) {
-      const segment = channelData.slice(sample, sample + fftSamples)
-      let spectrum = fft.calculateSpectrum(segment)
+      frame.set(channelData.subarray(sample, sample + fftSamples))
+      let spectrum = fft.calculateSpectrum(frame)
 
       // Apply filter bank if specified (same as main thread)
       if (filterBank) {

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -45,8 +45,18 @@ import SpectrogramWorker from 'web-worker:./spectrogram-worker.ts'
 export type SpectrogramPluginOptions = {
   /** Selector of element or element in which to render */
   container?: string | HTMLElement
-  /** Number of samples to fetch to FFT. Must be a power of 2. */
+  /** Number of samples per analysis window. Must be a power of 2, unless fftSize is set (then any integer from 2 to fftSize). */
   fftSamples?: number
+  /**
+   * Length of the zero-padded FFT, in samples. Must be a power of two, and at least fftSamples.
+   * When set, each fftSamples-long analysis window is zero-padded to fftSize before the FFT, which
+   * only adds interpolated frequency bins (fftSize / 2 in total) - it does not improve the true
+   * frequency resolution, and the time resolution (window and hop) is unchanged. Same split as
+   * win_length vs n_fft in librosa/scipy or AnalyserNode.fftSize. When fftSize is set, fftSamples
+   * may be any integer from 2 up to fftSize (the power-of-two requirement moves to fftSize).
+   * (default: fftSamples)
+   */
+  fftSize?: number
   /** Height of the spectrogram view in CSS pixels */
   height?: number
   /** Set to true to display frequency labels. */
@@ -125,6 +135,10 @@ export type SpectrogramPluginEvents = BasePluginEvents & {
   click: [relativeX: number]
 }
 
+// Exact for all safe-integer powers of two; deliberately not bitwise (Int32 truncation would
+// accept values like 2^32 + 1)
+const isPowerOfTwo = (value: number) => Number.isInteger(value) && value >= 2 && Number.isInteger(Math.log2(value))
+
 class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramPluginOptions> {
   private static MAX_CANVAS_WIDTH = 30000
   private static MAX_NODES = 10
@@ -137,6 +151,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
   private canvasContainer: HTMLElement
   private colorMap: number[][]
   private fftSamples: SpectrogramPluginOptions['fftSamples']
+  private fftSize: SpectrogramPluginOptions['fftSize']
   private height: SpectrogramPluginOptions['height']
   private noverlap: SpectrogramPluginOptions['noverlap']
   private windowFunc: SpectrogramPluginOptions['windowFunc']
@@ -198,9 +213,30 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
     // Set up color map using shared utility
     this.colorMap = setupColorMap(options.colorMap)
 
-    this.fftSamples = options.fftSamples || 512
+    this.fftSize = options.fftSize
+    // With fftSize set, fftSamples is a validated analysis-window length: only absent values get
+    // the default. Without it, the historical coercion of falsy values is preserved.
+    this.fftSamples = this.fftSize != null ? (options.fftSamples ?? 512) : options.fftSamples || 512
     this.height = options.height || 200
     this.noverlap = options.noverlap || null // Will be calculated later based on canvas size
+
+    // The transform length must be a power of two; with fftSize set, fftSamples is just the
+    // analysis window length and only needs to fit inside the transform
+    const fftLength = this.fftSize ?? this.fftSamples
+    if (!isPowerOfTwo(fftLength)) {
+      throw new TypeError(
+        `fftSize (or fftSamples when fftSize is not set) must be a power of two and at least 2, got ${fftLength}`,
+      )
+    }
+    if (
+      this.fftSize != null &&
+      (!Number.isInteger(this.fftSamples) || this.fftSamples < 2 || this.fftSamples > this.fftSize)
+    ) {
+      throw new TypeError(`fftSamples must be an integer between 2 and fftSize, got ${this.fftSamples}`)
+    }
+    if (options.noverlap != null && !Number.isInteger(options.noverlap)) {
+      throw new TypeError(`noverlap must be an integer number of samples, got ${options.noverlap}`)
+    }
     this.windowFunc = options.windowFunc || 'hann'
     this.alpha = options.alpha
 
@@ -213,11 +249,12 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
     this.rangeDB = options.rangeDB ?? 80
     this.scale = options.scale || 'mel'
 
-    // Other values will currently cause a misalignment between labels and the spectrogram
-    this.numMelFilters = this.fftSamples / 2
-    this.numLogFilters = this.fftSamples / 2
-    this.numBarkFilters = this.fftSamples / 2
-    this.numErbFilters = this.fftSamples / 2
+    // Rendering and labels derive their geometry from the computed data, so these follow the
+    // transform length
+    this.numMelFilters = fftLength / 2
+    this.numLogFilters = fftLength / 2
+    this.numBarkFilters = fftLength / 2
+    this.numErbFilters = fftLength / 2
 
     // Override the default max canvas width if provided
     if (options.maxCanvasWidth) {
@@ -887,6 +924,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
             endTime: buffer.duration,
             sampleRate: buffer.sampleRate,
             fftSamples: this.fftSamples,
+            fftSize: this.fftSize,
             windowFunc: this.windowFunc,
             alpha: this.alpha,
             noverlap,
@@ -923,6 +961,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
     }
 
     const fftSamples = this.fftSamples
+    const fftLength = this.fftSize ?? fftSamples
     const channels =
       (this.options.splitChannels ?? this.wavesurfer?.options.splitChannels) ? buffer.numberOfChannels : 1
 
@@ -938,19 +977,24 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
       noverlap = Math.max(0, Math.round(fftSamples - uniqueSamplesPerPx))
     }
 
-    // Calculate hop size (same as worker for consistency)
+    // Calculate hop size (same as worker for consistency); integer arithmetic so non-power-of-two
+    // windows cannot produce fractional frame starts
     let actualNoverlap = noverlap || Math.max(0, Math.round(fftSamples * 0.5))
-    const maxOverlap = fftSamples * 0.5
+    const maxOverlap = Math.floor(fftSamples / 2)
     actualNoverlap = Math.min(actualNoverlap, maxOverlap)
-    const minHopSize = Math.max(64, fftSamples * 0.25)
+    const minHopSize = Math.max(64, Math.ceil(fftSamples * 0.25))
     const hopSize = Math.max(minHopSize, fftSamples - actualNoverlap)
 
-    // Create FFT instance (reuse if possible for performance)
-    const fft = new FFT(fftSamples, sampleRate, this.windowFunc, this.alpha)
+    // Create FFT instance (reuse if possible for performance); the window covers fftSamples
+    // samples, zero-padded up to fftLength
+    const fft = new FFT(fftLength, sampleRate, this.windowFunc, this.alpha, fftSamples)
 
     // Create filter bank based on scale using centralized function
-    const numFilters = this.fftSamples / 2
-    const filterBank = createSparseFilterBankForScale(this.scale, numFilters, this.fftSamples, sampleRate)
+    const numFilters = fftLength / 2
+    const filterBank = createSparseFilterBankForScale(this.scale, numFilters, fftLength, sampleRate)
+
+    // One reused frame buffer; the zero tail beyond fftSamples doubles as the FFT padding
+    const frame = new Float32Array(fftLength)
 
     for (let c = 0; c < channels; c++) {
       // for each channel
@@ -959,8 +1003,8 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
 
       // Use same hop size calculation as worker for consistency
       for (let sample = 0; sample + fftSamples < channelData.length; sample += hopSize) {
-        const segment = channelData.slice(sample, sample + fftSamples)
-        let spectrum = fft.calculateSpectrum(segment)
+        frame.set(channelData.subarray(sample, sample + fftSamples))
+        let spectrum = fft.calculateSpectrum(frame)
 
         if (filterBank) {
           spectrum = applySparseFilterBank(spectrum, filterBank)

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -24,8 +24,8 @@
 import FFT, {
   hzToScale,
   scaleToHz,
-  createFilterBankForScale,
-  applyFilterBank,
+  createSparseFilterBankForScale,
+  applySparseFilterBank,
   setupColorMap,
   freqType,
   unitType,
@@ -950,7 +950,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
 
     // Create filter bank based on scale using centralized function
     const numFilters = this.fftSamples / 2
-    const filterBank = createFilterBankForScale(this.scale, numFilters, this.fftSamples, sampleRate)
+    const filterBank = createSparseFilterBankForScale(this.scale, numFilters, this.fftSamples, sampleRate)
 
     for (let c = 0; c < channels; c++) {
       // for each channel
@@ -963,7 +963,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
         let spectrum = fft.calculateSpectrum(segment)
 
         if (filterBank) {
-          spectrum = applyFilterBank(spectrum, filterBank)
+          spectrum = applySparseFilterBank(spectrum, filterBank)
         }
 
         // Convert to uint8 color indices


### PR DESCRIPTION
## Short description

`fftSamples` currently sets both the analysis window and the FFT length, so short windows (needed for good time resolution on speech) yield very few frequency bins — `fftSamples: 64` gives 32 rows that get stretched to the full band height. The new `fftSize` option zero-pads each `fftSamples`-long window to a longer FFT, adding interpolated bins (`fftSize / 2` in total) without touching the window, hop, or time resolution. It's the same `win_length` / `n_fft` split as librosa and scipy, and the same name as WebAudio's `AnalyserNode.fftSize` (already used in this repo by the Record plugin).

To be clear about what it does and doesn't do: zero-padding interpolates the spectrum for a smoother image — it does not improve true frequency resolution.

## Implementation details

Two commits, and the first one stands on its own:

**1. `perf(Spectrogram): apply frequency scales with a sparse two-tap mapper`.** Every filter row that `createFilterBank()` builds has exactly two adjacent non-zero taps, but `applyFilterBank()` scans every FFT bin for every row — O(filters × bins) per frame. At the current defaults (`scale: 'mel'`, `fftSamples: 512`, hop 256) that's ~2.5 billion multiply-adds for a 10-minute 16 kHz file: ~4.8s of pure filter work in Node. The sparse mapper stores just the two taps per row (`{ lo, weightLo, weightHi, centerHz }`) and applies in O(filters): ~30ms for the same file, ~160x. Output is byte-identical (pinned by jest parity tests across mel/logarithmic/bark/erb). The windowed plugin was also rebuilding the bank on every frame inside its FFT loop — it's now created once per computation. The old dense exports stay in place since they're public via `dist/fft.js`.

Without this, `fftSize` would make non-linear scales quadratically worse; with it, they get much faster than today even when padded.

**2. The `fftSize` option.** `FFT` takes an optional `windowLength`: the window is built over `windowLength` samples, scaled by `bufferSize / windowLength` so the `2 / bufferSize` magnitude normalization stays calibrated, zeros beyond (the zero tail also masks any stale samples in the reused frame buffer). Both plugins and the worker compute with `fftLength = fftSize ?? fftSamples` — one reused zero-padded frame buffer per compute, `subarray()` reads instead of a per-frame `slice()` allocation.

A useful side effect: with `fftSize` set, `fftSamples` may be any integer from 2 to `fftSize` — the power-of-two requirement moves to the transform length. That unlocks exact speech-analysis windows like 5 ms at 16 kHz (80 samples), which the pow-2 constraint made impossible. Hop arithmetic is pinned to integers (`floor`/`ceil`) so non-pow-2 windows can't produce fractional frame starts; the values are unchanged at pow-2 sizes.

Validation is strict `TypeError`s from the constructor: the transform length must be a power of two (checked with a JS-number-safe predicate, not 32-bit bitwise), `fftSamples` an integer from 2 to `fftSize`, `noverlap` an integer. One behavior note: a non-pow-2 `fftSamples` without `fftSize` now fails at construction with a clear message instead of mid-render inside `calculateSpectrum`.

Heads-up on two open PRs of mine that touch adjacent lines: #4327 (worker alpha default) overlaps the worker FFT-construction line, and #4328 (worker error rejection) overlaps the windowed plugin's postMessage block. Whichever lands second I'll rebase — the resolutions are trivial.

## How to test it

`npm run test:unit` — 48 new tests cover sparse/dense parity, padding calibration (the test fails by −18 dB if the window scaling is dropped), validation, integer hops, and byte-parity between the main-thread and worker paths. In the browser: spectrogram example with `fftSamples: 64` and then `fftSamples: 64, fftSize: 512` — same time resolution, 8x the frequency bins. Verified worker-on/off renders are pixel-identical with `fftSize` set, and all five scales render correctly with a padded FFT.

## Screenshots

`demo.wav` @ 16 kHz, `scale: 'linear'`, `frequencyMax: 4000`, `fftSamples: 64` (4 ms window):

| | |
|---|---|
| `fftSamples: 64` | ![without fftSize](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-fft-size/fft64-no-fftsize.png) |
| `fftSamples: 64, fftSize: 512` | ![with fftSize 512](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-fft-size/fft64-fftsize512.png) |
| mel scale with `fftSize: 512` | ![mel scale](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-fft-size/scales-mel-fftsize.png) |
| stereo `splitChannels` with `fftSize: 512` | ![stereo split](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-fft-size/stereo-split-fftsize.png) |

## Checklist
* [ ] This PR is covered by e2e tests — the spectrogram e2e suite is currently disabled (`xdescribe`); the numeric behavior is covered by the new jest suites (sparse parity, padding calibration, hop/frame-count pins, main-vs-worker byte parity) and verified manually in Chrome across all scales.
* [x] It introduces no breaking API changes
