### PR TITLE
fix(Decoder): avoid closing a closed AudioContext

### DIFF
--- a/src/__tests__/decoder.test.ts
+++ b/src/__tests__/decoder.test.ts
@@ -1,0 +1,41 @@
+import Decoder from '../decoder.js'
+
+describe('Decoder', () => {
+  const originalAudioContext = global.AudioContext
+  const audioBuffer = {} as AudioBuffer
+  const decodeAudioData = jest.fn()
+  const close = jest.fn()
+  let state: AudioContextState
+
+  beforeEach(() => {
+    state = 'running'
+    decodeAudioData.mockReset().mockResolvedValue(audioBuffer)
+    close.mockReset().mockResolvedValue(undefined)
+
+    global.AudioContext = jest.fn().mockImplementation(() => ({
+      decodeAudioData,
+      close,
+      get state() {
+        return state
+      },
+    }))
+  })
+
+  afterAll(() => {
+    global.AudioContext = originalAudioContext
+  })
+
+  test('closes an active AudioContext after decoding', async () => {
+    const result = await Decoder.decode(new ArrayBuffer(0), 8_000)
+
+    expect(result).toBe(audioBuffer)
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not close an AudioContext that is already closed', async () => {
+    state = 'closed'
+
+    await expect(Decoder.decode(new ArrayBuffer(0), 8_000)).resolves.toBe(audioBuffer)
+    expect(close).not.toHaveBeenCalled()
+  })
+})

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -6,7 +6,7 @@ async function decode(audioData: ArrayBuffer, sampleRate: number): Promise<Audio
   } finally {
     // Ensure AudioContext is always closed, even on synchronous errors
     if (audioCtx.state !== 'closed') {
-      await audioCtx.close()
+      await audioCtx.close().catch(() => undefined)
     }
   }
 }

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -5,7 +5,9 @@ async function decode(audioData: ArrayBuffer, sampleRate: number): Promise<Audio
     return await audioCtx.decodeAudioData(audioData)
   } finally {
     // Ensure AudioContext is always closed, even on synchronous errors
-    audioCtx.close()
+    if (audioCtx.state !== 'closed') {
+      await audioCtx.close()
+    }
   }
 }
 


### PR DESCRIPTION
## Short description

Prevent decoder cleanup from attempting to close an `AudioContext` that is already closed.

Safari can reject the promise returned by `AudioContext.close()` with `InvalidStateError: Cannot close a closed AudioContext.` Because the existing call is fire-and-forget, that rejection surfaces as an unhandled browser exception even though decoding has already completed.

## Implementation details

- Check the context state before closing it.
- Await the close promise so cleanup completes within the decoder promise instead of producing an unhandled rejection.
- Add unit coverage for both active and already-closed contexts.