### PR TITLE
fix(regions): prune per-region subscriptions from plugin-level array on remove

### DIFF
--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -731,7 +731,8 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       const unsubscribeRender = region.on('render', renderIfVisible)
 
       // Only push the unsubscribe functions, not the once() return values
-      this.subscriptions.push(unsubscribeScroll, unsubscribeZoom, unsubscribeResize, unsubscribeRender)
+      const virtualAppendSubscriptions = [unsubscribeScroll, unsubscribeZoom, unsubscribeResize, unsubscribeRender]
+      this.subscriptions.push(...virtualAppendSubscriptions)
 
       // Clean up subscriptions when region is removed
       region.once('remove', () => {
@@ -739,6 +740,10 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         unsubscribeZoom()
         unsubscribeResize()
         unsubscribeRender()
+        // Prune this region's now-dead unsubscribe closures from the plugin-level
+        // subscriptions array; otherwise it only gets emptied in destroy(), so every
+        // removed region stays retained (via its captured closures) for the plugin's lifetime.
+        this.subscriptions = this.subscriptions.filter((sub) => !virtualAppendSubscriptions.includes(sub))
       })
     }, 0)
   }
@@ -781,6 +786,10 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       // Remove the region from the list when it's removed
       region.once('remove', () => {
         regionSubscriptions.forEach((unsubscribe) => unsubscribe())
+        // Prune this region's now-dead unsubscribe closures from the plugin-level
+        // subscriptions array; otherwise it only gets emptied in destroy(), so every
+        // removed region stays retained (via its captured closures) for the plugin's lifetime.
+        this.subscriptions = this.subscriptions.filter((sub) => !regionSubscriptions.includes(sub))
         this.regions = this.regions.filter((reg) => reg !== region)
         this.emit('region-removed', region)
       }),
@@ -803,12 +812,14 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     this.emit('region-initialized', region)
 
     if (!duration) {
-      this.subscriptions.push(
-        this.wavesurfer.once('ready', (duration) => {
-          region._setTotalDuration(duration)
-          this.saveRegion(region)
-        }),
-      )
+      // Prune this once('ready') unsubscriber after it fires instead of retaining it
+      // (and the region it captures) in the plugin-level subscriptions array until destroy().
+      const unsubscribeReady = this.wavesurfer.once('ready', (duration) => {
+        region._setTotalDuration(duration)
+        this.saveRegion(region)
+        this.subscriptions = this.subscriptions.filter((sub) => sub !== unsubscribeReady)
+      })
+      this.subscriptions.push(unsubscribeReady)
     } else {
       this.saveRegion(region)
     }


### PR DESCRIPTION
## Problem

`RegionsPlugin` pushes an unsubscribe closure into the plugin-level `subscriptions` array for every event it wires up per region — roughly 11 per region:

- `saveRegion`: 7 (`update`, `update-end`, `play`, `click`, `dblclick`, `content-changed`, `remove`)
- `virtualAppend`: 4 (`scroll`, `zoom`, `resize`, region `render`)
- `addRegion` pre-decode: 1 (`once('ready')`)

That array is only ever emptied in `destroy()`. When a region is removed, its `once('remove')` handler *calls* the unsubscribe closures but never *removes them from the array*. Since each closure captures its region (and its DOM element), **every region ever created stays retained for the plugin's lifetime**.

In long-lived players that repeatedly add and remove regions (e.g. an editor that rebuilds regions as the user works), this is an unbounded memory leak. The ever-growing `subscriptions` array also turns each rebuild into quadratic work.

Note: #4258 fixed the *per-region* `SingleRegion.subscriptions` (DOM listeners) but not this *plugin-level* array, so the leak still reproduces on current `main`.

## Fix

Prune each region's closures from `this.subscriptions` at the moment the region is removed, and drop the pre-decode `once('ready')` unsubscriber once it has fired:

- `saveRegion` / `virtualAppend`: on `region.once('remove')`, after invoking the closures, `filter` them out of `this.subscriptions`.
- `addRegion`: after `once('ready')` fires, remove its unsubscriber from `this.subscriptions`.

Behavior is otherwise unchanged — the same closures still run on removal; they just no longer linger in the array afterwards.

## Verification

- `tsc --noEmit` clean
- `eslint src/plugins/regions.ts` clean

Repeatedly adding/removing regions now keeps `plugin.subscriptions` bounded (returns to baseline after each add/remove cycle) instead of growing without limit.