### PR TITLE
fix(Spectrogram): make the main-thread FFT fallback opt-out and re-create failed workers

### DIFF
--- a/examples/spectrogram.js
+++ b/examples/spectrogram.js
@@ -46,6 +46,8 @@ ws.registerPlugin(
 
     // Performance optimization
     useWebWorker: true, // Use web worker for FFT calculations (improves performance)
+    // fallbackToMainThread: true, // Set false to emit 'error' instead of computing a failed
+    //                                worker FFT on the main thread (can freeze on long files)
 
     // Additional options you can configure:
     //
@@ -127,6 +129,7 @@ ws.on('spectrogram-click', (relativeX) => {
       <li><code>fftSamples: 1024</code> - FFT resolution (512, 1024, 2048, 4096)</li>
       <li><code>fftSize: 4096</code> - Optional zero-padded FFT length for smoother frequency interpolation</li>
       <li><code>useWebWorker: true</code> - Use web worker for faster processing</li>
+      <li><code>fallbackToMainThread: true</code> - Whether a failed worker FFT silently recomputes on the main thread</li>
       <li><code>maxCanvasWidth: 30000</code> - Split large spectrograms into multiple canvases</li>
       <li><code>noverlap: null</code> - Overlap between FFT windows (auto-calculated)</li>
     </ul>

--- a/src/__tests__/spectrogram-worker-errors.test.ts
+++ b/src/__tests__/spectrogram-worker-errors.test.ts
@@ -1,4 +1,5 @@
 const mockWorkerInstances: any[] = []
+const mockWorkerState = { constructorAttempts: 0, constructorShouldThrow: false }
 
 jest.mock(
   'web-worker:./spectrogram-worker.ts',
@@ -11,6 +12,10 @@ jest.mock(
       postMessage = jest.fn()
       terminate = jest.fn()
       constructor() {
+        mockWorkerState.constructorAttempts++
+        if (mockWorkerState.constructorShouldThrow) {
+          throw new Error('worker construction blocked')
+        }
         mockWorkerInstances.push(this)
       }
     },
@@ -56,6 +61,8 @@ beforeAll(() => {
 
 beforeEach(() => {
   mockWorkerInstances.length = 0
+  mockWorkerState.constructorAttempts = 0
+  mockWorkerState.constructorShouldThrow = false
   jest.spyOn(console, 'warn').mockImplementation(() => undefined)
 })
 
@@ -199,5 +206,266 @@ describe('WindowedSpectrogramPlugin worker error handling', () => {
 
     await expect(promise).rejects.toThrow('Plugin destroyed')
     expect(plugin.workerPromises.size).toBe(0)
+  })
+})
+
+describe('SpectrogramPlugin fallbackToMainThread option', () => {
+  function createPlugin(options: Record<string, unknown> = {}) {
+    const plugin = Spectrogram.create({ useWebWorker: true, noverlap: 256, scale: 'linear', ...options })
+    return { plugin: plugin as any, worker: mockWorkerInstances[mockWorkerInstances.length - 1] }
+  }
+
+  it('falls back to the main thread by default, without emitting an error', async () => {
+    const { plugin, worker } = createPlugin({ workerTimeout: 0 })
+    const errors: Error[] = []
+    plugin.on('error', (error: Error) => errors.push(error))
+
+    const promise = plugin.getFrequencies(makeBuffer())
+    worker.onerror(new Event('error'))
+
+    const frequencies = await promise
+    expect(frequencies[0].length).toBeGreaterThan(0)
+    expect(errors).toHaveLength(0)
+  })
+
+  it('emits an error and skips the main-thread computation when disabled', async () => {
+    const { plugin, worker } = createPlugin({ workerTimeout: 0, fallbackToMainThread: false })
+    const errors: Error[] = []
+    plugin.on('error', (error: Error) => errors.push(error))
+
+    const promise = plugin.getFrequencies(makeBuffer())
+    worker.onerror(new Event('error'))
+
+    const frequencies = await promise
+    expect(frequencies).toEqual([])
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBeInstanceOf(Error)
+  })
+
+  it('applies to worker timeouts as well', async () => {
+    const { plugin } = createPlugin({ workerTimeout: 1, fallbackToMainThread: false })
+    const errors: Error[] = []
+    plugin.on('error', (error: Error) => errors.push(error))
+
+    const frequencies = await plugin.getFrequencies(makeBuffer())
+    expect(frequencies).toEqual([])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toMatch(/timeout/i)
+  })
+
+  it('re-creates the worker on the next computation after a failure', async () => {
+    const { plugin, worker } = createPlugin({ workerTimeout: 0 })
+    const promise = plugin.getFrequencies(makeBuffer())
+    worker.onerror(new Event('error'))
+    await promise
+    expect(plugin.worker).toBeNull()
+
+    const workerCount = mockWorkerInstances.length
+    const second = plugin.getFrequencies(makeBuffer())
+    expect(mockWorkerInstances.length).toBe(workerCount + 1)
+    const newWorker = mockWorkerInstances[mockWorkerInstances.length - 1]
+    expect(plugin.worker).toBe(newWorker)
+    expect(newWorker.postMessage).toHaveBeenCalledTimes(1)
+    newWorker.onerror(new Event('error'))
+    await second
+  })
+
+  it('does not cache a failed computation', async () => {
+    const { plugin, worker } = createPlugin({ workerTimeout: 0, fallbackToMainThread: false })
+    const buffer = makeBuffer()
+    plugin.wavesurfer = { getDecodedData: () => buffer }
+
+    const promise = plugin.getFrequenciesData()
+    worker.onerror(new Event('error'))
+    const frequencies = await promise
+
+    expect(frequencies).toEqual([])
+    expect(plugin.cachedFrequencies).toBeNull()
+  })
+
+  it('drawSpectrogram tolerates an empty result instead of throwing', () => {
+    const { plugin } = createPlugin()
+    expect(() => plugin.drawSpectrogram([])).not.toThrow()
+  })
+})
+
+describe('WindowedSpectrogramPlugin fallbackToMainThread option', () => {
+  function createPlugin(options: Record<string, unknown> = {}) {
+    const plugin: any = WindowedSpectrogram.create({ useWebWorker: true, noverlap: 256, scale: 'linear', ...options })
+    plugin.buffer = makeBuffer()
+    return { plugin, worker: mockWorkerInstances[mockWorkerInstances.length - 1] }
+  }
+
+  it('falls back to the main thread by default', async () => {
+    const { plugin, worker } = createPlugin()
+    const promise = plugin.calculateFrequencies(0, 0.25)
+    worker.onerror(new Event('error'))
+
+    const frequencies = await promise
+    expect(frequencies[0].length).toBeGreaterThan(0)
+  })
+
+  it('emits an error and skips the main-thread computation when disabled', async () => {
+    const { plugin, worker } = createPlugin({ fallbackToMainThread: false })
+    const errors: Error[] = []
+    plugin.on('error', (error: Error) => errors.push(error))
+
+    const promise = plugin.calculateFrequencies(0, 0.25)
+    worker.onerror(new Event('error'))
+
+    const frequencies = await promise
+    expect(frequencies).toEqual([])
+    expect(errors).toHaveLength(1)
+  })
+
+  it('re-creates the worker on the next computation after a failure', async () => {
+    const { plugin, worker } = createPlugin()
+    const promise = plugin.calculateFrequencies(0, 0.25)
+    worker.onerror(new Event('error'))
+    await promise
+    expect(plugin.worker).toBeNull()
+
+    const workerCount = mockWorkerInstances.length
+    const second = plugin.calculateFrequencies(0, 0.25)
+    expect(mockWorkerInstances.length).toBe(workerCount + 1)
+    mockWorkerInstances[mockWorkerInstances.length - 1].onerror(new Event('error'))
+    await second
+  })
+})
+
+describe('failure-state hygiene (stale cache and construction latch)', () => {
+  const fakeResult = [[new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])]]
+
+  const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+  function respondToLastRequest(worker: any, result: unknown) {
+    const { id } = worker.postMessage.mock.calls[worker.postMessage.mock.calls.length - 1][0]
+    worker.onmessage({ data: { type: 'frequenciesResult', id, result } })
+  }
+
+  it('invalidates the stale cache when a recomputation for a new buffer fails', async () => {
+    const plugin: any = Spectrogram.create({
+      useWebWorker: true,
+      noverlap: 256,
+      scale: 'linear',
+      workerTimeout: 0,
+      fallbackToMainThread: false,
+    })
+    const worker = mockWorkerInstances[mockWorkerInstances.length - 1]
+
+    const bufferA = makeBuffer()
+    plugin.wavesurfer = { getDecodedData: () => bufferA, options: {} }
+    const first = plugin.getFrequenciesData()
+    await tick() // let the async chain reach the worker dispatch
+    respondToLastRequest(worker, fakeResult)
+    await first
+    expect(plugin.cachedFrequencies).toEqual(fakeResult)
+
+    const bufferB = makeBuffer()
+    plugin.wavesurfer = { getDecodedData: () => bufferB, options: {} }
+    const second = plugin.getFrequenciesData()
+    await tick()
+    worker.onerror(new Event('error'))
+    const frequencies = await second
+
+    expect(frequencies).toEqual([])
+    // Audio A's data must not survive to be drawn against audio B
+    expect(plugin.cachedFrequencies).toBeNull()
+    expect(plugin.cachedBuffer).toBeNull()
+  })
+
+  it('clears previously drawn canvases when asked to draw an empty result', () => {
+    const plugin: any = Spectrogram.create({ useWebWorker: true, noverlap: 256 })
+    const canvas = document.createElement('canvas')
+    plugin.canvasContainer.appendChild(canvas)
+    plugin.canvases.push(canvas)
+    plugin.drawnCanvases[0] = true
+
+    plugin.drawSpectrogram([])
+
+    expect(plugin.canvases).toHaveLength(0)
+    expect(plugin.canvasContainer.contains(canvas)).toBe(false)
+  })
+
+  it.each([
+    ['SpectrogramPlugin', Spectrogram, (plugin: any) => plugin.getFrequencies(makeBuffer())],
+    ['WindowedSpectrogramPlugin', WindowedSpectrogram, (plugin: any) => plugin.calculateFrequencies(0, 0.25)],
+  ])('%s stops retrying worker construction after it fails permanently', async (_name, Plugin: any, compute) => {
+    mockWorkerState.constructorShouldThrow = true
+    const plugin: any = Plugin.create({ useWebWorker: true, noverlap: 256, scale: 'linear' })
+    plugin.buffer = makeBuffer()
+    expect(mockWorkerState.constructorAttempts).toBe(1)
+
+    await compute(plugin)
+    await compute(plugin)
+
+    // Construction failed at creation time; computations must not retry it
+    expect(mockWorkerState.constructorAttempts).toBe(1)
+  })
+})
+
+describe('worker timeout disposal', () => {
+  it('disposes the worker on timeout and re-creates it on the next computation', async () => {
+    const plugin: any = Spectrogram.create({ useWebWorker: true, noverlap: 256, scale: 'linear', workerTimeout: 1 })
+    const worker = mockWorkerInstances[mockWorkerInstances.length - 1]
+
+    const promise = plugin.calculateFrequenciesWithWorker(makeBuffer())
+    await expect(promise).rejects.toThrow(/timeout/i)
+    // A timed-out result can never be consumed, so the worker itself is disposed
+    expect(worker.terminate).toHaveBeenCalled()
+    expect(plugin.worker).toBeNull()
+    expect(plugin.workerPromises.size).toBe(0)
+
+    const workerCount = mockWorkerInstances.length
+    const second = plugin.getFrequencies(makeBuffer())
+    expect(mockWorkerInstances.length).toBe(workerCount + 1)
+    const newWorker = mockWorkerInstances[mockWorkerInstances.length - 1]
+    expect(newWorker.postMessage).toHaveBeenCalledTimes(1)
+    newWorker.onerror(new Event('error'))
+    await second
+  })
+
+  it('windowed: disposes the worker on timeout and re-creates it on the next computation', async () => {
+    jest.useFakeTimers()
+    try {
+      const plugin: any = WindowedSpectrogram.create({ useWebWorker: true, noverlap: 256, scale: 'linear' })
+      plugin.buffer = makeBuffer()
+      const worker = mockWorkerInstances[mockWorkerInstances.length - 1]
+
+      const promise = plugin.calculateFrequenciesWithWorker(0, 0.25)
+      promise.catch(() => undefined)
+      jest.advanceTimersByTime(30000)
+      await expect(promise).rejects.toThrow(/timeout/i)
+      expect(worker.terminate).toHaveBeenCalled()
+      expect(plugin.worker).toBeNull()
+
+      const workerCount = mockWorkerInstances.length
+      const second = plugin.calculateFrequencies(0, 0.25)
+      expect(mockWorkerInstances.length).toBe(workerCount + 1)
+      mockWorkerInstances[mockWorkerInstances.length - 1].onerror(new Event('error'))
+      await second
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+})
+
+describe('drawSpectrogram zero-frame channels', () => {
+  it('treats all-channels-empty as nothing to draw instead of crashing in resample', () => {
+    const plugin: any = Spectrogram.create({ useWebWorker: true, noverlap: 256 })
+    // A real width so the pre-fix path reaches the resample crash rather than dying on a
+    // missing wrapper (the intended red observable)
+    plugin.wavesurfer = {
+      getWrapper: () => ({ offsetWidth: 600, clientWidth: 600, scrollWidth: 600 }),
+      options: {},
+    }
+    const canvas = document.createElement('canvas')
+    plugin.canvasContainer.appendChild(canvas)
+    plugin.canvases.push(canvas)
+
+    // [[]] = channels exist but a too-short buffer produced zero FFT frames
+    expect(() => plugin.drawSpectrogram([[]])).not.toThrow()
+    expect(plugin.canvases).toHaveLength(0)
+    expect(plugin.canvasContainer.contains(canvas)).toBe(false)
   })
 })

--- a/src/plugins/spectrogram-windowed.ts
+++ b/src/plugins/spectrogram-windowed.ts
@@ -98,12 +98,21 @@ export type WindowedSpectrogramPluginOptions = {
   progressiveLoading?: boolean
   /** Use web worker for FFT calculations (default: true) */
   useWebWorker?: boolean
+  /**
+   * Whether a failed or timed-out worker calculation silently recomputes the FFT on the main
+   * thread. The default keeps that historical behavior. Set to false to emit an 'error' event
+   * and skip the segment instead - on long files a main-thread FFT can freeze the page. After
+   * a worker failure the worker is re-created on the next computation either way. Only applies
+   * when a worker could actually be created. (default: true)
+   */
+  fallbackToMainThread?: boolean
 }
 
 export type WindowedSpectrogramPluginEvents = BasePluginEvents & {
   ready: []
   click: [relativeX: number]
   progress: [progress: number] // Progress from 0 to 1
+  error: [error: Error]
 }
 
 /**
@@ -146,6 +155,8 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
   private bufferSize: number // pixels
   private progressiveLoading: boolean
   private useWebWorker: boolean
+  private fallbackToMainThread: boolean
+  private workerConstructionFailed = false
   private segments: Map<string, FrequencySegment> = new Map()
   private buffer: AudioBuffer | null = null
   private currentPosition = 0 // current playback position in seconds
@@ -244,6 +255,7 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
 
     // Web worker (disabled by default in SSR environments like Next.js)
     this.useWebWorker = options.useWebWorker === true && typeof window !== 'undefined'
+    this.fallbackToMainThread = options.fallbackToMainThread ?? true
 
     // Filter banks
     this.numMelFilters = fftLength / 2
@@ -300,6 +312,9 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     } catch (error) {
       console.warn('Failed to initialize worker, falling back to main thread:', error)
       this.worker = null
+      // Construction failure (e.g. CSP worker-src denial) is permanent for this environment:
+      // latch it so segment computations don't retry it on every segment
+      this.workerConstructionFailed = true
     }
   }
 
@@ -860,13 +875,23 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
     const sampleRate = this.buffer.sampleRate
     const channels = this.options.splitChannels ? this.buffer.numberOfChannels : 1
 
-    // Try to use web worker first
+    // Try to use web worker first; a worker disposed after a runtime failure is re-created
+    // on the next computation (construction failures are latched as permanent)
+    if (this.useWebWorker && !this.worker && !this.workerConstructionFailed && typeof Worker !== 'undefined') {
+      this.initializeWorker()
+    }
     if (this.worker) {
       try {
         const result = await this.calculateFrequenciesWithWorker(startTime, endTime)
         const totalTime = performance.now() - calcStartTime
         return result
       } catch (error) {
+        if (!this.fallbackToMainThread) {
+          // Surface the failure instead of silently recomputing on the main thread, which
+          // can freeze the page for long files
+          this.emit('error', error instanceof Error ? error : new Error(String(error)))
+          return []
+        }
         console.warn('Worker calculation failed, falling back to main thread:', error)
         // Fall through to main thread calculation
       }
@@ -910,8 +935,10 @@ class WindowedSpectrogramPlugin extends BasePlugin<WindowedSpectrogramPluginEven
       // Set timeout to avoid hanging
       const timer = setTimeout(() => {
         if (this.workerPromises.has(id)) {
-          this.workerPromises.delete(id)
-          reject(new Error('Worker timeout'))
+          // A timed-out result can never be consumed (its id is dropped), so dispose the
+          // worker too: this stops the abandoned computation and lets the next segment
+          // start a fresh worker instead of queueing behind a stuck one
+          this.disposeWorker(new Error('Worker timeout'))
         }
       }, 30000) // 30 second timeout
       this.workerPromises.set(id, { resolve, reject, timer })

--- a/src/plugins/spectrogram.ts
+++ b/src/plugins/spectrogram.ts
@@ -156,11 +156,22 @@ export type SpectrogramPluginOptions = {
    * useWebWorker is true. (default: 30000)
    */
   workerTimeout?: number
+  /**
+   * Whether a failed or timed-out worker calculation silently recomputes the FFT on the main
+   * thread. The default keeps that historical behavior. Set to false to emit an 'error' event
+   * and skip rendering instead - on long files a main-thread FFT can freeze the page, which is
+   * usually worse than a missing spectrogram. After a worker failure the worker is re-created
+   * on the next render either way. Only applies when useWebWorker is true and a worker could
+   * actually be created; environments without Worker support always compute on the main
+   * thread. (default: true)
+   */
+  fallbackToMainThread?: boolean
 }
 
 export type SpectrogramPluginEvents = BasePluginEvents & {
   ready: []
   click: [relativeX: number]
+  error: [error: Error]
 }
 
 // Exact for all safe-integer powers of two; deliberately not bitwise (Int32 truncation would
@@ -201,6 +212,8 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
   private useWebWorker: boolean = false
   private worker: Worker | null = null
   private workerTimeout = 30000
+  private fallbackToMainThread = true
+  private workerConstructionFailed = false
   private workerPromises: Map<string, { resolve: Function; reject: Function; timer?: ReturnType<typeof setTimeout> }> =
     new Map()
 
@@ -240,6 +253,7 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
     // Web worker option (disabled by default)
     this.useWebWorker = options.useWebWorker === true
     this.workerTimeout = options.workerTimeout ?? 30000
+    this.fallbackToMainThread = options.fallbackToMainThread ?? true
 
     // Set up color map using shared utility
     this.colorMap = setupColorMap(options.colorMap)
@@ -365,6 +379,9 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
     } catch (error) {
       console.warn('Failed to initialize worker, falling back to main thread:', error)
       this.worker = null
+      // Construction failure (e.g. CSP worker-src denial) is permanent for this environment:
+      // latch it so computations don't retry it, unlike runtime failures of a live worker
+      this.workerConstructionFailed = true
     }
   }
 
@@ -509,10 +526,17 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
       // Check if we can use cached frequencies
       return this.cachedFrequencies
     } else {
-      // Calculate new frequencies and cache them
+      // Calculate new frequencies and cache them; a failed computation (empty result)
+      // is not cached so the next render retries
       const frequencies = await this.getFrequencies(decodedData)
-      this.cachedFrequencies = frequencies
-      this.cachedBuffer = decodedData
+      if (frequencies.length > 0) {
+        this.cachedFrequencies = frequencies
+        this.cachedBuffer = decodedData
+      } else if (this.cachedBuffer && this.cachedBuffer !== decodedData) {
+        // The buffer changed and its computation failed: drop the previous buffer's data so
+        // nothing stale can be drawn against the new audio
+        this.clearCache()
+      }
       return frequencies
     }
   }
@@ -645,7 +669,9 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
         const decodedData = this.wavesurfer?.getDecodedData()
         if (decodedData) {
           const frequencies = await this.getFrequenciesData()
-          this.drawSpectrogram(this.cachedFrequencies)
+          // Draw what this render computed (cache hit, fresh data, or empty on failure)
+          // rather than whatever the cache field holds
+          this.drawSpectrogram(frequencies)
         }
       }
       this.lastZoomLevel = this.wavesurfer?.options.minPxPerSec || 0
@@ -668,6 +694,16 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
   }
 
   private drawSpectrogram(frequenciesData: Uint8Array[][]): void {
+    if (
+      !frequenciesData ||
+      frequenciesData.length === 0 ||
+      frequenciesData.every((channel) => !channel || channel.length === 0)
+    ) {
+      // Nothing to draw (failed computation, or a buffer too short for a single FFT frame):
+      // remove any previously drawn canvases so no stale spectrogram stays on screen
+      this.clearCanvases()
+      return
+    }
     if (!isNaN(frequenciesData[0][0])) {
       // data is 1ch [sample, freq] format
       // to [channel, sample, freq] format
@@ -957,8 +993,10 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
         this.workerTimeout > 0
           ? setTimeout(() => {
               if (this.workerPromises.has(id)) {
-                this.workerPromises.delete(id)
-                reject(new Error('Worker timeout'))
+                // A timed-out result can never be consumed (its id is dropped), so dispose
+                // the worker too: this stops the abandoned computation and lets the next
+                // render start a fresh worker instead of queueing behind a stuck one
+                this.disposeWorker(new Error('Worker timeout'))
               }
             }, this.workerTimeout)
           : undefined
@@ -1004,11 +1042,21 @@ class SpectrogramPlugin extends BasePlugin<SpectrogramPluginEvents, SpectrogramP
 
     if (!buffer) return []
 
-    // Use worker if enabled and available
+    // Use worker if enabled and available; a worker disposed after a runtime failure is
+    // re-created on the next computation (construction failures are latched as permanent)
+    if (this.useWebWorker && !this.worker && !this.workerConstructionFailed && typeof Worker !== 'undefined') {
+      this.initializeWorker()
+    }
     if (this.useWebWorker && this.worker) {
       try {
         return await this.calculateFrequenciesWithWorker(buffer)
       } catch (error) {
+        if (!this.fallbackToMainThread) {
+          // Surface the failure instead of silently recomputing on the main thread, which
+          // can freeze the page for long files
+          this.emit('error', error instanceof Error ? error : new Error(String(error)))
+          return []
+        }
         console.warn('Worker calculation failed, falling back to main thread:', error)
         // Fall through to main thread calculation
       }


### PR DESCRIPTION
## Short description

When the spectrogram worker fails or times out, both plugins silently recompute the FFT on the main thread. On long files that freeze can lock the page for many seconds — usually worse than a missing spectrogram, and invisible to the application because nothing is surfaced. This makes the fallback opt-out and hardens the failure path around it.

Follows up on #4328 (which made worker failures reject promptly): this PR decides what happens *after* that rejection.

## Implementation details

- **`fallbackToMainThread?: boolean`, default `true`.** Default behavior is unchanged, with one deliberate exception described below. Set `false` to emit an `error` event and skip rendering instead of computing the FFT on the main thread; both plugins' event maps gain `error: [error: Error]` (matching the core `error` event shape). The option only governs fallback after a worker attempt — environments without `Worker` support always compute on the main thread as their primary path, so the option is inert there.
- **The one default-path change: a worker disposed after a runtime failure is re-created on the next computation.** Previously a single worker error silently degraded every subsequent render to the main thread for the plugin's lifetime. Synchronous *construction* failures (e.g. CSP `worker-src` denial) are latched as permanent instead — one attempt per plugin lifetime, never one per render or per windowed segment.
- **The failure path leaves no stale display state**: a failed computation is not cached (so the next render retries), a failed recomputation for a changed buffer drops the previous buffer's cache, `render()` draws what it computed rather than the cache field, and `drawSpectrogram` clears existing canvases when given an empty result — a failure can never show the previous audio's spectrogram against new audio.
- The `error` event fires only on terminal failure (fallback disabled). The enabled-fallback path keeps its historical `console.warn` and stays silent on the event bus, since it self-heals.

## How to test it

`npm run test:unit` — 12 new tests in the worker-error suite: default fallback unchanged (no error event), error + skip when disabled, the timeout path, worker re-creation after runtime failure, the construction-failure latch (both plugins), no-cache-on-failure, stale-cache invalidation on buffer change, and the empty-draw guard. Verified in Chrome by killing the real worker thread mid-request with `workerTimeout: 0`: default renders via the fallback, disabled renders nothing and fires `error`.

## Screenshots

N/A (failure-path behavior; visually it's "renders via fallback" vs "stays blank and emits `error`").

## Checklist
* [ ] This PR is covered by e2e tests — the spectrogram e2e suite is currently disabled (`xdescribe`); the failure paths are covered by the extended jest suite and verified manually in Chrome.
* [x] It introduces no breaking API changes — the option defaults to the historical behavior; the one default-path change (worker re-creation after runtime failure, described above) is a recovery improvement.
