### PR TITLE
feat(Spectrogram): Praat-style display pre-emphasis and automatic gain

### DIFF
--- a/examples/spectrogram.js
+++ b/examples/spectrogram.js
@@ -59,6 +59,11 @@ ws.registerPlugin(
     // gainDB: 20,        // Brightness adjustment (default: 20dB)
     // rangeDB: 80,       // Dynamic range (default: 80dB)
     //
+    // Praat-style display options (combine with windowFunc: 'gauss', scale: 'linear',
+    // colorMap: 'gray' and rangeDB: 70 for the classic Praat look):
+    // preEmphasis: 6,    // dB/octave boost above 1 kHz so speech formants stay visible
+    // autoGain: true,    // Map the loudest bin to black instead of using the fixed gainDB
+    //
     // Overlap between FFT windows:
     // noverlap: null,    // Auto-calculated by default, or set manually
     //
@@ -131,6 +136,8 @@ ws.on('spectrogram-click', (relativeX) => {
       <li><code>colorMap: 'gray'|'igray'|'roseus'</code> - Color scheme for frequency intensity</li>
       <li><code>gainDB: 20</code> - Brightness adjustment (-20 to +40)</li>
       <li><code>rangeDB: 80</code> - Dynamic range (20 to 120)</li>
+      <li><code>preEmphasis: 6</code> - Praat-style dB/octave display tilt around 1 kHz</li>
+      <li><code>autoGain: true</code> - Praat-style autoscaling of the white point</li>
       <li><code>windowFunc: 'hann'</code> - FFT window function (hann, hamming, blackman, etc.)</li>
     </ul>
     

--- a/src/__tests__/fft.test.ts
+++ b/src/__tests__/fft.test.ts
@@ -4,6 +4,11 @@ import FFT, {
   createFilterBankForScale,
   createSparseFilterBankForScale,
   magnitudesToColorIndices,
+  magnitudesToDb,
+  dbToColorIndices,
+  createPreEmphasisTilt,
+  getBinFrequencies,
+  SILENCE_FLOOR_DB,
 } from '../fft.js'
 
 const SCALES = ['mel', 'logarithmic', 'bark', 'erb'] as const
@@ -212,5 +217,78 @@ describe('magnitudesToColorIndices', () => {
     expect(() => magnitudesToColorIndices(spectrum, -20, -80)).toThrow(TypeError)
     expect(() => magnitudesToColorIndices(spectrum, -20, NaN)).toThrow(TypeError)
     expect(() => magnitudesToColorIndices(spectrum, Infinity, 80)).toThrow(TypeError)
+  })
+})
+
+describe('preEmphasis tilt and autoGain helpers', () => {
+  it('computes the Praat tilt: -6/0/+6 dB at 500/1000/2000 Hz for preEmphasis 6', () => {
+    const tilt = createPreEmphasisTilt(6, [500, 1000, 2000])
+    expect(tilt[0]).toBeCloseTo(-6, 10)
+    expect(tilt[1]).toBeCloseTo(0, 10)
+    expect(tilt[2]).toBeCloseTo(6, 10)
+  })
+
+  it('sends the DC bin toward -infinity instead of NaN (the 1e-308 guard)', () => {
+    const tilt = createPreEmphasisTilt(6, [0, 1000])
+    expect(Number.isFinite(tilt[0])).toBe(true)
+    expect(tilt[0]).toBeLessThan(-6000)
+  })
+
+  it('rejects non-finite preEmphasis', () => {
+    expect(() => createPreEmphasisTilt(NaN, [1000])).toThrow(TypeError)
+    expect(() => createPreEmphasisTilt(Infinity, [1000])).toThrow(TypeError)
+  })
+
+  it('derives bin frequencies from linear bins or the sparse scale rows', () => {
+    const linear = getBinFrequencies(null, 512, 16000)
+    expect(linear.length).toBe(256)
+    expect(linear[0]).toBe(0)
+    expect(linear[64]).toBe((64 * 16000) / 512)
+
+    const bank = createSparseFilterBankForScale('mel', 256, 512, 16000)!
+    const scaled = getBinFrequencies(bank, 512, 16000)
+    expect(Array.from(scaled)).toEqual(bank.map((filter) => filter.centerHz))
+  })
+
+  it('rejects a tilt whose length does not match the spectrum', () => {
+    const spectrum = new Float32Array(8)
+    const tilt = createPreEmphasisTilt(6, [1000])
+    expect(() => magnitudesToColorIndices(spectrum, -20, 80, tilt)).toThrow(TypeError)
+    expect(() => magnitudesToDb(spectrum, tilt)).toThrow(TypeError)
+  })
+
+  it('reuses the out buffer in magnitudesToDb when shapes match', () => {
+    const spectrum = Float32Array.from([1, 0.1, 0.01])
+    const out = new Float32Array(3)
+    expect(magnitudesToDb(spectrum, null, out)).toBe(out)
+    expect(out[0]).toBeCloseTo(0, 5)
+    expect(out[1]).toBeCloseTo(-20, 4)
+  })
+
+  it('maps the exact white point to 255 in dbToColorIndices (autoGain semantics)', () => {
+    const db = Float32Array.from([-10, -30, -90, -200])
+    const indices = dbToColorIndices(db, -10, 80)
+    expect(indices[0]).toBe(255) // valueDB === whiteDb -> 255, not the wrapped 0
+    expect(indices[3]).toBe(0) // below whiteDb - rangeDB
+    expect(indices[1]).toBeGreaterThan(0)
+    expect(indices[1]).toBeLessThan(255)
+    expect(indices[1]).toBeGreaterThan(indices[2])
+  })
+
+  it('rejects invalid whiteDb/rangeDB in dbToColorIndices', () => {
+    const db = new Float32Array(4)
+    expect(() => dbToColorIndices(db, NaN, 80)).toThrow(TypeError)
+    expect(() => dbToColorIndices(db, -20, 0)).toThrow(TypeError)
+    expect(() => dbToColorIndices(db, -20, -1)).toThrow(TypeError)
+  })
+
+  it('exports a silence floor far below real signal levels', () => {
+    expect(SILENCE_FLOOR_DB).toBe(-180)
+  })
+
+  it('honors an explicit blackman alpha of 0 instead of coercing it to the default', () => {
+    const explicitZero = new (FFT as any)(64, 8000, 'blackman', 0)
+    const defaulted = new (FFT as any)(64, 8000, 'blackman', undefined)
+    expect(explicitZero.windowValues[10]).not.toBe(defaulted.windowValues[10])
   })
 })

--- a/src/__tests__/fft.test.ts
+++ b/src/__tests__/fft.test.ts
@@ -3,6 +3,7 @@ import FFT, {
   applySparseFilterBank,
   createFilterBankForScale,
   createSparseFilterBankForScale,
+  magnitudesToColorIndices,
 } from '../fft.js'
 
 const SCALES = ['mel', 'logarithmic', 'bark', 'erb'] as const
@@ -145,5 +146,71 @@ describe('FFT zero-padding (windowLength)', () => {
     expect(() => new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, NaN)).toThrow()
     expect(() => new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, 80.5)).toThrow()
     expect(() => new (FFT as any)(512, SAMPLE_RATE, 'hann', undefined, -64)).toThrow()
+  })
+})
+
+describe('magnitudesToColorIndices', () => {
+  /** The exact inline loop this helper replaced in all three plugins */
+  function legacyLoop(spectrum: Float32Array, gainDB: number, rangeDB: number): Uint8Array {
+    const freqBins = new Uint8Array(spectrum.length)
+    const gainPlusRange = gainDB + rangeDB
+    for (let j = 0; j < spectrum.length; j++) {
+      const magnitude = spectrum[j] > 1e-12 ? spectrum[j] : 1e-12
+      const valueDB = 20 * Math.log10(magnitude)
+      if (valueDB < -gainPlusRange) {
+        freqBins[j] = 0
+      } else if (valueDB > -gainDB) {
+        freqBins[j] = 255
+      } else {
+        freqBins[j] = Math.round(((valueDB + gainDB) / rangeDB) * 255)
+      }
+    }
+    return freqBins
+  }
+
+  const dbToMagnitude = (db: number) => Math.pow(10, db / 20)
+
+  it('is byte-identical to the inline loop it replaced, including boundary and wrap values', () => {
+    const gainDB = 20
+    const rangeDB = 80
+    // Magnitudes spanning silence, the 1e-12 floor, the full ramp, both clip branches, and
+    // values just around the -gainDB white point where the historical arithmetic wraps
+    const values: number[] = [0, 1e-15, 1e-12, 2e-12, 1]
+    for (let db = -140; db <= 20; db += 0.37) {
+      values.push(dbToMagnitude(db))
+    }
+    for (const db of [-100.001, -100, -99.999, -20.2, -20.157, -20.1, -20.001, -20, -19.999]) {
+      values.push(dbToMagnitude(db))
+    }
+    const spectrum = Float32Array.from(values)
+
+    expect(Array.from(magnitudesToColorIndices(spectrum, -gainDB, rangeDB))).toEqual(
+      Array.from(legacyLoop(spectrum, gainDB, rangeDB)),
+    )
+  })
+
+  it('is byte-identical to the inline loop across gain/range combinations on a real spectrum', () => {
+    const signal = makeSine(512, 1000, 16000)
+    const spectrum = new (FFT as any)(512, 16000, 'hann', undefined).calculateSpectrum(signal)
+
+    for (const [gainDB, rangeDB] of [
+      [20, 80],
+      [0, 40],
+      [40, 120],
+      [-10, 60],
+    ]) {
+      expect(Array.from(magnitudesToColorIndices(spectrum, -gainDB, rangeDB))).toEqual(
+        Array.from(legacyLoop(spectrum, gainDB, rangeDB)),
+      )
+    }
+  })
+
+  it('rejects invalid whiteDb and rangeDB values', () => {
+    const spectrum = new Float32Array(4)
+    expect(() => magnitudesToColorIndices(spectrum, NaN, 80)).toThrow(TypeError)
+    expect(() => magnitudesToColorIndices(spectrum, -20, 0)).toThrow(TypeError)
+    expect(() => magnitudesToColorIndices(spectrum, -20, -80)).toThrow(TypeError)
+    expect(() => magnitudesToColorIndices(spectrum, -20, NaN)).toThrow(TypeError)
+    expect(() => magnitudesToColorIndices(spectrum, Infinity, 80)).toThrow(TypeError)
   })
 })

--- a/src/__tests__/spectrogram-praat-options.test.ts
+++ b/src/__tests__/spectrogram-praat-options.test.ts
@@ -1,0 +1,284 @@
+jest.mock(
+  'web-worker:./spectrogram-worker.ts',
+  () => ({
+    __esModule: true,
+    default: class MockSpectrogramWorker {
+      onmessage: ((e: { data: any }) => void) | null = null
+      onerror: ((e: Event) => void) | null = null
+      postMessage = jest.fn()
+      terminate = jest.fn()
+    },
+  }),
+  { virtual: true },
+)
+
+import Spectrogram from '../plugins/spectrogram.js'
+import WindowedSpectrogram from '../plugins/spectrogram-windowed.js'
+import '../plugins/spectrogram-worker.js'
+
+const SAMPLE_RATE = 8000
+
+function makeSine(length: number, amplitude = 1): Float32Array {
+  const signal = new Float32Array(length)
+  for (let i = 0; i < length; i++) {
+    signal[i] = amplitude * Math.sin((2 * Math.PI * 1000 * i) / SAMPLE_RATE)
+  }
+  return signal
+}
+
+/** Dispatch a message to the worker handler and return its response synchronously */
+function runWorker(signal: Float32Array, options: Record<string, unknown>): Uint8Array[][] {
+  const postMessage = jest.fn()
+  ;(self as any).postMessage = postMessage
+  ;(self as any).onmessage({
+    data: {
+      type: 'calculateFrequencies',
+      id: 'test',
+      audioData: [signal],
+      options: {
+        startTime: 0,
+        endTime: signal.length / SAMPLE_RATE,
+        sampleRate: SAMPLE_RATE,
+        fftSamples: 256,
+        windowFunc: 'hann',
+        noverlap: 128,
+        scale: 'linear',
+        gainDB: 20,
+        rangeDB: 80,
+        splitChannels: false,
+        ...options,
+      },
+    },
+  })
+  const response = postMessage.mock.calls[0][0]
+  expect(response.error).toBeUndefined()
+  return response.result
+}
+
+const flatten = (result: Uint8Array[][]) => result[0].map((frame) => Array.from(frame))
+
+beforeAll(() => {
+  // jsdom has no Worker; the plugins only check its existence before using the bundled constructor
+  ;(globalThis as any).Worker = function Worker() {}
+})
+
+describe.each([
+  ['SpectrogramPlugin', Spectrogram],
+  ['WindowedSpectrogramPlugin', WindowedSpectrogram],
+])('%s Praat display option validation', (_name, Plugin: any) => {
+  it('rejects non-finite or non-positive rangeDB', () => {
+    expect(() => Plugin.create({ rangeDB: 0 })).toThrow(TypeError)
+    expect(() => Plugin.create({ rangeDB: -5 })).toThrow(TypeError)
+    expect(() => Plugin.create({ rangeDB: NaN })).toThrow(TypeError)
+    expect(() => Plugin.create({ rangeDB: Infinity })).toThrow(TypeError)
+  })
+
+  it('rejects non-finite gainDB and preEmphasis', () => {
+    expect(() => Plugin.create({ gainDB: NaN })).toThrow(TypeError)
+    expect(() => Plugin.create({ preEmphasis: NaN })).toThrow(TypeError)
+    expect(() => Plugin.create({ preEmphasis: Infinity })).toThrow(TypeError)
+  })
+
+  it('accepts finite preEmphasis values including zero and negatives', () => {
+    expect(() => Plugin.create({ preEmphasis: 0 })).not.toThrow()
+    expect(() => Plugin.create({ preEmphasis: 6 })).not.toThrow()
+    expect(() => Plugin.create({ preEmphasis: -3 })).not.toThrow()
+  })
+
+  it('rejects invalid alpha values per window function', () => {
+    expect(() => Plugin.create({ alpha: NaN })).toThrow(TypeError)
+    expect(() => Plugin.create({ windowFunc: 'gauss', alpha: 0 })).toThrow(TypeError)
+    expect(() => Plugin.create({ windowFunc: 'gauss', alpha: -0.2 })).toThrow(TypeError)
+  })
+
+  it('accepts an explicit blackman alpha of 0', () => {
+    expect(() => Plugin.create({ windowFunc: 'blackman', alpha: 0 })).not.toThrow()
+  })
+})
+
+describe('worker compute with preEmphasis', () => {
+  it('quantizes the DC bin to 0 and changes the output', () => {
+    const signal = makeSine(4000)
+    const plain = runWorker(signal, {})
+    const tilted = runWorker(signal, { preEmphasis: 6 })
+
+    expect(flatten(tilted)).not.toEqual(flatten(plain))
+    for (const frame of tilted[0]) {
+      expect(frame[0]).toBe(0)
+    }
+  })
+
+  it('applies the tilt on non-linear scales using the row center frequencies', () => {
+    const signal = makeSine(4000)
+    const plain = runWorker(signal, { scale: 'mel' })
+    const tilted = runWorker(signal, { scale: 'mel', preEmphasis: 6 })
+
+    expect(flatten(tilted)).not.toEqual(flatten(plain))
+    expect(tilted[0].some((frame) => frame.some((value) => value > 0))).toBe(true)
+  })
+})
+
+describe('worker compute with autoGain', () => {
+  it('produces identical output regardless of absolute signal level', () => {
+    const loud = runWorker(makeSine(4000, 1), { autoGain: true })
+    const quiet = runWorker(makeSine(4000, 0.01), { autoGain: true })
+
+    expect(flatten(quiet)).toEqual(flatten(loud))
+  })
+
+  it('ignores gainDB while enabled', () => {
+    const signal = makeSine(4000)
+    const lowGain = runWorker(signal, { autoGain: true, gainDB: 0 })
+    const highGain = runWorker(signal, { autoGain: true, gainDB: 60 })
+
+    expect(flatten(highGain)).toEqual(flatten(lowGain))
+  })
+
+  it('maps the loudest bin to 255', () => {
+    const result = runWorker(makeSine(4000, 0.05), { autoGain: true })
+    const max = Math.max(...result[0].map((frame) => Math.max(...Array.from(frame))))
+    expect(max).toBe(255)
+  })
+
+  it('leaves digital silence blank instead of amplifying the numeric floor', () => {
+    const result = runWorker(new Float32Array(4000), { autoGain: true })
+    expect(result[0].length).toBeGreaterThan(0)
+    for (const frame of result[0]) {
+      expect(frame.every((value: number) => value === 0)).toBe(true)
+    }
+  })
+
+  it('produces identical output on the buffered and recompute memory strategies', () => {
+    const signal = makeSine(4000)
+    const options = { autoGain: true, preEmphasis: 6 }
+    const buffered = runWorker(signal, options)
+    const recomputed = runWorker(signal, { ...options, autoGainBufferBudgetBytes: 1 })
+
+    expect(flatten(recomputed)).toEqual(flatten(buffered))
+  })
+})
+
+describe('main-thread parity with the worker for the new options', () => {
+  function makeBuffer(signal: Float32Array): AudioBuffer {
+    return {
+      sampleRate: SAMPLE_RATE,
+      length: signal.length,
+      duration: signal.length / SAMPLE_RATE,
+      numberOfChannels: 1,
+      getChannelData: () => signal,
+    } as unknown as AudioBuffer
+  }
+
+  it.each([
+    ['preEmphasis', { preEmphasis: 6 }],
+    ['autoGain', { autoGain: true }],
+    ['both combined on mel scale', { preEmphasis: 6, autoGain: true, scale: 'mel' }],
+  ])('matches the worker byte for byte with %s', async (_label, extra) => {
+    const signal = makeSine(4000)
+    const plugin: any = Spectrogram.create({ fftSamples: 256, noverlap: 128, scale: 'linear', ...extra } as any)
+
+    const mainResult = await plugin.getFrequencies(makeBuffer(signal))
+    const workerResult = runWorker(signal, extra as Record<string, unknown>)
+
+    expect(mainResult[0].length).toBe(workerResult[0].length)
+    mainResult[0].forEach((frame: Uint8Array, i: number) => {
+      expect(Array.from(frame)).toEqual(Array.from(workerResult[0][i]))
+    })
+  })
+
+  it('uses the recompute strategy on the main thread when over budget, with identical output', async () => {
+    const signal = makeSine(4000)
+    const makePlugin = (): any => Spectrogram.create({ fftSamples: 256, noverlap: 128, autoGain: true })
+
+    const buffered = await makePlugin().getFrequencies(makeBuffer(signal))
+    const constrained = makePlugin()
+    constrained.autoGainBudgetBytes = 1
+    const recomputed = await constrained.getFrequencies(makeBuffer(signal))
+
+    expect(flatten(recomputed)).toEqual(flatten(buffered))
+  })
+})
+
+describe('explicit blackman alpha: 0 end-to-end', () => {
+  function makeBuffer(signal: Float32Array): AudioBuffer {
+    return {
+      sampleRate: SAMPLE_RATE,
+      length: signal.length,
+      duration: signal.length / SAMPLE_RATE,
+      numberOfChannels: 1,
+      getChannelData: () => signal,
+    } as unknown as AudioBuffer
+  }
+
+  it('is honored on the worker path, byte-identical to the main thread', async () => {
+    // Distinct fftSamples so the worker module's FFT cache (keyed on sizes only) cannot
+    // serve a window built for another test's windowFunc/alpha
+    const signal = makeSine(4000)
+    const options = { fftSamples: 512, noverlap: 256, windowFunc: 'blackman', alpha: 0 }
+
+    const workerResult = runWorker(signal, options)
+    const plugin: any = Spectrogram.create({ ...options, scale: 'linear' } as any)
+    const mainResult = await plugin.getFrequencies(makeBuffer(signal))
+
+    expect(mainResult[0].length).toBe(workerResult[0].length)
+    mainResult[0].forEach((frame: Uint8Array, i: number) => {
+      expect(Array.from(frame)).toEqual(Array.from(workerResult[0][i]))
+    })
+  })
+
+  it('produces different output than the blackman default on the main thread', async () => {
+    const signal = makeSine(4000)
+    const create = (alpha?: number): any =>
+      Spectrogram.create({ fftSamples: 256, noverlap: 128, scale: 'linear', windowFunc: 'blackman', alpha } as any)
+
+    const explicitZero = await create(0).getFrequencies(makeBuffer(signal))
+    const defaulted = await create(undefined).getFrequencies(makeBuffer(signal))
+
+    expect(explicitZero[0].map((f: Uint8Array) => Array.from(f))).not.toEqual(
+      defaulted[0].map((f: Uint8Array) => Array.from(f)),
+    )
+  })
+})
+
+describe('windowed plugin preEmphasis', () => {
+  it('tilts the main-thread computation', async () => {
+    const signal = makeSine(4000)
+    const create = (preEmphasis: number): any => {
+      const plugin: any = WindowedSpectrogram.create({ fftSamples: 256, noverlap: 128, scale: 'linear', preEmphasis })
+      plugin.buffer = {
+        sampleRate: SAMPLE_RATE,
+        length: signal.length,
+        duration: signal.length / SAMPLE_RATE,
+        numberOfChannels: 1,
+        getChannelData: () => signal,
+      }
+      return plugin
+    }
+
+    const plain = await create(0).calculateFrequenciesMainThread(0, signal.length / SAMPLE_RATE)
+    const tilted = await create(6).calculateFrequenciesMainThread(0, signal.length / SAMPLE_RATE)
+
+    expect(flatten(tilted)).not.toEqual(flatten(plain))
+    for (const frame of tilted[0]) {
+      expect(frame[0]).toBe(0)
+    }
+  })
+
+  it('forwards preEmphasis to the worker', async () => {
+    const plugin: any = WindowedSpectrogram.create({ useWebWorker: true, noverlap: 128, preEmphasis: 6 })
+    plugin.buffer = {
+      sampleRate: SAMPLE_RATE,
+      length: 4000,
+      duration: 0.5,
+      numberOfChannels: 1,
+      getChannelData: () => makeSine(4000),
+    }
+
+    const promise = plugin.calculateFrequenciesWithWorker(0, 0.5)
+    promise.catch(() => undefined)
+    const worker = plugin.worker
+    expect(worker.postMessage).toHaveBeenCalledTimes(1)
+    expect(worker.postMessage.mock.calls[0][0].options.preEmphasis).toBe(6)
+    plugin.destroy()
+  })
+})

--- a/src/fft.ts
+++ b/src/fft.ts
@@ -227,6 +227,36 @@ export function createSparseFilterBankForScale(
   }
 }
 
+/**
+ * Convert one frame of FFT magnitudes into 8-bit color indices, exactly as the spectrogram
+ * plugins have always done: dB = 20*log10(max(magnitude, 1e-12)); 255 at/above whiteDb, 0 below
+ * whiteDb - rangeDB, and the historical ramp arithmetic in between. The ramp expression is
+ * negative over its whole range and relies on Uint8Array's mod-256 wrap - kept bit-for-bit
+ * because changing it would shift every mid-tone pixel of every existing spectrogram.
+ */
+export function magnitudesToColorIndices(spectrum: Float32Array, whiteDb: number, rangeDB: number): Uint8Array {
+  if (!Number.isFinite(whiteDb) || !Number.isFinite(rangeDB) || rangeDB <= 0) {
+    throw new TypeError(
+      `whiteDb must be finite and rangeDB must be a finite positive number, got ${whiteDb}/${rangeDB}`,
+    )
+  }
+  const colorIndices = new Uint8Array(spectrum.length)
+  const floorDb = whiteDb - rangeDB
+  for (let i = 0; i < spectrum.length; i++) {
+    const magnitude = spectrum[i] > 1e-12 ? spectrum[i] : 1e-12
+    const valueDB = 20 * Math.log10(magnitude)
+
+    if (valueDB < floorDb) {
+      colorIndices[i] = 0
+    } else if (valueDB > whiteDb) {
+      colorIndices[i] = 255
+    } else {
+      colorIndices[i] = Math.round(((valueDB - whiteDb) / rangeDB) * 255)
+    }
+  }
+  return colorIndices
+}
+
 export const COLOR_MAPS = {
   gray: () => {
     const colorMap = []

--- a/src/fft.ts
+++ b/src/fft.ts
@@ -228,23 +228,84 @@ export function createSparseFilterBankForScale(
 }
 
 /**
- * Convert one frame of FFT magnitudes into 8-bit color indices, exactly as the spectrogram
- * plugins have always done: dB = 20*log10(max(magnitude, 1e-12)); 255 at/above whiteDb, 0 below
- * whiteDb - rangeDB, and the historical ramp arithmetic in between. The ramp expression is
- * negative over its whole range and relies on Uint8Array's mod-256 wrap - kept bit-for-bit
- * because changing it would shift every mid-tone pixel of every existing spectrogram.
+ * Global-peak level below which autoGain treats the whole signal as digital silence and leaves
+ * the spectrogram blank instead of amplifying the numeric floor. -180 dBFS is well below the
+ * quantization floor of 24-bit audio (~-144 dBFS) and float32 near full scale (~-138 dB), but
+ * far above denormals, so it only triggers on true silence.
  */
-export function magnitudesToColorIndices(spectrum: Float32Array, whiteDb: number, rangeDB: number): Uint8Array {
+export const SILENCE_FLOOR_DB = -180
+
+/**
+ * autoGain transient-memory budget: below this estimate (frames x bins x 4 bytes x channels)
+ * the Float32 dB frames are kept between the two passes (single FFT pass, fastest); at or
+ * above it, only the running maximum is kept and the spectra are recomputed for quantization,
+ * trading a second FFT pass on very long short-window files for a bounded heap.
+ */
+export const AUTO_GAIN_BUFFER_BUDGET_BYTES = 64 * 1024 * 1024
+
+/**
+ * Per-bin display tilt in dB: preEmphasis dB/octave relative to 1 kHz - 0 dB at 1 kHz,
+ * boosting above, attenuating below. This is Praat's display pre-emphasis formula, including
+ * its 1e-308 guard that sends the DC bin toward -infinity instead of NaN.
+ */
+export function createPreEmphasisTilt(preEmphasis: number, binFrequencies: ArrayLike<number>): Float64Array {
+  if (!Number.isFinite(preEmphasis)) {
+    throw new TypeError(`preEmphasis must be a finite number, got ${preEmphasis}`)
+  }
+  const tilt = new Float64Array(binFrequencies.length)
+  for (let i = 0; i < binFrequencies.length; i++) {
+    tilt[i] = preEmphasis * Math.log2(binFrequencies[i] / 1000 + 1e-308)
+  }
+  return tilt
+}
+
+/** Center frequency in Hz of each output row: sparse scale rows, or linear FFT bins */
+export function getBinFrequencies(
+  filterBank: SparseFilter[] | null,
+  fftLength: number,
+  sampleRate: number,
+): Float64Array {
+  if (filterBank) {
+    return Float64Array.from(filterBank, (filter) => filter.centerHz)
+  }
+  const bins = fftLength / 2
+  const frequencies = new Float64Array(bins)
+  for (let i = 0; i < bins; i++) {
+    frequencies[i] = (i * sampleRate) / fftLength
+  }
+  return frequencies
+}
+
+/**
+ * Convert one frame of FFT magnitudes into 8-bit color indices, exactly as the spectrogram
+ * plugins have always done: dB = 20*log10(max(magnitude, 1e-12)); 255 strictly above whiteDb,
+ * 0 strictly below whiteDb - rangeDB, and the historical ramp arithmetic for everything in
+ * between - including both exact boundaries, where the negative ramp expression and
+ * Uint8Array's mod-256 wrap map valueDB === whiteDb to 0 and valueDB === whiteDb - rangeDB
+ * to 1. Kept bit-for-bit because changing it would shift every mid-tone pixel of every
+ * existing spectrogram (dbToColorIndices is the clean-mapping counterpart used by autoGain).
+ * The optional tilt (createPreEmphasisTilt) is added to each bin's dB value before mapping.
+ */
+export function magnitudesToColorIndices(
+  spectrum: Float32Array,
+  whiteDb: number,
+  rangeDB: number,
+  tilt?: Float64Array | null,
+): Uint8Array {
   if (!Number.isFinite(whiteDb) || !Number.isFinite(rangeDB) || rangeDB <= 0) {
     throw new TypeError(
       `whiteDb must be finite and rangeDB must be a finite positive number, got ${whiteDb}/${rangeDB}`,
     )
   }
+  if (tilt && tilt.length !== spectrum.length) {
+    throw new TypeError(`tilt length ${tilt.length} does not match spectrum length ${spectrum.length}`)
+  }
   const colorIndices = new Uint8Array(spectrum.length)
   const floorDb = whiteDb - rangeDB
   for (let i = 0; i < spectrum.length; i++) {
     const magnitude = spectrum[i] > 1e-12 ? spectrum[i] : 1e-12
-    const valueDB = 20 * Math.log10(magnitude)
+    let valueDB = 20 * Math.log10(magnitude)
+    if (tilt) valueDB += tilt[i]
 
     if (valueDB < floorDb) {
       colorIndices[i] = 0
@@ -252,6 +313,51 @@ export function magnitudesToColorIndices(spectrum: Float32Array, whiteDb: number
       colorIndices[i] = 255
     } else {
       colorIndices[i] = Math.round(((valueDB - whiteDb) / rangeDB) * 255)
+    }
+  }
+  return colorIndices
+}
+
+/**
+ * One frame of FFT magnitudes to dB (same floor and tilt semantics as
+ * magnitudesToColorIndices), materialized as Float32 for autoGain's deferred quantization.
+ * Pass `out` to reuse a scratch buffer when the frame is not retained.
+ */
+export function magnitudesToDb(spectrum: Float32Array, tilt?: Float64Array | null, out?: Float32Array): Float32Array {
+  if (tilt && tilt.length !== spectrum.length) {
+    throw new TypeError(`tilt length ${tilt.length} does not match spectrum length ${spectrum.length}`)
+  }
+  const db = out && out.length === spectrum.length ? out : new Float32Array(spectrum.length)
+  for (let i = 0; i < spectrum.length; i++) {
+    const magnitude = spectrum[i] > 1e-12 ? spectrum[i] : 1e-12
+    db[i] = tilt ? 20 * Math.log10(magnitude) + tilt[i] : 20 * Math.log10(magnitude)
+  }
+  return db
+}
+
+/**
+ * Quantize a dB frame produced by magnitudesToDb: 255 at/above whiteDb, 0 at/below
+ * whiteDb - rangeDB, linear in between. Used by autoGain, whose white point is the exact
+ * spectrogram maximum - unlike magnitudesToColorIndices this deliberately does NOT reproduce
+ * the historical wrap arithmetic, because with valueDB === whiteDb the wrap would map the
+ * loudest bin to 0 instead of 255.
+ */
+export function dbToColorIndices(db: Float32Array, whiteDb: number, rangeDB: number): Uint8Array {
+  if (!Number.isFinite(whiteDb) || !Number.isFinite(rangeDB) || rangeDB <= 0) {
+    throw new TypeError(
+      `whiteDb must be finite and rangeDB must be a finite positive number, got ${whiteDb}/${rangeDB}`,
+    )
+  }
+  const colorIndices = new Uint8Array(db.length)
+  const floorDb = whiteDb - rangeDB
+  for (let i = 0; i < db.length; i++) {
+    const valueDB = db[i]
+    if (valueDB >= whiteDb) {
+      colorIndices[i] = 255
+    } else if (valueDB <= floorDb) {
+      colorIndices[i] = 0
+    } else {
+      colorIndices[i] = Math.round(((valueDB - floorDb) / rangeDB) * 255)
     }
   }
   return colorIndices
@@ -640,7 +746,7 @@ function FFT(bufferSize: number, sampleRate: number, windowFunc: string, alpha: 
       }
       break
     case 'blackman':
-      alpha = alpha || 0.16
+      alpha = alpha ?? 0.16
       for (let i = 0; i < windowLength; i++) {
         this.windowValues[i] =
           (1 - alpha) / 2 -

--- a/src/plugins/spectrogram-windowed.ts
+++ b/src/plugins/spectrogram-windowed.ts
@@ -16,6 +16,8 @@ import FFT, {
   createSparseFilterBankForScale,
   applySparseFilterBank,
   magnitudesToColorIndices,
+  createPreEmphasisTilt,
+  getBinFrequencies,
   setupColorMap,
   freqType,
   unitType,
@@ -76,6 +78,14 @@ export type WindowedSpectrogramPluginOptions = {
   gainDB?: number
   /** Range in dB */
   rangeDB?: number
+  /**
+   * Praat-style display pre-emphasis in dB per octave, applied before quantization: each bin
+   * gets preEmphasis * log2(binHz / 1000) dB - 0 dB at 1 kHz, boosting higher frequencies and
+   * attenuating lower ones (Praat's default is 6). Set 0 to disable. Note: the autoGain option
+   * of SpectrogramPlugin is not available here - segments are computed lazily while scrolling,
+   * so no global maximum exists. (default: 0)
+   */
+  preEmphasis?: number
   /** Color map */
   colorMap?: number[][] | 'gray' | 'igray' | 'roseus'
   /** Render a spectrogram for each channel independently when true. */
@@ -128,6 +138,7 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
   private frequencyMax: WindowedSpectrogramPluginOptions['frequencyMax']
   private gainDB: WindowedSpectrogramPluginOptions['gainDB']
   private rangeDB: WindowedSpectrogramPluginOptions['rangeDB']
+  private preEmphasis: number
   private scale: WindowedSpectrogramPluginOptions['scale']
 
   // Windowing properties
@@ -204,6 +215,25 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     this.gainDB = options.gainDB ?? 20
     this.rangeDB = options.rangeDB ?? 80
     this.scale = options.scale || 'mel'
+    this.preEmphasis = options.preEmphasis ?? 0
+
+    if (options.gainDB != null && !Number.isFinite(options.gainDB)) {
+      throw new TypeError(`gainDB must be a finite number, got ${options.gainDB}`)
+    }
+    if (options.rangeDB != null && (!Number.isFinite(options.rangeDB) || options.rangeDB <= 0)) {
+      throw new TypeError(`rangeDB must be a finite positive number, got ${options.rangeDB}`)
+    }
+    if (options.preEmphasis != null && !Number.isFinite(options.preEmphasis)) {
+      throw new TypeError(`preEmphasis must be a finite number, got ${options.preEmphasis}`)
+    }
+    if (options.alpha != null) {
+      if (!Number.isFinite(options.alpha)) {
+        throw new TypeError(`alpha must be a finite number, got ${options.alpha}`)
+      }
+      if (this.windowFunc === 'gauss' && options.alpha <= 0) {
+        throw new TypeError(`alpha must be positive for the gauss window, got ${options.alpha}`)
+      }
+    }
 
     // Windowing options
     this.windowSize = options.windowSize || 30 // 30 seconds window
@@ -904,6 +934,7 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
             scale: this.scale,
             gainDB: this.gainDB,
             rangeDB: this.rangeDB,
+            preEmphasis: this.preEmphasis,
             splitChannels: this.options.splitChannels || false,
           },
         })
@@ -956,6 +987,11 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     // Create the filter bank once for all frames and channels
     const filterBank = this.getFilterBank(sampleRate)
 
+    // Optional Praat display pre-emphasis, precomputed per output row
+    const tilt = this.preEmphasis
+      ? createPreEmphasisTilt(this.preEmphasis, getBinFrequencies(filterBank, fftLength, sampleRate))
+      : null
+
     // One reused frame buffer; the zero tail beyond fftSamples doubles as the FFT padding
     const frame = new Float32Array(fftLength)
 
@@ -974,7 +1010,7 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
         }
 
         // Convert to uint8 color indices
-        channelFreq.push(magnitudesToColorIndices(spectrum, -this.gainDB, this.rangeDB))
+        channelFreq.push(magnitudesToColorIndices(spectrum, -this.gainDB, this.rangeDB, tilt))
       }
       frequencies.push(channelFreq)
     }

--- a/src/plugins/spectrogram-windowed.ts
+++ b/src/plugins/spectrogram-windowed.ts
@@ -15,6 +15,7 @@ import FFT, {
   scaleToHz,
   createSparseFilterBankForScale,
   applySparseFilterBank,
+  magnitudesToColorIndices,
   setupColorMap,
   freqType,
   unitType,
@@ -973,22 +974,7 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
         }
 
         // Convert to uint8 color indices
-        const freqBins = new Uint8Array(spectrum.length)
-        const gainPlusRange = this.gainDB + this.rangeDB
-
-        for (let j = 0; j < spectrum.length; j++) {
-          const magnitude = spectrum[j] > 1e-12 ? spectrum[j] : 1e-12
-          const valueDB = 20 * Math.log10(magnitude)
-
-          if (valueDB < -gainPlusRange) {
-            freqBins[j] = 0
-          } else if (valueDB > -this.gainDB) {
-            freqBins[j] = 255
-          } else {
-            freqBins[j] = Math.round(((valueDB + this.gainDB) / this.rangeDB) * 255)
-          }
-        }
-        channelFreq.push(freqBins)
+        channelFreq.push(magnitudesToColorIndices(spectrum, -this.gainDB, this.rangeDB))
       }
       frequencies.push(channelFreq)
     }

--- a/src/plugins/spectrogram-worker.ts
+++ b/src/plugins/spectrogram-worker.ts
@@ -4,7 +4,17 @@
  */
 
 // Import centralized FFT functionality
-import FFT, { createSparseFilterBankForScale, applySparseFilterBank, magnitudesToColorIndices } from '../fft.js'
+import FFT, {
+  createSparseFilterBankForScale,
+  applySparseFilterBank,
+  magnitudesToColorIndices,
+  magnitudesToDb,
+  dbToColorIndices,
+  createPreEmphasisTilt,
+  getBinFrequencies,
+  SILENCE_FLOOR_DB,
+  AUTO_GAIN_BUFFER_BUDGET_BYTES,
+} from '../fft.js'
 
 // Global FFT instance (reused for performance)
 let fft: FFT | null = null
@@ -25,6 +35,10 @@ interface WorkerMessage {
     scale: 'linear' | 'logarithmic' | 'mel' | 'bark' | 'erb'
     gainDB: number
     rangeDB: number
+    preEmphasis?: number
+    autoGain?: boolean
+    /** Internal: overrides the autoGain transient-memory budget (used by tests) */
+    autoGainBufferBudgetBytes?: number
     splitChannels: boolean
   }
 }
@@ -76,6 +90,9 @@ function calculateFrequencies(audioChannels: Float32Array[], options: WorkerMess
     scale,
     gainDB,
     rangeDB,
+    preEmphasis,
+    autoGain,
+    autoGainBufferBudgetBytes,
     splitChannels,
   } = options
 
@@ -85,7 +102,8 @@ function calculateFrequencies(audioChannels: Float32Array[], options: WorkerMess
   const fftLength = fftSize ?? fftSamples
 
   // Initialize FFT (reuse if possible for performance); the window covers fftSamples samples,
-  // zero-padded up to fftLength
+  // zero-padded up to fftLength. Alpha passes through untouched so FFT's per-window defaults
+  // and the explicit blackman alpha: 0 semantics match the main thread
   if (!fft || fft.bufferSize !== fftLength || fft.windowLength !== fftSamples) {
     fft = new (FFT as any)(fftLength, sampleRate, windowFunc, alpha, fftSamples)
   }
@@ -107,21 +125,91 @@ function calculateFrequencies(audioChannels: Float32Array[], options: WorkerMess
   // One reused frame buffer; the zero tail beyond fftSamples doubles as the FFT padding
   const frame = new Float32Array(fftLength)
 
+  // Optional Praat display pre-emphasis, precomputed per output row (same as main thread)
+  const tilt = preEmphasis
+    ? createPreEmphasisTilt(preEmphasis, getBinFrequencies(filterBank, fftLength, sampleRate))
+    : null
+
+  const computeSpectrum = (channelData: Float32Array, sample: number): Float32Array => {
+    frame.set(channelData.subarray(sample, sample + fftSamples))
+    let spectrum = fft.calculateSpectrum(frame)
+
+    // Apply filter bank if specified (same as main thread)
+    if (filterBank) {
+      spectrum = applySparseFilterBank(spectrum, filterBank)
+    }
+    return spectrum
+  }
+
+  if (!autoGain) {
+    for (let c = 0; c < channels; c++) {
+      const channelData = audioChannels[c]
+      const channelFreq: Uint8Array[] = []
+
+      for (let sample = startSample; sample + fftSamples < endSample; sample += hopSize) {
+        // Convert to uint8 color indices
+        channelFreq.push(magnitudesToColorIndices(computeSpectrum(channelData, sample), -gainDB, rangeDB, tilt))
+      }
+      frequencies.push(channelFreq)
+    }
+    return frequencies
+  }
+
+  // autoGain (Praat-style autoscaling): the white point is the loudest bin of the whole
+  // spectrogram, found after pre-emphasis, shared across channels. Two strategies bound the
+  // transient memory - see the main thread implementation for details.
+  const bins = fftLength / 2
+  const span = endSample - startSample
+  const frameCount = span > fftSamples ? Math.floor((span - fftSamples - 1) / hopSize) + 1 : 0
+  const estimatedBytes = frameCount * bins * 4 * channels
+  const budgetBytes = autoGainBufferBudgetBytes ?? AUTO_GAIN_BUFFER_BUDGET_BYTES
+  let maxDb = -Infinity
+
+  if (estimatedBytes < budgetBytes) {
+    const dbFrames: Float32Array[][] = []
+    for (let c = 0; c < channels; c++) {
+      const channelData = audioChannels[c]
+      const channelDb: Float32Array[] = []
+      for (let sample = startSample; sample + fftSamples < endSample; sample += hopSize) {
+        const db = magnitudesToDb(computeSpectrum(channelData, sample), tilt)
+        for (let i = 0; i < db.length; i++) {
+          if (db[i] > maxDb) maxDb = db[i]
+        }
+        channelDb.push(db)
+      }
+      dbFrames.push(channelDb)
+    }
+    const silent = maxDb < SILENCE_FLOOR_DB
+    for (const channelDb of dbFrames) {
+      frequencies.push(
+        channelDb.map((db) => (silent ? new Uint8Array(db.length) : dbToColorIndices(db, maxDb, rangeDB))),
+      )
+    }
+    return frequencies
+  }
+
+  // Over budget: pass 1 tracks only the maximum with one reused dB frame
+  const dbScratch = new Float32Array(bins)
+  for (let c = 0; c < channels; c++) {
+    const channelData = audioChannels[c]
+    for (let sample = startSample; sample + fftSamples < endSample; sample += hopSize) {
+      const db = magnitudesToDb(computeSpectrum(channelData, sample), tilt, dbScratch)
+      for (let i = 0; i < db.length; i++) {
+        if (db[i] > maxDb) maxDb = db[i]
+      }
+    }
+  }
+  const silent = maxDb < SILENCE_FLOOR_DB
   for (let c = 0; c < channels; c++) {
     const channelData = audioChannels[c]
     const channelFreq: Uint8Array[] = []
-
     for (let sample = startSample; sample + fftSamples < endSample; sample += hopSize) {
-      frame.set(channelData.subarray(sample, sample + fftSamples))
-      let spectrum = fft.calculateSpectrum(frame)
-
-      // Apply filter bank if specified (same as main thread)
-      if (filterBank) {
-        spectrum = applySparseFilterBank(spectrum, filterBank)
+      if (silent) {
+        channelFreq.push(new Uint8Array(bins))
+      } else {
+        const db = magnitudesToDb(computeSpectrum(channelData, sample), tilt, dbScratch)
+        channelFreq.push(dbToColorIndices(db, maxDb, rangeDB))
       }
-
-      // Convert to uint8 color indices
-      channelFreq.push(magnitudesToColorIndices(spectrum, -gainDB, rangeDB))
     }
     frequencies.push(channelFreq)
   }

--- a/src/plugins/spectrogram-worker.ts
+++ b/src/plugins/spectrogram-worker.ts
@@ -4,7 +4,7 @@
  */
 
 // Import centralized FFT functionality
-import FFT, { createSparseFilterBankForScale, applySparseFilterBank } from '../fft.js'
+import FFT, { createSparseFilterBankForScale, applySparseFilterBank, magnitudesToColorIndices } from '../fft.js'
 
 // Global FFT instance (reused for performance)
 let fft: FFT | null = null
@@ -121,22 +121,7 @@ function calculateFrequencies(audioChannels: Float32Array[], options: WorkerMess
       }
 
       // Convert to uint8 color indices
-      const freqBins = new Uint8Array(spectrum.length)
-      const gainPlusRange = gainDB + rangeDB
-
-      for (let j = 0; j < spectrum.length; j++) {
-        const magnitude = spectrum[j] > 1e-12 ? spectrum[j] : 1e-12
-        const valueDB = 20 * Math.log10(magnitude)
-
-        if (valueDB < -gainPlusRange) {
-          freqBins[j] = 0
-        } else if (valueDB > -gainDB) {
-          freqBins[j] = 255
-        } else {
-          freqBins[j] = Math.round(((valueDB + gainDB) / rangeDB) * 255)
-        }
-      }
-      channelFreq.push(freqBins)
+      channelFreq.push(magnitudesToColorIndices(spectrum, -gainDB, rangeDB))
     }
     frequencies.push(channelFreq)
   }

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -27,6 +27,12 @@ import FFT, {
   createSparseFilterBankForScale,
   applySparseFilterBank,
   magnitudesToColorIndices,
+  magnitudesToDb,
+  dbToColorIndices,
+  createPreEmphasisTilt,
+  getBinFrequencies,
+  SILENCE_FLOOR_DB,
+  AUTO_GAIN_BUFFER_BUDGET_BYTES,
   setupColorMap,
   freqType,
   unitType,
@@ -108,6 +114,27 @@ export type SpectrogramPluginOptions = {
    */
   rangeDB?: number
   /**
+   * Praat-style display pre-emphasis in dB per octave, applied before quantization: each bin
+   * gets preEmphasis * log2(binHz / 1000) dB - 0 dB at 1 kHz, boosting higher frequencies and
+   * attenuating lower ones (Praat's default is 6). Counteracts the natural ~-6 dB/oct spectral
+   * slope of speech so formants above 1 kHz stay visible. Set 0 to disable. Only applies when
+   * frequencies are computed from audio, not to pre-computed frequenciesDataUrl data.
+   * (default: 0)
+   */
+  preEmphasis?: number
+  /**
+   * Praat-style autoscaling: map the loudest bin of the computed spectrogram (found after
+   * pre-emphasis) to the last colormap entry and everything rangeDB below it to the first,
+   * instead of using the fixed gainDB white point. gainDB is ignored while enabled. With
+   * splitChannels, a single maximum serves all channels, so inter-channel level differences
+   * are preserved (a quieter channel renders lighter); per-channel scaling was rejected to
+   * keep channels comparable. If the whole signal is digital silence, the spectrogram is left
+   * blank instead of amplifying the numeric floor. SpectrogramPlugin only - the windowed
+   * variant computes segments lazily and has no global maximum. No effect with
+   * frequenciesDataUrl. (default: false)
+   */
+  autoGain?: boolean
+  /**
    * A 256 long array of 4-element arrays. Each entry should contain a float between 0 and 1 and specify r, g, b, and alpha.
    * Each entry should contain a float between 0 and 1 and specify r, g, b, and alpha.
    * - gray: Gray scale.
@@ -161,6 +188,9 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
   private frequencyMax: SpectrogramPluginOptions['frequencyMax']
   private gainDB: SpectrogramPluginOptions['gainDB']
   private rangeDB: SpectrogramPluginOptions['rangeDB']
+  private preEmphasis: number
+  private autoGain: boolean
+  private autoGainBudgetBytes = AUTO_GAIN_BUFFER_BUDGET_BYTES
   private scale: SpectrogramPluginOptions['scale']
   private numMelFilters: number
   private numLogFilters: number
@@ -249,6 +279,26 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
     this.gainDB = options.gainDB ?? 20
     this.rangeDB = options.rangeDB ?? 80
     this.scale = options.scale || 'mel'
+    this.preEmphasis = options.preEmphasis ?? 0
+    this.autoGain = options.autoGain ?? false
+
+    if (options.gainDB != null && !Number.isFinite(options.gainDB)) {
+      throw new TypeError(`gainDB must be a finite number, got ${options.gainDB}`)
+    }
+    if (options.rangeDB != null && (!Number.isFinite(options.rangeDB) || options.rangeDB <= 0)) {
+      throw new TypeError(`rangeDB must be a finite positive number, got ${options.rangeDB}`)
+    }
+    if (options.preEmphasis != null && !Number.isFinite(options.preEmphasis)) {
+      throw new TypeError(`preEmphasis must be a finite number, got ${options.preEmphasis}`)
+    }
+    if (options.alpha != null) {
+      if (!Number.isFinite(options.alpha)) {
+        throw new TypeError(`alpha must be a finite number, got ${options.alpha}`)
+      }
+      if (this.windowFunc === 'gauss' && options.alpha <= 0) {
+        throw new TypeError(`alpha must be positive for the gauss window, got ${options.alpha}`)
+      }
+    }
 
     // Rendering and labels derive their geometry from the computed data, so these follow the
     // transform length
@@ -932,6 +982,9 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
             scale: this.scale,
             gainDB: this.gainDB,
             rangeDB: this.rangeDB,
+            preEmphasis: this.preEmphasis,
+            autoGain: this.autoGain,
+            autoGainBufferBudgetBytes: this.autoGainBudgetBytes,
             splitChannels: this.options.splitChannels || false,
           },
         })
@@ -997,26 +1050,95 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
     // One reused frame buffer; the zero tail beyond fftSamples doubles as the FFT padding
     const frame = new Float32Array(fftLength)
 
+    // Optional Praat display pre-emphasis, precomputed per output row
+    const tilt = this.preEmphasis
+      ? createPreEmphasisTilt(this.preEmphasis, getBinFrequencies(filterBank, fftLength, sampleRate))
+      : null
+
+    const computeSpectrum = (channelData: Float32Array, sample: number): Float32Array => {
+      frame.set(channelData.subarray(sample, sample + fftSamples))
+      let spectrum = fft.calculateSpectrum(frame)
+      if (filterBank) {
+        spectrum = applySparseFilterBank(spectrum, filterBank)
+      }
+      return spectrum
+    }
+
+    if (!this.autoGain) {
+      for (let c = 0; c < channels; c++) {
+        // for each channel
+        const channelData = buffer.getChannelData(c)
+        const channelFreq: Uint8Array[] = []
+
+        // Use same hop size calculation as worker for consistency
+        for (let sample = 0; sample + fftSamples < channelData.length; sample += hopSize) {
+          // Convert to uint8 color indices
+          channelFreq.push(
+            magnitudesToColorIndices(computeSpectrum(channelData, sample), -this.gainDB, this.rangeDB, tilt),
+          )
+        }
+        frequencies.push(channelFreq)
+      }
+      return frequencies
+    }
+
+    // autoGain (Praat-style autoscaling): the white point is the loudest bin of the whole
+    // spectrogram, found after pre-emphasis, shared across channels. Two strategies bound the
+    // transient memory: below the budget the dB frames are kept between the two passes; above
+    // it only the maximum is tracked and the spectra are recomputed for quantization.
+    const bins = fftLength / 2
+    const frameCount = buffer.length > fftSamples ? Math.floor((buffer.length - fftSamples - 1) / hopSize) + 1 : 0
+    const estimatedBytes = frameCount * bins * 4 * channels
+    let maxDb = -Infinity
+
+    if (estimatedBytes < this.autoGainBudgetBytes) {
+      const dbFrames: Float32Array[][] = []
+      for (let c = 0; c < channels; c++) {
+        const channelData = buffer.getChannelData(c)
+        const channelDb: Float32Array[] = []
+        for (let sample = 0; sample + fftSamples < channelData.length; sample += hopSize) {
+          const db = magnitudesToDb(computeSpectrum(channelData, sample), tilt)
+          for (let i = 0; i < db.length; i++) {
+            if (db[i] > maxDb) maxDb = db[i]
+          }
+          channelDb.push(db)
+        }
+        dbFrames.push(channelDb)
+      }
+      const silent = maxDb < SILENCE_FLOOR_DB
+      for (const channelDb of dbFrames) {
+        frequencies.push(
+          channelDb.map((db) => (silent ? new Uint8Array(db.length) : dbToColorIndices(db, maxDb, this.rangeDB))),
+        )
+      }
+      return frequencies
+    }
+
+    // Over budget: pass 1 tracks only the maximum with one reused dB frame
+    const dbScratch = new Float32Array(bins)
     for (let c = 0; c < channels; c++) {
-      // for each channel
+      const channelData = buffer.getChannelData(c)
+      for (let sample = 0; sample + fftSamples < channelData.length; sample += hopSize) {
+        const db = magnitudesToDb(computeSpectrum(channelData, sample), tilt, dbScratch)
+        for (let i = 0; i < db.length; i++) {
+          if (db[i] > maxDb) maxDb = db[i]
+        }
+      }
+    }
+    const silent = maxDb < SILENCE_FLOOR_DB
+    for (let c = 0; c < channels; c++) {
       const channelData = buffer.getChannelData(c)
       const channelFreq: Uint8Array[] = []
-
-      // Use same hop size calculation as worker for consistency
       for (let sample = 0; sample + fftSamples < channelData.length; sample += hopSize) {
-        frame.set(channelData.subarray(sample, sample + fftSamples))
-        let spectrum = fft.calculateSpectrum(frame)
-
-        if (filterBank) {
-          spectrum = applySparseFilterBank(spectrum, filterBank)
+        if (silent) {
+          channelFreq.push(new Uint8Array(bins))
+        } else {
+          const db = magnitudesToDb(computeSpectrum(channelData, sample), tilt, dbScratch)
+          channelFreq.push(dbToColorIndices(db, maxDb, this.rangeDB))
         }
-
-        // Convert to uint8 color indices
-        channelFreq.push(magnitudesToColorIndices(spectrum, -this.gainDB, this.rangeDB))
       }
       frequencies.push(channelFreq)
     }
-
     return frequencies
   }
 

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -26,6 +26,7 @@ import FFT, {
   scaleToHz,
   createSparseFilterBankForScale,
   applySparseFilterBank,
+  magnitudesToColorIndices,
   setupColorMap,
   freqType,
   unitType,
@@ -1011,22 +1012,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
         }
 
         // Convert to uint8 color indices
-        const freqBins = new Uint8Array(spectrum.length)
-        const gainPlusRange = this.gainDB + this.rangeDB
-
-        for (let j = 0; j < spectrum.length; j++) {
-          const magnitude = spectrum[j] > 1e-12 ? spectrum[j] : 1e-12
-          const valueDB = 20 * Math.log10(magnitude)
-
-          if (valueDB < -gainPlusRange) {
-            freqBins[j] = 0
-          } else if (valueDB > -this.gainDB) {
-            freqBins[j] = 255
-          } else {
-            freqBins[j] = Math.round(((valueDB + this.gainDB) / this.rangeDB) * 255)
-          }
-        }
-        channelFreq.push(freqBins)
+        channelFreq.push(magnitudesToColorIndices(spectrum, -this.gainDB, this.rangeDB))
       }
       frequencies.push(channelFreq)
     }


### PR DESCRIPTION
## Short description

Two display conventions from [Praat](https://www.fon.hum.uva.nl/praat/), as compute-time options on the spectrogram plugins (both default-off, so existing output is unchanged).

**Why Praat's display model:** Praat (Boersma & Weenink, University of Amsterdam) is the de facto standard tool in phonetics, linguistics and speech pathology — it's where speech researchers and annotators spend their working day, reading a broadband spectrogram to place segment boundaries by formant structure, stop bursts and voicing, with [TextGrid](https://www.fon.hum.uva.nl/praat/manual/TextGrid.html) tiers underneath (the annotation interchange format of the field; forced aligners like the [Montreal Forced Aligner](https://montreal-forced-aligner.readthedocs.io/) emit it). Their eyes are trained on a very specific view: short Gaussian window, 0–5 kHz, 70 dB dynamic range, [6 dB/oct pre-emphasis and autoscaling on by default](https://www.fon.hum.uva.nl/praat/manual/Advanced_spectrogram_settings___.html) (see also [Intro 3.1 — Viewing a spectrogram](https://www.fon.hum.uva.nl/praat/manual/Intro_3_1__Viewing_a_spectrogram.html)). Anyone building browser-based annotation UIs for that audience — which wavesurfer explicitly courts with the `linguistics` keyword in its own package.json — currently can't reproduce that view: without pre-emphasis the low band saturates dark, and without autoscaling every differently-recorded file needs manual `gainDB` fiddling. These two options close exactly that gap:

- **`preEmphasis`** (dB/octave): speech has a natural ~-6 dB/oct spectral slope, so without display pre-emphasis the low band saturates dark and formants above 1 kHz wash out. Each bin gets `preEmphasis * log2(binHz / 1000)` dB before quantization — 0 dB at 1 kHz, boost above, attenuation below. This is Praat's exact formula including its `1e-308` DC guard ([`fon/Spectrogram.cpp`](https://github.com/praat/praat/blob/master/fon/Spectrogram.cpp), `preemphasisTerm_db`; Praat's default is 6).
- **`autoGain`**: Praat-style [autoscaling](https://www.fon.hum.uva.nl/praat/manual/Advanced_spectrogram_settings___.html) (`spectrogram_autoscaling`, on by default in Praat — it's why annotators there never touch a gain knob when switching between files recorded at different levels). Instead of the fixed `gainDB` white point — which assumes a known signal level and renders arbitrary user audio too dark or too washed out — the white point becomes the loudest bin of the computed spectrogram (found after pre-emphasis), with everything `rangeDB` below it mapping to the other end. `gainDB` is ignored while enabled.

Combining `windowFunc: 'gauss'`, `scale: 'linear'`, `colorMap: 'gray'`, `rangeDB: 70`, `preEmphasis: 6`, `autoGain: true` (with the new `fftSize` for smooth bins) reproduces the classic Praat working view — the [broadband spectrogram](https://www.fon.hum.uva.nl/praat/manual/Sound__To_Spectrogram___.html) every phonetics student learns to read.

## Implementation details

Two commits:

**1. `refactor(Spectrogram): extract shared dB quantization helpers`** — the dB → Uint8 loop existed in three identical copies (main plugin, worker, windowed). It's now one `magnitudesToColorIndices()` in `fft.ts`, byte-identical by construction and pinned by tests that replay the old inline loop. Drive-by observation while extracting: the historical ramp expression is negative over its whole range and renders via `Uint8Array`'s mod-256 wrap, with a one-quantum seam just below the white point. I preserved it bit-for-bit (changing it would shift every mid-tone pixel of every existing spectrogram) and documented it — happy to do a separate clean-ramp fix if you want one.

**2. The two options.**
- The pre-emphasis tilt is precomputed once per render — per output row, from the linear bin frequencies or the sparse scale rows' center frequencies — so it costs one add per bin and is correct on all five scales, not just linear.
- `autoGain` computes one global maximum shared across channels (with `splitChannels`, a quieter channel renders lighter — inter-channel level differences are preserved; per-channel scaling was considered and rejected to keep channels comparable, matching Praat's whole-visible-part behavior). Digital silence (peak < -180 dBFS, i.e. below any real 16/24-bit or float32 noise floor) renders blank instead of amplifying the numeric floor.
- Memory-bounded two-pass design: below an internal 64 MB estimate (`frames x bins x 4 bytes x channels`) the Float32 dB frames are kept between passes; above it, only the running maximum is kept and spectra are recomputed for quantization (second FFT pass on very long short-window files, bounded heap). Only final `Uint8Array` results ever cross the worker boundary. Both strategies are test-pinned byte-identical.
- The autoGain quantizer maps `value >= whitePoint` to the last colormap entry with a clean linear ramp — deliberately not the preserved historical arithmetic, whose wrap would map the loudest bin to 0 when the white point is the exact data maximum.
- `autoGain` is SpectrogramPlugin + worker only. The windowed plugin computes segments lazily while scrolling, so a global maximum doesn't exist and a per-segment max would make brightness jump between segments — it gets `preEmphasis` only, documented in its JSDoc.
- Constructor validation (TypeError): `rangeDB` finite and > 0, `gainDB`/`preEmphasis` finite, `alpha` finite (and > 0 for `gauss`, where 0 divides by zero in the window formula). The FFT's blackman fallback becomes nullish so an explicit `alpha: 0` — a legitimate blackman parameter — is honored end to end. One behavior change to disclose: `rangeDB: 0` previously produced a degenerate binary map silently; it now throws with a clear message.
- Neither option affects `frequenciesDataUrl` (precomputed data is drawn as-is), and the default-path quantization is performance-neutral (measured 0.99x vs the old inline loop).

Deliberate deviations from Praat, for the record: wavesurfer computes window-uncompensated dBFS magnitudes rather than Praat's calibrated dB/Hz PSD (browser audio has no acoustic calibration — autoGain's relative mapping is what makes the images match anyway); the -180 dBFS silence guard replaces Praat's 0 dB/Hz autoscale floor, which has no dBFS analog; Praat's per-column dynamic compression (default off there) is not implemented.

## How to test it

`npm run test:unit` — 38 new tests: Praat tilt values (-6/0/+6 dB at 500/1000/2000 Hz), DC-bin behavior, autoGain level-invariance (same input at -40 dB gives identical bytes), gainDB-ignored, silence guard, buffered-vs-recompute parity, main-vs-worker byte parity for every option combination, refactor byte-parity against the old loop, and the validation matrix. In the browser: the example config below on any speech file, worker on/off — verified pixel-identical.

## Screenshots

`demo.wav` @ 16 kHz, gray colormap, 0-5 kHz:

| | |
|---|---|
| current defaults (fixed gainDB, no tilt) | ![defaults](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-praat-display/defaults-before.png) |
| `preEmphasis: 6, autoGain: true, rangeDB: 70`, gauss ("Praat look") | ![praat look](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-praat-display/praat-look.png) |
| same but `preEmphasis: 0` (autoGain only) | ![no preemphasis](https://raw.githubusercontent.com/koyukan/wavesurfer.js/screenshots/spectrogram-praat-display/praat-look-no-preemphasis.png) |

## Checklist
* [ ] This PR is covered by e2e tests — the spectrogram e2e suite is currently disabled (`xdescribe`); the numeric behavior is covered by the new jest suites and verified manually in Chrome (worker/main pixel parity, all scales).
* [x] It introduces no breaking API changes — new options are default-off with unchanged output; the one disclosed edge is `rangeDB: 0` now throwing instead of silently producing a degenerate binary map.
