### PR TITLE
definePlugin: functional plugin API with scope-owned teardown; six plugins ported

### DIFF
--- a/docs/RELEASE_NOTES-scope-refactor.md
+++ b/docs/RELEASE_NOTES-scope-refactor.md
@@ -188,13 +188,15 @@ and event name+payload is preserved. `record` and the spectrogram plugins were *
   once. When the caller doesn't pass `maxZoom`, it's derived from the container's `clientWidth`
   at setup time; a destroy → re-init cycle (e.g. after a container resize) now picks up the
   current width rather than the value computed at the plugin's first init.
-- **`hover`, `regions`, and `minimap` now remove their root DOM element (wrapper /
-  `regionsContainer` / minimap wrapper) as part of scope disposal, which runs BEFORE the
-  `'destroy'` event is emitted** (`definePlugin`'s destroy order is: dispose `ctx.scope`, then
-  `super.destroy()` — which emits `'destroy'` last). Previously these three plugins removed their
-  root element AFTER the `'destroy'` event, so a `plugin.on('destroy', ...)` listener could still
-  observe the element attached to the DOM; it can no longer do so. Each port's test suite (plus
-  the regions memory-leak suite) was checked and found nothing pinned the old ordering.
+- **`hover` and `regions` now remove their root DOM element (wrapper / `regionsContainer`) as
+  part of scope disposal, which runs BEFORE the `'destroy'` event is emitted**
+  (`definePlugin`'s destroy order is: dispose `ctx.scope`, then `super.destroy()` — which emits
+  `'destroy'` last). Previously these two plugins removed their root element AFTER the
+  `'destroy'` event, so a `plugin.on('destroy', ...)` listener could still observe the element
+  attached to the DOM; it can no longer do so. Each port's test suite (plus the regions
+  memory-leak suite) was checked and found nothing pinned the old ordering. (`minimap` also
+  removes its wrapper via scope disposal now, but its pre-port `destroy()` already removed the
+  wrapper before `super.destroy()`, so this is not an ordering change for minimap.)
 - **The timeline plugin's "container not found" error message wording changed**, from
   `` `No Timeline container found matching ${container}` `` to
   `` `timeline: container not found: ${container}` `` (now produced by the shared

--- a/docs/RELEASE_NOTES-scope-refactor.md
+++ b/docs/RELEASE_NOTES-scope-refactor.md
@@ -138,12 +138,22 @@ replacing hand-rolled window tracking and load-version guards. No event-timing o
 Adds a functional plugin API, `definePlugin(name, (ctx, options) => api)`, whose teardown is a
 single `Scope` disposal instead of a hand-rolled `destroy()` override, and rebuilds six of the
 seven remaining first-party plugins on it. This is an **additive** API — `BasePlugin`
-class-based plugins (first-party and third-party) keep working unchanged. `definePlugin` is now
-re-exported from the package's main entry point alongside its supporting types:
+class-based plugins (first-party and third-party) keep working unchanged. `definePlugin` is
+exposed as a static on the `WaveSurfer` class rather than a named export from the main entry
+point — the main-entry rollup outputs (CJS/UMD) use `output.exports: 'default'`, which hard-errors
+on a runtime named export alongside the default export. Its supporting types (`PluginContext`,
+`PluginSetup`, `DefinedPlugin`) are still re-exported by name from the main entry, since types are
+erased before bundling and don't hit that restriction:
 
 ```ts
-import { definePlugin, type PluginContext, type PluginSetup, type DefinedPlugin } from 'wavesurfer.js'
+import WaveSurfer, { type PluginContext, type PluginSetup, type DefinedPlugin } from 'wavesurfer.js'
+
+const MyPlugin = WaveSurfer.definePlugin('MyPlugin', (ctx, options) => ({ ... }))
 ```
+
+If you need `definePlugin` without importing all of `wavesurfer.js`, it's also available directly
+from its dist subpath: `import { definePlugin } from 'wavesurfer.js/dist/define-plugin.js'` (that
+module has no default export, so it's unaffected by the `exports: 'default'` restriction above).
 
 ### New API
 
@@ -161,8 +171,12 @@ import { definePlugin, type PluginContext, type PluginSetup, type DefinedPlugin 
 
 `hover`, `zoom`, `timeline`, `minimap`, `envelope`, `regions`. Every exported class name, default
 export, `Plugin.create(options)` / `new Plugin(options)` constructor form, public method/field,
-and event name+payload is preserved. `record` and the spectrogram plugins were **not** ported
-(see below); `spectrogram-*` unification is scheduled for a later phase.
+and event name+payload is preserved — including each class's runtime `Function.name` (`HoverPlugin`,
+`ZoomPlugin`, `TimelinePlugin`, `MinimapPlugin`, `EnvelopePlugin`, `RegionsPlugin`), which
+`definePlugin`'s internal `Defined` class takes on via the first argument passed to
+`definePlugin(name, setup)`; this keeps devtools/stack-trace display names stable across the port.
+`record` and the spectrogram plugins were **not** ported (see below); `spectrogram-*` unification is
+scheduled for a later phase.
 
 - **`RecordPlugin` stays class-based.** It's usable standalone (construct → `startMic()`/
   `record()` → `destroy()`, without ever calling `registerPlugin()`), which `definePlugin`'s
@@ -201,3 +215,13 @@ and event name+payload is preserved. `record` and the spectrogram plugins were *
   `` `No Timeline container found matching ${container}` `` to
   `` `timeline: container not found: ${container}` `` (now produced by the shared
   `resolveContainer()` helper, consistent with every other plugin's container-resolution error).
+- **`minimap` and `envelope`'s `create(options)` / `new Plugin(options)` argument is now
+  optional** (`MinimapPlugin.create()` and `EnvelopePlugin.create()` are both valid with no
+  argument now, as is `new MinimapPlugin()` / `new EnvelopePlugin()`). Previously the hand-written
+  classes declared `constructor(options: MinimapPluginOptions)` /
+  `constructor(options: EnvelopePluginOptions)` — a required parameter — even though every field on
+  both options types was already optional. `definePlugin`'s `PluginCtorArgs` derives
+  optionality structurally (an all-optional `Options` type gets an optional `create()`/constructor
+  parameter), so this falls out automatically from the port. It's a pure type widening, not a
+  runtime behavior change: both setups already handled an omitted/`undefined` `options` correctly
+  via `Object.assign({}, defaultOptions, options)`.

--- a/docs/RELEASE_NOTES-scope-refactor.md
+++ b/docs/RELEASE_NOTES-scope-refactor.md
@@ -132,3 +132,70 @@ replacing hand-rolled window tracking and load-version guards. No event-timing o
 
 - Deferred-minor cleanup sweep: webaudio stale-source guard, envelope polyline null checks,
   duplicate drag-stream tests, computed subscriber disposal on destroy.
+
+## Phase 3 — definePlugin + plugin ports (branch: `refactor/define-plugin`)
+
+Adds a functional plugin API, `definePlugin(name, (ctx, options) => api)`, whose teardown is a
+single `Scope` disposal instead of a hand-rolled `destroy()` override, and rebuilds six of the
+seven remaining first-party plugins on it. This is an **additive** API — `BasePlugin`
+class-based plugins (first-party and third-party) keep working unchanged. `definePlugin` is now
+re-exported from the package's main entry point alongside its supporting types:
+
+```ts
+import { definePlugin, type PluginContext, type PluginSetup, type DefinedPlugin } from 'wavesurfer.js'
+```
+
+### New API
+
+- **`definePlugin()`** (`src/define-plugin.ts`) — builds a plugin as `setup(ctx, options) => api`
+  where `ctx = { wavesurfer, scope, state, emit }`. `ctx.scope` is a fresh `Scope` per (re-)init;
+  every listener/timer/child-scope registered on it is torn down automatically on `destroy()` —
+  no manual `subscriptions` array or `destroy()` override needed. `BasePlugin` gained a
+  `protected scope: Scope` field so both `definePlugin` and hand-written class-based plugins
+  (including `RecordPlugin`, see below) can use the same disposal primitive.
+- **`resolveContainer`, `overlayElement`, `bridgeEvents`** (`src/plugin-utils.ts`) — shared
+  helpers extracted from four/six/one copy-paste implementations respectively that previously
+  lived duplicated across plugins.
+
+### Plugins ported (public surface unchanged; internals rebuilt on `definePlugin`)
+
+`hover`, `zoom`, `timeline`, `minimap`, `envelope`, `regions`. Every exported class name, default
+export, `Plugin.create(options)` / `new Plugin(options)` constructor form, public method/field,
+and event name+payload is preserved. `record` and the spectrogram plugins were **not** ported
+(see below); `spectrogram-*` unification is scheduled for a later phase.
+
+- **`RecordPlugin` stays class-based.** It's usable standalone (construct → `startMic()`/
+  `record()` → `destroy()`, without ever calling `registerPlugin()`), which `definePlugin`'s
+  setup-at-init model can't express. It now adopts the chassis's `protected scope` internally for
+  its own resources, but its public surface and its `destroy()` override are unchanged.
+
+### Behavior changes worth calling out
+
+- **`SingleRegion.subscriptions` (public field) has been removed.** It was a hand-rolled disposer
+  array (`public subscriptions: (() => void)[]`); region teardown is now expressed as disposing a
+  per-region child `Scope` owned by the plugin. Code that read or pushed onto
+  `region.subscriptions` directly will fail to compile against this version's types.
+- **Calling a ported plugin's public API method before the plugin has been initialized (i.e.
+  before `wavesurfer.registerPlugin(...)` has run `_init()`) now throws a bare `TypeError`
+  (`... is not a function`) instead of the previous descriptive `Error('WaveSurfer is not
+  initialized')`.** This is a `definePlugin`-wide semantic: a plugin's api methods (e.g.
+  `envelope.addPoint()`, `regions.addRegion()`) only exist on the instance once `setup()` has run
+  and `Object.assign`ed its return value on — calling one beforehand hits a missing method, not a
+  guarded field. (`regions.addRegion()` itself still throws the descriptive
+  `'WaveSurfer is not initialized'` error for the narrower case where `ctx.wavesurfer` reads
+  `undefined` post-destroy while the method still exists on the instance.)
+- **`zoom`'s `maxZoom` default is now recomputed on every (re-)init** instead of being derived
+  once. When the caller doesn't pass `maxZoom`, it's derived from the container's `clientWidth`
+  at setup time; a destroy → re-init cycle (e.g. after a container resize) now picks up the
+  current width rather than the value computed at the plugin's first init.
+- **`hover`, `regions`, and `minimap` now remove their root DOM element (wrapper /
+  `regionsContainer` / minimap wrapper) as part of scope disposal, which runs BEFORE the
+  `'destroy'` event is emitted** (`definePlugin`'s destroy order is: dispose `ctx.scope`, then
+  `super.destroy()` — which emits `'destroy'` last). Previously these three plugins removed their
+  root element AFTER the `'destroy'` event, so a `plugin.on('destroy', ...)` listener could still
+  observe the element attached to the DOM; it can no longer do so. Each port's test suite (plus
+  the regions memory-leak suite) was checked and found nothing pinned the old ordering.
+- **The timeline plugin's "container not found" error message wording changed**, from
+  `` `No Timeline container found matching ${container}` `` to
+  `` `timeline: container not found: ${container}` `` (now produced by the shared
+  `resolveContainer()` helper, consistent with every other plugin's container-resolution error).

--- a/docs/superpowers/plans/2026-07-27-refactor-roadmap.md
+++ b/docs/superpowers/plans/2026-07-27-refactor-roadmap.md
@@ -29,20 +29,118 @@ Implemented in branch `refactor/declarative-load-and-viewport` (7 tasks, all pas
 - Load lifecycle on child `Scope` + `AbortSignal`: replaces `_loadVersion`, `_isDestroyed` post-await guards, and `abortController`
 - Deferred-minor cleanup sweep completed (webaudio stale-src guard, envelope polyline null, duplicate drag-stream tests, computed subscriber clearing on dispose).
 
-## Plan 3 — definePlugin + plugin ports (after Plan 2)
+## Plan 3 — definePlugin + plugin ports (DONE ✓, full plan in 2026-07-27-define-plugin.md)
 
-Spec: functional plugin API `definePlugin(name, (ctx, options) => api)`
-with `ctx = { wavesurfer, scope, state }`; teardown = scope disposal only;
-`BasePlugin` becomes a deprecated compat shim over it. Shared utilities to
-kill the copy-paste classes found in review: `resolveContainer()` (one
-error behavior, replaces 4 divergent copies), `overlayElement(scope,
-style)` (6 copies), `bridgeEvents(from, to, names, scope)` (minimap's 64
-forwarder lines). Port order: hover, zoom (smallest) → timeline, minimap →
-regions, envelope, record (per-entity child scopes). Public API: existing
-plugin classes keep working via the shim through v8; `definePlugin` is
-additive.
-Depends on Plan 2's `visibleRange` (timeline/minimap ports consume it) and
-`loadPhase` (record/regions guards).
+Implemented in branch `refactor/define-plugin` (12 tasks, all passing:
+465 jest tests, tsc+eslint clean). `definePlugin` is re-exported from the
+main entry (`wavesurfer.ts`) alongside `PluginContext`/`PluginSetup`/
+`DefinedPlugin`. Six plugins ported (hover, zoom, timeline, minimap,
+envelope, regions); record deliberately NOT ported (see ruling below);
+spectrograms deliberately NOT ported (Plan 4). Produced interfaces (for
+Plan 4's author):
+
+**`definePlugin` / `PluginContext` (src/define-plugin.ts):**
+```typescript
+export interface PluginContext<Events extends BasePluginEvents> {
+  wavesurfer: WaveSurfer   // lazy getter — reads the CURRENT plugin.wavesurfer,
+                           // not a snapshot; undefined after destroy() despite the type
+  scope: Scope             // fresh per (re-)init; disposed on destroy, BEFORE super.destroy()
+  state: WaveSurferState   // lazy getter — wavesurfer.getState() read live, not cached
+  emit: <K extends keyof Events>(event: K, ...args: Events[K] extends unknown[] ? Events[K] : never) => void
+}
+export type PluginSetup<Options, Events extends BasePluginEvents, Api extends object> =
+  (ctx: PluginContext<Events>, options: Options) => Api
+export type DefinedPlugin<Options, Events extends BasePluginEvents, Api extends object> = {
+  new (...args: PluginCtorArgs<Options>): BasePlugin<Events, Options> & Api
+  create(...args: PluginCtorArgs<Options>): BasePlugin<Events, Options> & Api
+}
+export function definePlugin<Options, Events extends BasePluginEvents, Api extends object>(
+  name: string,
+  setup: PluginSetup<Options, Events, Api>,
+): DefinedPlugin<Options, Events, Api>
+```
+- `ctx.wavesurfer`/`ctx.state` are **lazy getters**, not values captured at
+  setup time — api closures always see current plugin state and can't pin a
+  destroyed WaveSurfer alive.
+- **API collision guard**: every key returned by `setup()` is checked at
+  init time against a `RESERVED_CHASSIS_KEYS` set (`destroy`, `_init`,
+  `emit`, `on`, `un`, `once`, `unAll`, `options`, `wavesurfer`,
+  `subscriptions`, `scope`, `destroyed`, `isDestroyed`, `listeners` —
+  includes TS-`private` chassis fields, which `Object.assign` doesn't
+  respect at runtime); a collision throws
+  `definePlugin('<name>'): api key "<key>" collides with the plugin chassis`
+  instead of silently disabling core plugin machinery.
+- **`PluginCtorArgs<Options>` optionality rule**: `new Plugin(options)` /
+  `Plugin.create(options)` takes the options argument as *optional* iff
+  every property of `Options` is optional (`Record<string, never> extends
+  Options`), otherwise required — matching what a hand-written
+  `constructor(options?: Options)` vs `constructor(options: Options)` would
+  offer. When omitted, `setup` receives `options === undefined` (not `{}`)
+  — setup must default it itself.
+- **Destroy order**: `ctx.scope.dispose()` runs FIRST, `super.destroy()`
+  (emits `'destroy'`, drains legacy `subscriptions`, then `unAll()`s
+  listeners) runs LAST. Scope-owned root-DOM-element removal is therefore
+  torn down BEFORE the `'destroy'` event reaches consumers. Two plugins
+  (hover, regions) historically removed their root element AFTER
+  `super.destroy()` so a `'destroy'` listener could still observe an
+  attached node; both ports checked their test suites, found nothing pins
+  that ordering, and moved removal onto `ctx.scope` (documented, deliberate
+  behavior change — see RELEASE_NOTES-scope-refactor.md).
+
+**`plugin-utils.ts` (consumed by every port):**
+```typescript
+export function resolveContainer(
+  option: HTMLElement | string | undefined,
+  fallback: HTMLElement,
+  pluginName: string,
+): HTMLElement
+// string → querySelector, throws `${pluginName}: container not found: ${option}` on miss;
+// HTMLElement → itself; undefined → fallback.
+
+export function overlayElement(
+  scope: Scope,
+  parent: HTMLElement,
+  style?: Partial<CSSStyleDeclaration>,
+): HTMLElement
+// position:absolute div appended to parent; scope.add(() => el.remove()).
+
+export function bridgeEvents<Events extends Record<string, unknown[]>>(
+  scope: Scope,
+  from: { on: (e: never, cb: never) => () => void },
+  to: { emit: (e: never, ...args: never[]) => void },
+  names: Array<keyof Events & string>,
+): void
+// Forwards each named event from `from` to `to.emit`; each subscription is scope.add()'d.
+```
+
+**Per-region child-scope pattern (regions.ts, Task 11):** each `SingleRegion`
+owns a private `scope: Scope` handed to it by the plugin — `const
+regionScope = ctx.scope.child()` — tracked in a `WeakMap<Region, Scope>` on
+the plugin side. `region.remove()` disposes `regionScope` (cascading
+through `ctx.scope`'s child-scope tree) instead of draining a hand-rolled
+`subscriptions` array; drag-selection's in-progress region gets its own
+`regionScope` too, disposed and re-created per drag. Same pattern name
+(`regionScope`, `.child()`) used consistently; minimap's Task 8 nested-
+wavesurfer scope uses the identical `ctx.scope.child()` primitive (there
+called `miniScope`) for the same drain-before-recreate need.
+
+**RECORD stays class-based (ruling, Task 10):** `RecordPlugin` is usable
+standalone (construct → `startMic`/`record` → `destroy`, without ever
+calling `registerPlugin`), which `definePlugin`'s setup-at-init model
+cannot express — its constructor builds a `Timer` and its destroy path
+must work pre-init. `RecordPlugin` remains a `BasePlugin` subclass with an
+explicit `destroy()` override, but internally adopts the chassis's
+`protected scope: Scope` for its resources. Its public surface, and the
+`destroy()` override itself, are unchanged. Any future consolidation
+(e.g. if `definePlugin` grows a pre-init-usable variant) is out of scope
+for Plan 3/4.
+
+Shared utilities killed the copy-paste classes found in review:
+`resolveContainer()` (one error behavior, replaced 4 divergent copies),
+`overlayElement()` (replaced ~6 hand-rolled copies), `bridgeEvents()`
+(replaced minimap's 64 forwarder lines with one call). `BasePlugin` stays
+exported and functional — both as the chassis `definePlugin` builds on
+and, unchanged, for third-party class-based plugins and `record.ts`.
 
 ## Plan 4 — Spectrogram unification + leak harness + lint bans (last)
 

--- a/src/__tests__/define-plugin.test.ts
+++ b/src/__tests__/define-plugin.test.ts
@@ -147,6 +147,17 @@ describe('definePlugin', () => {
     expect(() => PluginB.create({})._init(wsStub())).toThrow(/collide-listeners/)
   })
 
+  it('throws when the setup api collides with the onInit chassis method', () => {
+    // An api key named `onInit` would shadow `Defined.prototype.onInit` on
+    // the instance via `Object.assign(this, api)`, silently breaking a
+    // subsequent destroy() -> _init() re-init cycle (see RESERVED_CHASSIS_KEYS
+    // comment in define-plugin.ts). Must be caught, same as `destroy`.
+    const Plugin = definePlugin<{}, { destroy: [] }, any>('collide-onInit', () => ({
+      onInit: () => undefined,
+    }))
+    expect(() => Plugin.create({})._init(wsStub())).toThrow(/collide-onInit/)
+  })
+
   it('makes the constructor/create() arg optional when Options has no required fields, required otherwise', () => {
     // All-optional Options: `create()`/`new Plugin()` need no argument.
     const OptionalPlugin = definePlugin<{ label?: string }, { destroy: [] }, {}>('optional-opts', () => ({}))

--- a/src/__tests__/define-plugin.test.ts
+++ b/src/__tests__/define-plugin.test.ts
@@ -147,6 +147,21 @@ describe('definePlugin', () => {
     expect(() => PluginB.create({})._init(wsStub())).toThrow(/collide-listeners/)
   })
 
+  it('makes the constructor/create() arg optional when Options has no required fields, required otherwise', () => {
+    // All-optional Options: `create()`/`new Plugin()` need no argument.
+    const OptionalPlugin = definePlugin<{ label?: string }, { destroy: [] }, {}>('optional-opts', () => ({}))
+    expect(() => OptionalPlugin.create()).not.toThrow()
+    expect(() => new OptionalPlugin()).not.toThrow()
+
+    // Options with a required field: the argument stays required — a
+    // no-arg call is a compile error (checked below), not just a runtime
+    // possibility.
+    const RequiredPlugin = definePlugin<{ req: number }, { destroy: [] }, {}>('required-opts', () => ({}))
+    // @ts-expect-error - `req` is required on this plugin's Options, so create() must be called with an argument
+    RequiredPlugin.create()
+    expect(() => RequiredPlugin.create({ req: 1 })).not.toThrow()
+  })
+
   it('does not eagerly read wavesurfer/state at setup time, only lazily via ctx getters', () => {
     const Plugin = definePlugin<{}, { destroy: [] }, { read: () => unknown }>('lazy-plugin', (ctx) => ({
       read: () => ctx.state,

--- a/src/__tests__/define-plugin.test.ts
+++ b/src/__tests__/define-plugin.test.ts
@@ -119,4 +119,23 @@ describe('definePlugin', () => {
     expect(ws.getActivePlugins()).toContain(plugin)
     ws.destroy()
   })
+
+  it('throws when the setup api collides with a chassis key, naming the plugin', () => {
+    const Plugin = definePlugin<{}, { destroy: [] }, { destroy: () => void }>('collide-plugin', () => ({
+      destroy: () => undefined,
+    }))
+    const plugin = Plugin.create({})
+    expect(() => plugin._init(wsStub())).toThrow(/collide-plugin/)
+  })
+
+  it('does not eagerly read wavesurfer/state at setup time, only lazily via ctx getters', () => {
+    const Plugin = definePlugin<{}, { destroy: [] }, { read: () => unknown }>('lazy-plugin', (ctx) => ({
+      read: () => ctx.state,
+    }))
+    const plugin = Plugin.create({})
+    // A stub missing getState() must not throw during _init — only when the
+    // api actually reads ctx.state.
+    const wsWithoutState = { getWrapper: () => document.createElement('div') } as never
+    expect(() => plugin._init(wsWithoutState)).not.toThrow()
+  })
 })

--- a/src/__tests__/define-plugin.test.ts
+++ b/src/__tests__/define-plugin.test.ts
@@ -128,6 +128,25 @@ describe('definePlugin', () => {
     expect(() => plugin._init(wsStub())).toThrow(/collide-plugin/)
   })
 
+  it('throws when the setup api collides with a runtime-private chassis field (isDestroyed / listeners)', () => {
+    // `Api = any` here: TS itself catches `isDestroyed`/`listeners` colliding
+    // with BasePlugin/EventEmitter's private fields at the type level
+    // (intersection collapses to `never`) when Api is precisely typed. The
+    // runtime guard exists for exactly the case type-checking can't cover —
+    // an untyped/`any`-typed setup(), a plain-JS consumer, or a type escape
+    // hatch — so this test deliberately opts out of that type-level safety
+    // net to exercise the runtime check.
+    const PluginA = definePlugin<{}, { destroy: [] }, any>('collide-isDestroyed', () => ({
+      isDestroyed: true,
+    }))
+    expect(() => PluginA.create({})._init(wsStub())).toThrow(/collide-isDestroyed/)
+
+    const PluginB = definePlugin<{}, { destroy: [] }, any>('collide-listeners', () => ({
+      listeners: {},
+    }))
+    expect(() => PluginB.create({})._init(wsStub())).toThrow(/collide-listeners/)
+  })
+
   it('does not eagerly read wavesurfer/state at setup time, only lazily via ctx getters', () => {
     const Plugin = definePlugin<{}, { destroy: [] }, { read: () => unknown }>('lazy-plugin', (ctx) => ({
       read: () => ctx.state,

--- a/src/__tests__/define-plugin.test.ts
+++ b/src/__tests__/define-plugin.test.ts
@@ -1,0 +1,122 @@
+jest.mock('../renderer.js', () => {
+  let lastInstance: any
+  class Renderer {
+    options: any
+    wrapper = document.createElement('div')
+    renderProgress = jest.fn()
+    on = jest.fn(() => () => undefined)
+    setOptions = jest.fn()
+    getWrapper = jest.fn(() => this.wrapper)
+    getWidth = jest.fn(() => 100)
+    getScroll = jest.fn(() => 0)
+    setScroll = jest.fn()
+    setScrollPercentage = jest.fn()
+    render = jest.fn()
+    zoom = jest.fn()
+    exportImage = jest.fn(() => [])
+    destroy = jest.fn()
+    constructor(options: any) {
+      this.options = options
+      lastInstance = this
+    }
+  }
+  return { __esModule: true, default: Renderer, getLastInstance: () => lastInstance }
+})
+
+jest.mock('../frame-scheduler.js', () => {
+  class FrameScheduler {
+    start = jest.fn()
+    stop = jest.fn()
+    constructor(scope: any) {
+      scope.add(() => this.stop())
+    }
+  }
+  return { __esModule: true, FrameScheduler }
+})
+
+jest.mock('../decoder.js', () => {
+  const createBuffer = jest.fn((data: any[], duration: number) => ({
+    duration,
+    numberOfChannels: data.length,
+    getChannelData: (i: number) => Float32Array.from(data[i] as number[]),
+  }))
+  return { __esModule: true, default: { decode: jest.fn(), createBuffer } }
+})
+
+import WaveSurfer from '../wavesurfer.js'
+import { definePlugin } from '../define-plugin.js'
+
+const makePlugin = () =>
+  definePlugin<
+    { label?: string },
+    { destroy: []; ping: [n: number] },
+    { ping: (n: number) => void; label: () => string }
+  >('test-plugin', (ctx, options) => {
+    const el = document.createElement('div')
+    ctx.wavesurfer.getWrapper().appendChild(el)
+    ctx.scope.add(() => el.remove())
+    return {
+      ping: (n) => ctx.emit('ping', n),
+      label: () => options.label ?? 'none',
+    }
+  })
+
+const wsStub = () => {
+  const wrapper = document.createElement('div')
+  return {
+    getWrapper: () => wrapper,
+    getState: () => ({}) as never,
+    _wrapper: wrapper,
+  } as never
+}
+
+describe('definePlugin', () => {
+  it('exposes api methods after init and emits typed events', () => {
+    const Plugin = makePlugin()
+    const plugin = Plugin.create({ label: 'x' })
+    plugin._init(wsStub())
+    const spy = jest.fn()
+    plugin.on('ping', spy)
+    plugin.ping(7)
+    expect(spy).toHaveBeenCalledWith(7)
+    expect(plugin.label()).toBe('x')
+  })
+
+  it('supports new Plugin(options) as well as create()', () => {
+    const Plugin = makePlugin()
+    expect(() => new Plugin({})).not.toThrow()
+  })
+
+  it('disposes the scope on destroy (resources released) and delivers the destroy event', () => {
+    const Plugin = makePlugin()
+    const plugin = Plugin.create({})
+    const ws = wsStub()
+    plugin._init(ws)
+    const wrapper = (ws as any)._wrapper as HTMLElement
+    expect(wrapper.children.length).toBe(1)
+    const onDestroy = jest.fn()
+    plugin.on('destroy', onDestroy)
+    plugin.destroy()
+    expect(onDestroy).toHaveBeenCalledTimes(1)
+    expect(wrapper.children.length).toBe(0)
+  })
+
+  it('re-init after destroy runs setup again on a fresh scope', () => {
+    const Plugin = makePlugin()
+    const plugin = Plugin.create({})
+    const ws = wsStub()
+    plugin._init(ws)
+    plugin.destroy()
+    plugin._init(ws)
+    expect(((ws as any)._wrapper as HTMLElement).children.length).toBe(1)
+    plugin.destroy()
+  })
+
+  it('is accepted by wavesurfer.registerPlugin', () => {
+    const Plugin = makePlugin()
+    const ws = WaveSurfer.create({ container: document.createElement('div') })
+    const plugin = ws.registerPlugin(Plugin.create({}))
+    expect(ws.getActivePlugins()).toContain(plugin)
+    ws.destroy()
+  })
+})

--- a/src/__tests__/envelope-leaks.test.ts
+++ b/src/__tests__/envelope-leaks.test.ts
@@ -1,4 +1,5 @@
 import EnvelopePlugin from '../plugins/envelope.js'
+import { Scope } from '../scope.js'
 
 // jsdom implements almost none of the SVG geometry APIs envelope.ts relies on
 // (SVGSVGElement.viewBox, SVGSVGElement.createSVGPoint, SVGPointList). Stub
@@ -44,18 +45,46 @@ const mockSvgGeometry = (svg: SVGSVGElement, width = 100, height = 100) => {
   })
 }
 
+type Listener = (...args: any[]) => void
+
+// EnvelopePlugin now only reaches its 'decode'/'redraw'/'timeupdate' wiring
+// through ctx.wavesurfer.on(...) registered inside setup() — which only runs
+// via the real _init() lifecycle. The pre-port tests bypassed all of that by
+// assigning `anyPlugin.wavesurfer` directly and calling private methods
+// (initPolyline()) by hand; that bypass no longer has anything to call. Use
+// a real emitter stub, drive everything through plugin._init(ws) + ws.emit,
+// and exercise the public Api (addPoint/removePoint/setPoints/destroy)
+// instead — same pattern as hover.test.ts / minimap.test.ts.
+const createEmitter = () => {
+  const listeners = new Map<string, Set<Listener>>()
+
+  return {
+    on: jest.fn((event: string, listener: Listener) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, new Set())
+      }
+
+      listeners.get(event)!.add(listener)
+      return () => listeners.get(event)?.delete(listener)
+    }),
+    emit: (event: string, ...args: any[]) => {
+      listeners.get(event)?.forEach((listener) => listener(...args))
+    },
+  }
+}
+
 const createWaveSurfer = (duration = 10) => {
   const wrapper = document.createElement('div')
   document.body.appendChild(wrapper)
 
   return {
+    ...createEmitter(),
     getWrapper: () => wrapper,
     getDuration: () => duration,
     getDecodedData: () => null,
     getVolume: () => 1,
     getCurrentTime: () => 0,
     setVolume: () => undefined,
-    on: () => () => undefined,
   }
 }
 
@@ -73,46 +102,73 @@ describe('EnvelopePlugin leak fixes', () => {
 
   afterEach(() => {
     document.body.innerHTML = ''
+    jest.restoreAllMocks()
   })
 
+  // ADAPTED: the pre-port test read `anyPlugin.polylineSubscriptions.length`
+  // directly. That array is now a child Scope (`ctx.scope.child()`),
+  // disposed and replaced — not accumulated — on every 'decode' (see
+  // envelope.ts:initPolyline). Scope has no size/length introspection by
+  // design, so we pin the same "replace, don't accumulate" contract one
+  // level down: spy on Scope.prototype.child (the mechanism itself, not an
+  // envelope.ts private) and assert firing 'decode' twice disposes the
+  // first child scope before/when creating the second, rather than leaving
+  // both live.
   it('does not accumulate polyline subscriptions across re-inits of the polyline', () => {
+    const childSpy = jest.spyOn(Scope.prototype, 'child')
+    const ws = createWaveSurfer()
     const plugin = EnvelopePlugin.create({ points: [] })
-    const anyPlugin = plugin as any
-    anyPlugin.wavesurfer = createWaveSurfer()
+    plugin._init(ws as any)
 
-    anyPlugin.initPolyline()
-    const after1 = anyPlugin.polylineSubscriptions.length
+    ws.emit('decode', 10)
+    const firstPolylineScope = childSpy.mock.results[childSpy.mock.results.length - 1].value as Scope
 
-    anyPlugin.initPolyline()
-    const after2 = anyPlugin.polylineSubscriptions.length
+    ws.emit('decode', 10)
+    const secondPolylineScope = childSpy.mock.results[childSpy.mock.results.length - 1].value as Scope
 
-    expect(after1).toBeGreaterThan(0)
-    expect(after2).toBe(after1) // replaced, not accumulated
+    expect(firstPolylineScope).not.toBe(secondPolylineScope)
+    expect(firstPolylineScope.disposed).toBe(true) // replaced, not accumulated
+    expect(secondPolylineScope.disposed).toBe(false)
   })
 
+  // ADAPTED: same underlying data-structure change as above. The pre-port
+  // test checked `polylineSubscriptions.length` goes from >0 to 0 across
+  // plugin.destroy(); the equivalent here is the current polyline child
+  // scope transitioning from live to disposed.
   it('drains polyline subscriptions on plugin destroy', () => {
+    const childSpy = jest.spyOn(Scope.prototype, 'child')
+    const ws = createWaveSurfer()
     const plugin = EnvelopePlugin.create({ points: [] })
-    const anyPlugin = plugin as any
-    anyPlugin.wavesurfer = createWaveSurfer()
+    plugin._init(ws as any)
 
-    anyPlugin.initPolyline()
-    expect(anyPlugin.polylineSubscriptions.length).toBeGreaterThan(0)
+    ws.emit('decode', 10)
+    const currentPolylineScope = childSpy.mock.results[childSpy.mock.results.length - 1].value as Scope
+    expect(currentPolylineScope.disposed).toBe(false)
 
     plugin.destroy()
-    expect(anyPlugin.polylineSubscriptions.length).toBe(0)
+
+    expect(currentPolylineScope.disposed).toBe(true)
   })
 
+  // ADAPTED: `anyPlugin.polyline.svg` no longer exists (`polyline` is a
+  // setup-closure variable, not an instance field). The SVG element it
+  // referenced is the same real DOM node Polyline appends into
+  // wavesurfer's wrapper, so we query it straight off the wrapper instead.
+  // The leak assertion itself (removeEventListener('pointerdown', ...)
+  // called when a point is removed) is unchanged.
   it('removePolyPoint disposes the per-point drag stream instead of leaking it', () => {
+    const ws = createWaveSurfer()
     const plugin = EnvelopePlugin.create({ points: [] })
-    const anyPlugin = plugin as any
-    anyPlugin.wavesurfer = createWaveSurfer()
-    anyPlugin.initPolyline()
-    mockSvgGeometry(anyPlugin.polyline.svg)
+    plugin._init(ws as any)
+    ws.emit('decode', 10)
+
+    const svg = ws.getWrapper().querySelector('svg') as SVGSVGElement
+    mockSvgGeometry(svg)
 
     const point = { time: 5, volume: 0.5 }
     plugin.addPoint(point)
 
-    const circle = anyPlugin.polyline.svg.querySelector('ellipse') as SVGEllipseElement
+    const circle = svg.querySelector('ellipse') as SVGEllipseElement
     expect(circle).toBeTruthy()
     const removeSpy = jest.spyOn(circle, 'removeEventListener')
 
@@ -124,52 +180,67 @@ describe('EnvelopePlugin leak fixes', () => {
     expect(removeSpy).toHaveBeenCalledWith('pointerdown', expect.any(Function))
   })
 
+  // ADAPTED: `anyPlugin.polyline.pointCleanups.size` no longer exists.
+  // Assert the same "disposed, not merely orphaned" guarantee observably:
+  // the stale points' circles must both have their pointerdown listener
+  // removed, and only the freshly-added point's circle remains in the DOM.
   it('setPoints does not leak one drag stream per pre-existing point', () => {
+    const ws = createWaveSurfer()
     const plugin = EnvelopePlugin.create({ points: [] })
-    const anyPlugin = plugin as any
-    anyPlugin.wavesurfer = createWaveSurfer()
-    anyPlugin.initPolyline()
-    mockSvgGeometry(anyPlugin.polyline.svg)
+    plugin._init(ws as any)
+    ws.emit('decode', 10)
+
+    const svg = ws.getWrapper().querySelector('svg') as SVGSVGElement
+    mockSvgGeometry(svg)
 
     const pointA = { time: 2, volume: 0.2 }
     const pointB = { time: 4, volume: 0.4 }
     plugin.addPoint(pointA)
     plugin.addPoint(pointB)
 
-    expect(anyPlugin.polyline.pointCleanups.size).toBe(2)
+    const staleCircles = Array.from(svg.querySelectorAll('ellipse'))
+    expect(staleCircles.length).toBe(2)
+    const removeSpies = staleCircles.map((circle) => jest.spyOn(circle, 'removeEventListener'))
 
     plugin.setPoints([{ time: 6, volume: 0.6 }])
 
-    // Only the freshly-added point's cleanup should remain; the two
+    // Only the freshly-added point's circle should remain; the two
     // pre-existing points' drag streams must have been disposed by
     // removePolyPoint, not merely orphaned.
-    expect(anyPlugin.polyline.pointCleanups.size).toBe(1)
+    expect(svg.querySelectorAll('ellipse').length).toBe(1)
+    removeSpies.forEach((spy) => {
+      expect(spy).toHaveBeenCalledWith('pointerdown', expect.any(Function))
+    })
   })
 
-  it('nulls the polyline on destroy so post-destroy calls cannot reach a torn-down instance', () => {
+  // MERGED + ADAPTED (was two tests: "nulls the polyline on destroy..." and
+  // "double Polyline.destroy() does not throw..."). Neither assertion is
+  // reachable anymore: `polyline` is a private closure variable with no
+  // instance-field equivalent, and the `Polyline` class is not exported, so
+  // there is no way to hold a reference to an instance from the test. Pin
+  // the same two guarantees the recipe calls for
+  // (`ctx.scope.add(() => { polyline?.destroy(); polyline = null })`)
+  // observably instead: destroying the plugin tears the polyline's DOM down
+  // and is safe to call twice, and a post-destroy Api call cannot reach (or
+  // resurrect) a torn-down polyline.
+  it('destroying the plugin twice does not throw, and post-destroy Api calls are safe no-ops', () => {
+    const ws = createWaveSurfer()
     const plugin = EnvelopePlugin.create({ points: [] })
-    const anyPlugin = plugin as any
-    anyPlugin.wavesurfer = createWaveSurfer()
-    anyPlugin.initPolyline()
+    plugin._init(ws as any)
+    ws.emit('decode', 10)
 
-    plugin.destroy()
-
-    expect(anyPlugin.polyline).toBeNull()
-  })
-
-  it('double Polyline.destroy() does not throw and empties its subscriptions', () => {
-    const plugin = EnvelopePlugin.create({ points: [] })
-    const anyPlugin = plugin as any
-    anyPlugin.wavesurfer = createWaveSurfer()
-    anyPlugin.initPolyline()
-
-    const polyline = anyPlugin.polyline
+    expect(ws.getWrapper().querySelector('svg')).toBeTruthy()
 
     expect(() => {
-      polyline.destroy()
-      polyline.destroy()
+      plugin.destroy()
+      plugin.destroy()
     }).not.toThrow()
 
-    expect(polyline.subscriptions.length).toBe(0)
+    expect(ws.getWrapper().querySelector('svg')).toBeNull()
+
+    expect(() => {
+      plugin.addPoint({ time: 1, volume: 0.5 })
+      plugin.removePoint({ time: 1, volume: 0.5 })
+    }).not.toThrow()
   })
 })

--- a/src/__tests__/envelope-leaks.test.ts
+++ b/src/__tests__/envelope-leaks.test.ts
@@ -223,13 +223,49 @@ describe('EnvelopePlugin leak fixes', () => {
   // observably instead: destroying the plugin tears the polyline's DOM down
   // and is safe to call twice, and a post-destroy Api call cannot reach (or
   // resurrect) a torn-down polyline.
+  //
+  // KNOWN COVERAGE LIMIT (found during review round 1, verified by
+  // temporarily deleting the `polyline = null` line and re-running this
+  // test — it still passed): `points` is closure state, not scope-owned, so
+  // it survives destroy() and `removePoint(point)` below genuinely reaches
+  // `polyline?.removePolyPoint(point)` (confirmed the reviewer's
+  // reachability hypothesis). But that call is a no-op whether or not
+  // `polyline` was nulled, because `Polyline#destroy()` itself
+  // unconditionally clears `this.polyPoints` (see the `destroy()` method
+  // above) *before* the outer disposer's `polyline = null` even runs — so a
+  // destroyed-but-not-nulled `polyline` reference is already functionally
+  // inert on every path currently reachable from the public Api (addPoint's
+  // polyline-touching branch is separately gated by `ctx.wavesurfer?.`,
+  // which is also undefined post-destroy). Dropping `polyline = null` alone
+  // is therefore a pure memory-retention regression (the closure keeps the
+  // whole destroyed Polyline object graph reachable), not a
+  // functional/DOM-observable one — no black-box assertion here can catch
+  // it without either changing Polyline's own idempotent destroy() design
+  // or reaching into the closure directly (both out of scope). This test
+  // still meaningfully improves on the pre-round-1 version: it's the first
+  // one to actually reach `removePolyPoint` post-destroy (via a real,
+  // identity-matched pre-added point, not a throwaway object), so it does
+  // catch e.g. a regression to the `ctx.wavesurfer?.` guard or to
+  // Polyline#destroy()'s own clearing.
   it('destroying the plugin twice does not throw, and post-destroy Api calls are safe no-ops', () => {
     const ws = createWaveSurfer()
     const plugin = EnvelopePlugin.create({ points: [] })
     plugin._init(ws as any)
     ws.emit('decode', 10)
 
-    expect(ws.getWrapper().querySelector('svg')).toBeTruthy()
+    const svg = ws.getWrapper().querySelector('svg') as SVGSVGElement
+    mockSvgGeometry(svg)
+
+    // Add a point BEFORE destroy, keeping the same object reference, so a
+    // post-destroy removePoint(point) call below actually finds it via
+    // `points.indexOf(point)` (identity, not shape) and reaches the
+    // `polyline?.removePolyPoint(point)` line — a removePoint call with a
+    // fresh, never-added object short-circuits on the `index > -1` guard
+    // before ever touching `polyline`, which is what the original version
+    // of this test did and is why it couldn't have caught a regression here.
+    const point = { time: 1, volume: 0.5 }
+    plugin.addPoint(point)
+    expect(svg.querySelectorAll('ellipse').length).toBe(1)
 
     expect(() => {
       plugin.destroy()
@@ -239,8 +275,16 @@ describe('EnvelopePlugin leak fixes', () => {
     expect(ws.getWrapper().querySelector('svg')).toBeNull()
 
     expect(() => {
-      plugin.addPoint({ time: 1, volume: 0.5 })
-      plugin.removePoint({ time: 1, volume: 0.5 })
+      plugin.addPoint({ time: 2, volume: 0.2 })
+      plugin.removePoint(point)
+      plugin.setVolume(0.3)
     }).not.toThrow()
+
+    // No <svg>/<ellipse> anywhere in the document afterward — asserted
+    // against `document`, not just the (already svg-less) wrapper, so a
+    // live polyline reference mutating its own detached DOM subtree would
+    // still be visible to this check.
+    expect(document.querySelectorAll('svg').length).toBe(0)
+    expect(document.querySelectorAll('ellipse').length).toBe(0)
   })
 })

--- a/src/__tests__/hover.test.ts
+++ b/src/__tests__/hover.test.ts
@@ -95,7 +95,7 @@ describe('HoverPlugin', () => {
     const container = document.createElement('div')
     const { wavesurfer } = createWaveSurfer(container, 10)
 
-    const plugin = HoverPlugin.create({})
+    const plugin = HoverPlugin.create()
     plugin._init(wavesurfer as any)
 
     const hover = container.querySelector<HTMLElement>('[part="hover"]')!

--- a/src/__tests__/hover.test.ts
+++ b/src/__tests__/hover.test.ts
@@ -95,7 +95,7 @@ describe('HoverPlugin', () => {
     const container = document.createElement('div')
     const { wavesurfer } = createWaveSurfer(container, 10)
 
-    const plugin = HoverPlugin.create()
+    const plugin = HoverPlugin.create({})
     plugin._init(wavesurfer as any)
 
     const hover = container.querySelector<HTMLElement>('[part="hover"]')!

--- a/src/__tests__/minimap.test.ts
+++ b/src/__tests__/minimap.test.ts
@@ -192,10 +192,15 @@ describe('MinimapPlugin', () => {
   })
 
   test('does not re-emit destroy when the nested wavesurfer is recreated', async () => {
-    const { plugin } = await createInitializedMinimap()
+    const { plugin, mainWaveSurfer } = await createInitializedMinimap()
     const onDestroy = jest.fn()
     plugin.on('destroy', onDestroy)
-    ;(plugin as any).destroyMinimap()
+    // `destroyMinimap()` is now a private setup-closure, not an instance
+    // method — drive the same recreate-the-nested-wavesurfer path through
+    // its public trigger (a 'decode' event) instead of poking a private
+    // internal directly. Same observable assertion as before.
+    mainWaveSurfer.emit('decode', 30)
+    await Promise.resolve()
     expect(onDestroy).not.toHaveBeenCalled()
   })
 })

--- a/src/__tests__/plugin-utils.test.ts
+++ b/src/__tests__/plugin-utils.test.ts
@@ -1,0 +1,60 @@
+import { Scope } from '../scope'
+import EventEmitter from '../event-emitter'
+import { resolveContainer, overlayElement, bridgeEvents } from '../plugin-utils'
+
+describe('plugin-utils', () => {
+  it('resolveContainer resolves selector, element, and fallback; throws with plugin name', () => {
+    const el = document.createElement('div')
+    el.id = 'host'
+    document.body.appendChild(el)
+    const fallback = document.createElement('div')
+
+    expect(resolveContainer('#host', fallback, 'test')).toBe(el)
+    expect(resolveContainer(el, fallback, 'test')).toBe(el)
+    expect(resolveContainer(undefined, fallback, 'test')).toBe(fallback)
+    expect(() => resolveContainer('#missing', fallback, 'test')).toThrow(/test/)
+
+    el.remove()
+  })
+
+  it('overlayElement appends absolutely-positioned div and removes it on scope dispose', () => {
+    const scope = new Scope()
+    const parent = document.createElement('div')
+    const overlay = overlayElement(scope, parent, { zIndex: '4' })
+
+    expect(overlay.parentElement).toBe(parent)
+    expect(overlay.style.position).toBe('absolute')
+    expect(overlay.style.zIndex).toBe('4')
+
+    scope.dispose()
+    expect(overlay.parentElement).toBeNull()
+  })
+
+  it('bridgeEvents forwards named events and stops on dispose', () => {
+    const scope = new Scope()
+
+    class Src extends EventEmitter<{ a: [number]; b: [] }> {
+      fire() {
+        this.emit('a', 1)
+      }
+    }
+
+    class Dst extends EventEmitter<{ a: [number]; b: [] }> {}
+
+    const src = new Src()
+    const dst = new Dst()
+    const spy = jest.fn()
+
+    dst.on('a', spy)
+
+    // Bridge events from src to dst via a simple emit wrapper
+    bridgeEvents(scope, src, { emit: (e, ...args) => (dst as any).emit(e, ...args) }, ['a'])
+
+    src.fire()
+    expect(spy).toHaveBeenCalledWith(1)
+
+    scope.dispose()
+    src.fire()
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/__tests__/regions.test.ts
+++ b/src/__tests__/regions.test.ts
@@ -132,6 +132,17 @@ describe('RegionsPlugin', () => {
     expect(clicked).toHaveBeenCalledTimes(1)
   })
 
+  // ADAPTED: the pre-port test read `region.subscriptions.length` directly.
+  // SingleRegion's hand-rolled `subscriptions` array is gone -- its listener
+  // bookkeeping (including resize-handle cleanup) now lives on a private
+  // child Scope with no length/size introspection (by design, see
+  // envelope-leaks.test.ts for the established precedent). Pin the same
+  // "does not grow" contract one level down: each `resize: true` toggle
+  // creates fresh left/right resize-handle elements and attaches one
+  // 'pointerdown' listener to each (via createDragStream); the *net* count of
+  // attached pointerdown listeners (adds minus removes) after settling on
+  // `resize: true` must stay constant across repeated off/on cycles, rather
+  // than growing if a stale cleanup were left behind each toggle.
   test('toggling resize option repeatedly does not grow region subscriptions', () => {
     const wavesurfer = createWaveSurfer()
     const plugin = RegionsPlugin.create()
@@ -140,15 +151,23 @@ describe('RegionsPlugin', () => {
 
     const region = plugin.addRegion({ start: 0, end: 1, resize: true })
 
-    region.setOptions({ resize: false })
-    region.setOptions({ resize: true })
-    const lengthAfterFirstToggle = region.subscriptions.length
+    const addSpy = jest.spyOn(HTMLElement.prototype, 'addEventListener')
+    const removeSpy = jest.spyOn(HTMLElement.prototype, 'removeEventListener')
+    const netPointerdownListeners = () => {
+      const adds = addSpy.mock.calls.filter(([type]) => type === 'pointerdown').length
+      const removes = removeSpy.mock.calls.filter(([type]) => type === 'pointerdown').length
+      return adds - removes
+    }
 
     region.setOptions({ resize: false })
     region.setOptions({ resize: true })
-    const lengthAfterSecondToggle = region.subscriptions.length
+    const netAfterFirstToggle = netPointerdownListeners()
 
-    expect(lengthAfterSecondToggle).toBe(lengthAfterFirstToggle)
+    region.setOptions({ resize: false })
+    region.setOptions({ resize: true })
+    const netAfterSecondToggle = netPointerdownListeners()
+
+    expect(netAfterSecondToggle).toBe(netAfterFirstToggle)
   })
 
   test('places a region in the first free row instead of summing all prior overlaps', () => {

--- a/src/__tests__/regions.test.ts
+++ b/src/__tests__/regions.test.ts
@@ -139,10 +139,17 @@ describe('RegionsPlugin', () => {
   // envelope-leaks.test.ts for the established precedent). Pin the same
   // "does not grow" contract one level down: each `resize: true` toggle
   // creates fresh left/right resize-handle elements and attaches one
-  // 'pointerdown' listener to each (via createDragStream); the *net* count of
-  // attached pointerdown listeners (adds minus removes) after settling on
-  // `resize: true` must stay constant across repeated off/on cycles, rather
-  // than growing if a stale cleanup were left behind each toggle.
+  // 'pointerdown' listener to each (via createDragStream). The spy is
+  // installed AFTER the region is constructed (so it doesn't see the
+  // construction-time attach, or the unrelated single pointerdown listener
+  // initMouseEvents attaches to the region element itself for its own drag
+  // handling -- that one is never toggled and would otherwise permanently
+  // skew the count). Two full off/on cycles land back on the same
+  // `resize: true` state the spy started at, so the total 'pointerdown'
+  // adds and removes it captured must match exactly -- mirroring the
+  // add/remove-count-equality pattern already used above in 'cleans up drag
+  // selection on plugin destroy'. A leaked per-cycle cleanup would show up
+  // here as adds outpacing removes.
   test('toggling resize option repeatedly does not grow region subscriptions', () => {
     const wavesurfer = createWaveSurfer()
     const plugin = RegionsPlugin.create()
@@ -153,21 +160,22 @@ describe('RegionsPlugin', () => {
 
     const addSpy = jest.spyOn(HTMLElement.prototype, 'addEventListener')
     const removeSpy = jest.spyOn(HTMLElement.prototype, 'removeEventListener')
-    const netPointerdownListeners = () => {
-      const adds = addSpy.mock.calls.filter(([type]) => type === 'pointerdown').length
-      const removes = removeSpy.mock.calls.filter(([type]) => type === 'pointerdown').length
-      return adds - removes
+
+    try {
+      region.setOptions({ resize: false })
+      region.setOptions({ resize: true })
+      region.setOptions({ resize: false })
+      region.setOptions({ resize: true })
+
+      const pointerdownAdds = addSpy.mock.calls.filter(([type]) => type === 'pointerdown').length
+      const pointerdownRemoves = removeSpy.mock.calls.filter(([type]) => type === 'pointerdown').length
+
+      expect(pointerdownAdds).toBeGreaterThan(0)
+      expect(pointerdownAdds).toBe(pointerdownRemoves)
+    } finally {
+      addSpy.mockRestore()
+      removeSpy.mockRestore()
     }
-
-    region.setOptions({ resize: false })
-    region.setOptions({ resize: true })
-    const netAfterFirstToggle = netPointerdownListeners()
-
-    region.setOptions({ resize: false })
-    region.setOptions({ resize: true })
-    const netAfterSecondToggle = netPointerdownListeners()
-
-    expect(netAfterSecondToggle).toBe(netAfterFirstToggle)
   })
 
   test('places a region in the first free row instead of summing all prior overlaps', () => {

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -313,25 +313,62 @@ describe('Renderer', () => {
     expect(lateUnsubscribe).not.toHaveBeenCalled()
   })
 
-  it('keeps visibleRange live (not disposed) across destroy -> render reuse', async () => {
+  it('keeps visibleRange live (not disposed) and revives scroll tracking across destroy -> render reuse', async () => {
     // visibleRange is instance-lifetime state, deliberately never disposed via
-    // this.scope (see the constructor comment): scrollStream/initEvents() only
-    // run once, so registering visibleRange's dispose on this.scope would
-    // permanently freeze it after the first destroy(), with nothing left to
-    // recreate it. Reading it post-destroy must not throw, and a subsequent
-    // render() reuse must still update it via the still-live audioDuration
-    // signal, even though this.scrollStream is now null.
+    // this.scope (see the constructor comment). Reading it post-destroy must
+    // not throw despite this.scrollStream being torn down, and a subsequent
+    // render() reuse must both keep the still-live audioDuration signal
+    // driving it AND re-subscribe to the brand new scroll stream that
+    // ensureInputEvents() creates on revival -- not stay pinned to the
+    // disposed pre-destroy percentages signal (see visibleRange's
+    // auto-tracking comment in the constructor).
     renderer.zoom(1000)
     await renderer.render(createAudioBuffer([[0, 0.5, -0.5]], 100))
 
     renderer.destroy()
 
+    // Immediately post-destroy: scrollStream is torn down, but reading
+    // visibleRange must not throw.
+    expect((renderer as any).scrollStream).toBeNull()
     expect(() => renderer.getVisibleRange().value).not.toThrow()
 
     await renderer.render(createAudioBuffer([[0, 0.5, -0.5]], 42))
 
-    expect((renderer as any).scrollStream).toBeNull()
-    expect(renderer.getVisibleRange().value).toEqual({ startTime: 0, endTime: 42 })
+    // render() revives the input pipeline, including a fresh scrollStream.
+    expect((renderer as any).scrollStream).not.toBeNull()
+
+    // jsdom performs no layout (scrollWidth/clientWidth both 0 by default),
+    // as in 'recomputes visibleRange when the underlying scroll position
+    // changes' above -- stub in sizes to exercise a real scroll delta.
+    const scrollContainer = (renderer as any).scrollContainer as HTMLElement
+    Object.defineProperty(scrollContainer, 'scrollWidth', { configurable: true, value: 1000 })
+    Object.defineProperty(scrollContainer, 'clientWidth', { configurable: true, value: 100 })
+
+    expect((renderer as any).isScrollable).toBe(true)
+
+    scrollContainer.scrollLeft = 500
+    scrollContainer.dispatchEvent(new Event('scroll'))
+
+    // visibleRange must react to the NEW scroll stream, proving it
+    // re-subscribed after reuse instead of staying pinned to the old one.
+    expect(renderer.getVisibleRange().value.startTime).toBeGreaterThan(0)
+  })
+
+  it('revives click and scroll input after destroy -> render reuse', async () => {
+    const localContainer = document.createElement('div')
+    document.body.appendChild(localContainer)
+    const localRenderer = new Renderer({ container: localContainer })
+    const clickSpy = jest.fn()
+    localRenderer.on('click', clickSpy)
+    localRenderer.destroy()
+    await localRenderer.render(createAudioBuffer([[0, 0.5, -0.5]]))
+    const wrapper = (localRenderer as any).wrapper as HTMLElement
+    wrapper.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 100, height: 50, right: 100, bottom: 50 }) as DOMRect
+    wrapper.dispatchEvent(new MouseEvent('click', { clientX: 10, clientY: 10 }))
+    expect(clickSpy).toHaveBeenCalled() // dead pre-fix: listener was removed at destroy, never re-added
+    localRenderer.destroy()
+    localContainer.remove()
   })
 
   it('cancels a pending resize debounce on destroy even after a render', async () => {

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -80,18 +80,50 @@ describe('TimelinePlugin', () => {
     expect(offsets[3]).toBeCloseTo(100)
   })
 
+  // ADAPTED (private-internal poke): the original spied on the plugin's
+  // private `updateVisibleNotches` method, which no longer exists as an
+  // instance member post-port (it's a setup()-local closure). Adapted to
+  // pin the same observable claim -- firing the visibleRange signal
+  // re-windows notch visibility using the CURRENT getScroll()/getWidth()
+  // mock values -- via the DOM instead of a spy: change what getWidth()
+  // returns *after* init (so a stale, init-time window would keep both
+  // notches visible), confirm nothing moves until the signal actually
+  // fires, then fire it and confirm the now-out-of-window notch is pruned.
   test('re-windows notches when visibleRange changes rather than on raw scroll math', () => {
-    const { plugin, wavesurfer } = createInitializedTimeline()
-    const spy = jest.spyOn(plugin as any, 'updateVisibleNotches')
+    const wavesurfer = createWaveSurfer(1, 100)
+    const plugin = TimelinePlugin.create({ duration: 1, timeInterval: 0.5 })
+    plugin._init(wavesurfer as any)
+
+    const notchAt0 = wavesurfer.getWrapper().querySelector<HTMLElement>('[part^="timeline-notch"][style*="left: 0px"]')
+    const notchAt50 = wavesurfer
+      .getWrapper()
+      .querySelector<HTMLElement>('[part^="timeline-notch"][style*="left: 50px"]')
+    expect(notchAt0).not.toBeNull()
+    expect(notchAt50).not.toBeNull()
+    // Both start out visible: getScroll()=0, getWidth()=200 (scrollWidth * 2).
+    expect(notchAt0?.isConnected).toBe(true)
+    expect(notchAt50?.isConnected).toBe(true)
+
+    // Shrink the live window so the notch at offset 50 falls outside it.
+    // Changing the mock alone must not move anything yet.
+    wavesurfer.getWidth = jest.fn(() => 30)
+    expect(notchAt50?.isConnected).toBe(true)
 
     wavesurfer.getRenderer().getVisibleRange().set({ startTime: 10, endTime: 20 })
 
-    expect(spy).toHaveBeenCalled()
+    expect(notchAt0?.isConnected).toBe(true)
+    expect(notchAt50?.isConnected).toBe(false)
   })
 
+  // ADAPTED (private-internal poke): same `updateVisibleNotches` spy removed
+  // as above. The first assertion (no 'scroll' subscription registered) is
+  // unmodified and is, on its own, sufficient to prove the plugin can't be
+  // driven by the raw 'scroll' event -- there's nothing to fire. The
+  // dropped second half (`spy not called`) is now covered by the previous
+  // test's boundary check, which shows the re-window path only reacts to
+  // the visibleRange signal.
   test('does not re-window notches on the raw wavesurfer "scroll" event anymore', () => {
-    const { plugin, wavesurfer } = createInitializedTimeline()
-    const spy = jest.spyOn(plugin as any, 'updateVisibleNotches')
+    const { wavesurfer } = createInitializedTimeline()
 
     // Find the listener the plugin registered for 'scroll' via wavesurfer.on
     // (still present for other consumers) and confirm firing it no longer
@@ -99,10 +131,16 @@ describe('TimelinePlugin', () => {
     const onCalls = (wavesurfer.on as jest.Mock).mock.calls
     const scrollListenerCall = onCalls.find(([event]) => event === 'scroll')
     expect(scrollListenerCall).toBeUndefined()
-
-    expect(spy).not.toHaveBeenCalled()
   })
 
+  // ADAPTED (private-internal poke): the original spied on
+  // `updateVisibleNotches` and asserted its exact call args, including a
+  // read of the private `currentTimeline` field. Neither exists post-port.
+  // Adapted to pin the same invariant -- the re-window uses
+  // getScroll() + getWidth() (padding-adjusted), not some other bounds --
+  // via a DOM boundary: place notches exactly either side of the padding-
+  // adjusted scrollRight (160 = getScroll() 10 + getWidth() 150) and confirm
+  // only the one strictly inside the window survives after the signal fires.
   test('scroll-driven notch window uses the padding-adjusted getWidth(), consistent with virtualAppend', () => {
     // Renderer.getWidth() returns clientWidth minus the container's inline
     // padding (see renderer.ts's getWidth()/containerInlinePadding). Simulate
@@ -111,38 +149,61 @@ describe('TimelinePlugin', () => {
     // check already used getScroll() + getWidth() for this reason; the
     // scroll-driven effect must compute the SAME window, not fall back to an
     // unpadded bounds value (as the legacy 'scroll' event used to report).
-    const wavesurfer = createWaveSurfer(1, 100)
-    const paddingAdjustedWidth = 150 // e.g. a 200px-wide container with 50px of inline padding
-    wavesurfer.getWidth = jest.fn(() => paddingAdjustedWidth)
+    // duration=20, scrollWidth=200 => pxPerSec=10, so integer notch indices
+    // land on exact, drift-free pixel offsets (i * 10) -- unlike a fractional
+    // timeInterval, which would accumulate floating-point error across the
+    // repeated `i += timeInterval` loop and make an exact "left: 150px"
+    // string match unreliable.
+    const wavesurfer = createWaveSurfer(20, 200)
+    // Start with a generous window so both boundary notches render visible
+    // at init time, before the padding-adjusted width kicks in.
+    wavesurfer.getWidth = jest.fn(() => 1000)
     wavesurfer.getScroll = jest.fn(() => 10)
 
-    const plugin = TimelinePlugin.create({ duration: 1 })
+    const plugin = TimelinePlugin.create({ duration: 20, timeInterval: 1, timeOffset: 0 })
     plugin._init(wavesurfer as any)
 
-    const updateSpy = jest.spyOn(plugin as any, 'updateVisibleNotches')
+    const wrapper = wavesurfer.getWrapper()
+    const notchAt150 = wrapper.querySelector<HTMLElement>('[part^="timeline-notch"][style*="left: 150px"]')
+    const notchAt160 = wrapper.querySelector<HTMLElement>('[part^="timeline-notch"][style*="left: 160px"]')
+    expect(notchAt150).not.toBeNull()
+    expect(notchAt160).not.toBeNull()
+    expect(notchAt150?.isConnected).toBe(true)
+    expect(notchAt160?.isConnected).toBe(true)
+
+    const paddingAdjustedWidth = 150 // e.g. a 200px-wide container with 50px of inline padding
+    wavesurfer.getWidth = jest.fn(() => paddingAdjustedWidth)
 
     wavesurfer.getRenderer().getVisibleRange().set({ startTime: 0.1, endTime: 0.9 })
 
-    // The exact same scrollRight virtualAppend() would compute right now,
-    // from the same getScroll()/getWidth() pair -- pins the invariant that
-    // both paths share one padding-adjusted width, not two different windows.
-    const virtualAppendScrollRight = wavesurfer.getScroll() + wavesurfer.getWidth()
-    expect(updateSpy).toHaveBeenCalledWith(10, virtualAppendScrollRight, (plugin as any).currentTimeline)
-    expect(updateSpy).toHaveBeenCalledWith(10, 160, (plugin as any).currentTimeline)
+    // scrollRight = getScroll() 10 + getWidth() 150 = 160. The notch at 150
+    // is strictly inside (150 < 160) and stays; the notch at exactly 160 is
+    // not (160 < 160 is false) and is pruned. If the re-window had instead
+    // used an unpadded bounds value, both would still be inside and the
+    // notch at 160 would incorrectly remain.
+    expect(notchAt150?.isConnected).toBe(true)
+    expect(notchAt160?.isConnected).toBe(false)
   })
 
-  test('clears notch element cache on destroy', () => {
+  // ADAPTED (private-internal poke): the original read the private
+  // `notchElements`/`currentTimeline` fields directly. Neither exists
+  // post-port (they're setup()-local closure state, discarded with the
+  // scope on destroy). Adapted to the equivalent DOM-observable claim: the
+  // timeline wrapper (and its notches) is detached from the container on
+  // destroy, i.e. nothing the plugin rendered is left behind.
+  test('removes the timeline DOM on destroy', () => {
     const wavesurfer = createWaveSurfer(1, 100)
     const plugin = TimelinePlugin.create({ duration: 1 })
 
     plugin._init(wavesurfer as any)
 
-    expect((plugin as any).notchElements.size).toBeGreaterThan(0)
-    expect((plugin as any).currentTimeline).not.toBeUndefined()
+    const wrapper = wavesurfer.getWrapper()
+    expect(wrapper.querySelectorAll('[part^="timeline-notch"]').length).toBeGreaterThan(0)
+    expect(wrapper.querySelector('[part="timeline-wrapper"]')).not.toBeNull()
 
     plugin.destroy()
 
-    expect((plugin as any).notchElements.size).toBe(0)
-    expect((plugin as any).currentTimeline).toBeUndefined()
+    expect(wrapper.querySelector('[part="timeline-wrapper"]')).toBeNull()
+    expect(wrapper.querySelectorAll('[part^="timeline-notch"]').length).toBe(0)
   })
 })

--- a/src/__tests__/wavesurfer.test.ts
+++ b/src/__tests__/wavesurfer.test.ts
@@ -685,5 +685,48 @@ describe('WaveSurfer public methods', () => {
 
       ws.destroy()
     })
+
+    it('settles a superseded load promise even when no loadedmetadata ever arrives', async () => {
+      const ws = WaveSurfer.create({ container: document.createElement('div') })
+      // Fetch resolves with a blob, so load A reaches the duration-promise await;
+      // jsdom never fires loadedmetadata, so pre-fix the promise pends forever.
+      const blob = new Blob([new ArrayBuffer(8)], { type: 'audio/wav' })
+      const response = {
+        status: 200,
+        blob: () => Promise.resolve(blob),
+        body: null,
+        headers: new Headers(),
+        clone: () => ({ body: null, headers: new Headers() }),
+      } as unknown as Response
+      const originalFetch = global.fetch
+      global.fetch = jest.fn().mockResolvedValue(response)
+      try {
+        const pA = ws.load('http://x/a.mp3')
+        await new Promise((r) => setTimeout(r, 0)) // let A reach the duration await
+        ws.load('http://x/b.mp3').catch(() => undefined) // supersede A
+        await expect(
+          Promise.race([
+            pA.then(
+              () => 'settled',
+              () => 'settled',
+            ),
+            new Promise((r) => setTimeout(() => r('pending'), 50)),
+          ]),
+        ).resolves.toBe('settled')
+      } finally {
+        global.fetch = originalFetch
+        ws.destroy()
+      }
+    })
+
+    it('sets loadPhase=error when a load listener throws synchronously', async () => {
+      const ws = WaveSurfer.create({ container: document.createElement('div') })
+      ws.on('load', () => {
+        throw new Error('listener boom')
+      })
+      await expect(ws.load('http://x/a.mp3')).rejects.toThrow('listener boom')
+      expect(ws.getState().loadPhase.value).toBe('error')
+      ws.destroy()
+    })
   })
 })

--- a/src/__tests__/zoom.test.ts
+++ b/src/__tests__/zoom.test.ts
@@ -1,0 +1,91 @@
+import ZoomPlugin from '../plugins/zoom.js'
+import { signal } from '../reactive/store.js'
+
+type Listener = (...args: any[]) => void
+
+const createEmitter = () => {
+  const listeners = new Map<string, Set<Listener>>()
+
+  return {
+    on: jest.fn((event: string, listener: Listener) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, new Set())
+      }
+
+      listeners.get(event)!.add(listener)
+      return () => listeners.get(event)?.delete(listener)
+    }),
+  }
+}
+
+const createWaveSurfer = (container: HTMLElement, wrapper: HTMLElement, durationValue: number) => {
+  const duration = signal(durationValue)
+  const zoom = signal(0)
+
+  return {
+    wavesurfer: {
+      ...createEmitter(),
+      options: { minPxPerSec: 50 },
+      getDuration: jest.fn(() => duration.value),
+      getScroll: jest.fn(() => 0),
+      getState: jest.fn(() => ({ zoom, duration })),
+      getWrapper: jest.fn(() => wrapper),
+      zoom: jest.fn(),
+    },
+  }
+}
+
+describe('ZoomPlugin', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    jest.clearAllMocks()
+  })
+
+  // Coordinator review finding (round 1): the pre-port class computed a
+  // missing `maxZoom` once from the container width and kept it on the
+  // long-lived `this.options` for the plugin instance's lifetime, even
+  // across a destroy -> re-init cycle. The port recomputes it fresh from
+  // the CURRENT container width on every (re-)init instead — this is a
+  // deliberate, disclosed behavior change (see the comment in zoom.ts).
+  // This test pins the new behavior via the only externally observable
+  // effect of `maxZoom`: it caps the pixels-per-second value passed to
+  // `wavesurfer.zoom()`.
+  test('derives the default maxZoom from the live container width on each re-init, not cached across destroy', () => {
+    const container = document.createElement('div')
+    const wrapper = document.createElement('div')
+    container.appendChild(wrapper)
+    document.body.appendChild(container)
+
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ left: 0 }),
+    })
+    Object.defineProperty(container, 'clientWidth', { configurable: true, value: 100 })
+
+    const { wavesurfer } = createWaveSurfer(container, wrapper, 10)
+
+    const plugin = ZoomPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    // A large wheel delta pushes the linear zoom calculation well past 100
+    // px/s, so the value actually applied is clamped at maxZoom. With
+    // duration=10 and width=100, 100 * 10 >= 100, so onWheel's "else"
+    // branch (`wavesurfer.zoom(newMinPxPerSec)`) fires with the clamped
+    // value directly.
+    container.dispatchEvent(new WheelEvent('wheel', { deltaY: -1000, deltaX: 0 }))
+    expect(wavesurfer.zoom).toHaveBeenLastCalledWith(100)
+
+    plugin.destroy()
+
+    // Resize the container between destroy and re-init.
+    Object.defineProperty(container, 'clientWidth', { configurable: true, value: 300 })
+    wavesurfer.zoom.mockClear()
+
+    plugin._init(wavesurfer as any)
+    container.dispatchEvent(new WheelEvent('wheel', { deltaY: -1000, deltaX: 0 }))
+
+    // If maxZoom had been cached from the first init (the pre-port
+    // behavior), this would still be clamped at 100.
+    expect(wavesurfer.zoom).toHaveBeenLastCalledWith(300)
+  })
+})

--- a/src/base-plugin.ts
+++ b/src/base-plugin.ts
@@ -1,4 +1,5 @@
 import EventEmitter from './event-emitter.js'
+import { Scope } from './scope.js'
 import type WaveSurfer from './wavesurfer.js'
 
 export type BasePluginEvents = {
@@ -12,6 +13,13 @@ export class BasePlugin<EventTypes extends BasePluginEvents, Options> extends Ev
   protected wavesurfer?: WaveSurfer
   protected subscriptions: (() => void)[] = []
   protected options: Options
+  /**
+   * A disposal scope owned by the plugin chassis. `definePlugin` (see
+   * define-plugin.ts) replaces this with a fresh Scope on every (re-)init
+   * and disposes it on destroy. BasePlugin itself does NOT dispose this —
+   * class-based plugins that don't opt in are unaffected.
+   */
+  protected scope: Scope = new Scope()
   private isDestroyed = false
 
   /** Whether destroy() has been called. Subclasses use this to guard async work. */

--- a/src/define-plugin.ts
+++ b/src/define-plugin.ts
@@ -34,6 +34,18 @@ export type DefinedPlugin<Options, Events extends BasePluginEvents, Api extends 
 // (e.g. an api key named `destroy` would shadow BasePlugin#destroy, making
 // `plugin.destroy()` a no-op — a hard leak with no error). Checked
 // unconditionally (not just in dev builds): failing fast beats a silent leak.
+//
+// Includes TS-`private` fields (`isDestroyed`, `listeners`) as well as
+// `protected`/public ones: `private` is compile-time-only — it does not
+// exist at runtime, and `Object.assign` does not respect it. An api key
+// `isDestroyed` (truthy) would make `destroy()` a permanent no-op (the
+// `if (this.isDestroyed) return` guard trips immediately); an api key
+// `listeners` would replace EventEmitter's backing store and silently kill
+// all event dispatch. (TS does catch precisely-typed collisions on these
+// two at compile time too — the intersection type collapses to `never` —
+// but that protection disappears the moment `Api` is `any`/untyped or the
+// plugin is authored in plain JS, which is exactly what this runtime check
+// is for.)
 const RESERVED_CHASSIS_KEYS = new Set([
   'destroy',
   '_init',
@@ -47,6 +59,8 @@ const RESERVED_CHASSIS_KEYS = new Set([
   'subscriptions',
   'scope',
   'destroyed',
+  'isDestroyed',
+  'listeners',
 ])
 
 /**
@@ -58,7 +72,11 @@ const RESERVED_CHASSIS_KEYS = new Set([
  *
  * Api methods only exist on the instance after `_init()` has run (i.e.
  * after `wavesurfer.registerPlugin(...)`); accessing them beforehand is
- * undefined behavior.
+ * undefined behavior. Symmetrically: calling an api method AFTER the
+ * plugin has been destroyed is also undefined behavior — `ctx.wavesurfer`
+ * is typed non-null, but `destroy()` sets the underlying field to
+ * `undefined`, so a post-destroy read returns `undefined` at runtime
+ * despite the type.
  */
 export function definePlugin<Options, Events extends BasePluginEvents, Api extends object>(
   name: string,

--- a/src/define-plugin.ts
+++ b/src/define-plugin.ts
@@ -1,0 +1,78 @@
+import BasePlugin, { type BasePluginEvents } from './base-plugin.js'
+import { Scope } from './scope.js'
+import type WaveSurfer from './wavesurfer.js'
+import type { WaveSurferState } from './state/wavesurfer-state.js'
+
+/** Everything a plugin's setup function needs, handed in fresh on every (re-)init. */
+export interface PluginContext<Events extends BasePluginEvents> {
+  wavesurfer: WaveSurfer
+  scope: Scope // disposed (and replaced) on plugin destroy
+  state: WaveSurferState // wavesurfer.getState()
+  // `Events[K] extends unknown[] ? Events[K] : never` (rather than a bare
+  // `Events[K]`) is required because `Events` is only constrained to
+  // `BasePluginEvents` (no index signature), so TS can't otherwise prove
+  // `Events[K]` is array-shaped for a rest parameter. For any real event
+  // map (all values are tuples) this resolves to the same effective type.
+  emit: <K extends keyof Events>(event: K, ...args: Events[K] extends unknown[] ? Events[K] : never) => void
+}
+
+/** A plugin's setup function: receives the context and options, returns its public API. */
+export type PluginSetup<Options, Events extends BasePluginEvents, Api extends object> = (
+  ctx: PluginContext<Events>,
+  options: Options,
+) => Api
+
+/** The constructor + factory produced by `definePlugin`. */
+export type DefinedPlugin<Options, Events extends BasePluginEvents, Api extends object> = {
+  new (options: Options): BasePlugin<Events, Options> & Api
+  create(options: Options): BasePlugin<Events, Options> & Api
+}
+
+/**
+ * Define a functional wavesurfer plugin from a setup function.
+ *
+ * `setup` runs once per (re-)init on a fresh Scope; whatever it returns is
+ * merged onto the plugin instance as its public API. Resources registered
+ * via `ctx.scope.add(...)` are torn down when the plugin is destroyed.
+ */
+export function definePlugin<Options, Events extends BasePluginEvents, Api extends object>(
+  name: string,
+  setup: PluginSetup<Options, Events, Api>,
+): DefinedPlugin<Options, Events, Api> {
+  class Defined extends BasePlugin<Events, Options> {
+    public static create(options: Options) {
+      return new Defined(options) as Defined & Api
+    }
+
+    protected onInit(): void {
+      // Fresh scope per (re-)init so a destroy -> _init -> destroy cycle
+      // starts each run with clean, undisposed resources.
+      this.scope = new Scope()
+      const api = setup(
+        {
+          wavesurfer: this.wavesurfer as WaveSurfer,
+          scope: this.scope,
+          state: (this.wavesurfer as WaveSurfer).getState(),
+          emit: (event, ...args) => this.emit(event, ...args),
+        },
+        this.options,
+      )
+      Object.assign(this, api)
+    }
+
+    // Decided order: dispose the scope FIRST, then call super.destroy()
+    // LAST (as everywhere else). super.destroy() emits 'destroy', drains
+    // `subscriptions`, then unAll()s listeners registered on this plugin.
+    // Consequence: scope teardown runs BEFORE the 'destroy' event is
+    // delivered to consumers. That mirrors how previously-ported
+    // class-based plugins tore down their own resources in destroy()
+    // before calling super.destroy() — same relative order, so this is
+    // consistent with existing plugin behavior.
+    public destroy(): void {
+      this.scope?.dispose()
+      super.destroy()
+    }
+  }
+  Object.defineProperty(Defined, 'name', { value: name })
+  return Defined as unknown as DefinedPlugin<Options, Events, Api>
+}

--- a/src/define-plugin.ts
+++ b/src/define-plugin.ts
@@ -28,12 +28,37 @@ export type DefinedPlugin<Options, Events extends BasePluginEvents, Api extends 
   create(options: Options): BasePlugin<Events, Options> & Api
 }
 
+// Own-property names on the plugin chassis (BasePlugin + EventEmitter) that
+// a setup()'s returned api must not shadow. Assigning over any of these via
+// `Object.assign(this, api)` would silently disable core plugin machinery
+// (e.g. an api key named `destroy` would shadow BasePlugin#destroy, making
+// `plugin.destroy()` a no-op — a hard leak with no error). Checked
+// unconditionally (not just in dev builds): failing fast beats a silent leak.
+const RESERVED_CHASSIS_KEYS = new Set([
+  'destroy',
+  '_init',
+  'emit',
+  'on',
+  'un',
+  'once',
+  'unAll',
+  'options',
+  'wavesurfer',
+  'subscriptions',
+  'scope',
+  'destroyed',
+])
+
 /**
  * Define a functional wavesurfer plugin from a setup function.
  *
  * `setup` runs once per (re-)init on a fresh Scope; whatever it returns is
  * merged onto the plugin instance as its public API. Resources registered
  * via `ctx.scope.add(...)` are torn down when the plugin is destroyed.
+ *
+ * Api methods only exist on the instance after `_init()` has run (i.e.
+ * after `wavesurfer.registerPlugin(...)`); accessing them beforehand is
+ * undefined behavior.
  */
 export function definePlugin<Options, Events extends BasePluginEvents, Api extends object>(
   name: string,
@@ -45,31 +70,54 @@ export function definePlugin<Options, Events extends BasePluginEvents, Api exten
     }
 
     protected onInit(): void {
+      // Self-healing: if onInit somehow runs twice without an intervening
+      // destroy(), dispose the stale scope first rather than leaking it.
+      this.scope.dispose()
       // Fresh scope per (re-)init so a destroy -> _init -> destroy cycle
       // starts each run with clean, undisposed resources.
       this.scope = new Scope()
-      const api = setup(
-        {
-          wavesurfer: this.wavesurfer as WaveSurfer,
-          scope: this.scope,
-          state: (this.wavesurfer as WaveSurfer).getState(),
-          emit: (event, ...args) => this.emit(event, ...args),
+      const plugin = this
+      const ctx: PluginContext<Events> = {
+        // Lazy getters (not values captured at setup time): api closures
+        // that read ctx.wavesurfer/ctx.state later see the CURRENT plugin
+        // state, not a snapshot from init. This also means an api closure
+        // can't pin a destroyed plugin's WaveSurfer alive — destroy() nulls
+        // `this.wavesurfer`, and the getter reads that live field. It also
+        // means test stubs that don't implement getState() only need to if
+        // the setup/api actually calls ctx.state.
+        get wavesurfer() {
+          return plugin.wavesurfer as WaveSurfer
         },
-        this.options,
-      )
+        get state() {
+          return (plugin.wavesurfer as WaveSurfer).getState()
+        },
+        scope: this.scope,
+        emit: (event, ...args) => this.emit(event, ...args),
+      }
+      const api = setup(ctx, this.options)
+      for (const key of Object.keys(api)) {
+        if (RESERVED_CHASSIS_KEYS.has(key)) {
+          throw new Error(`definePlugin('${name}'): api key "${key}" collides with the plugin chassis`)
+        }
+      }
       Object.assign(this, api)
     }
 
     // Decided order: dispose the scope FIRST, then call super.destroy()
     // LAST (as everywhere else). super.destroy() emits 'destroy', drains
     // `subscriptions`, then unAll()s listeners registered on this plugin.
-    // Consequence: scope teardown runs BEFORE the 'destroy' event is
-    // delivered to consumers. That mirrors how previously-ported
-    // class-based plugins tore down their own resources in destroy()
-    // before calling super.destroy() — same relative order, so this is
-    // consistent with existing plugin behavior.
+    // Consequence: scope-owned resources are torn down BEFORE the
+    // 'destroy' event reaches consumers (plugin.on('destroy', ...)).
+    // This matches six of the eight current class-based plugins' destroy()
+    // ordering (they tear down their own state before calling
+    // super.destroy()). Two plugins — hover and regions — intentionally
+    // remove their root DOM element AFTER super.destroy() so 'destroy'
+    // listeners still observe an attached node; ports of those plugins
+    // should keep that specific element removal OUT of ctx.scope (do it
+    // manually, after super.destroy(), instead of via ctx.scope.add) to
+    // preserve that behavior.
     public destroy(): void {
-      this.scope?.dispose()
+      this.scope.dispose() // always set (BasePlugin field initializer) — no `?.` needed
       super.destroy()
     }
   }

--- a/src/define-plugin.ts
+++ b/src/define-plugin.ts
@@ -22,10 +22,23 @@ export type PluginSetup<Options, Events extends BasePluginEvents, Api extends ob
   options: Options,
 ) => Api
 
+// `Record<string, never> extends Options` is true exactly when every
+// property Options declares is optional (an index signature of `never`
+// values satisfies any optional property, but can't satisfy a required
+// one) — including `Options = {}`/`Record<string, never>` itself. That
+// makes the constructor/`create()` parameter optional for all-optional
+// options types (e.g. `HoverPluginOptions`) and required otherwise (e.g. an
+// options type with a mandatory field), matching what a hand-written class
+// with `constructor(options?: Options)` vs `constructor(options: Options)`
+// would offer. See define-plugin.test.ts for the two-way compile-time
+// check (a no-arg `create()` on a required-field Options type is rejected
+// via `@ts-expect-error`).
+type PluginCtorArgs<Options> = Record<string, never> extends Options ? [options?: Options] : [options: Options]
+
 /** The constructor + factory produced by `definePlugin`. */
 export type DefinedPlugin<Options, Events extends BasePluginEvents, Api extends object> = {
-  new (options: Options): BasePlugin<Events, Options> & Api
-  create(options: Options): BasePlugin<Events, Options> & Api
+  new (...args: PluginCtorArgs<Options>): BasePlugin<Events, Options> & Api
+  create(...args: PluginCtorArgs<Options>): BasePlugin<Events, Options> & Api
 }
 
 // Own-property names on the plugin chassis (BasePlugin + EventEmitter) that
@@ -77,14 +90,29 @@ const RESERVED_CHASSIS_KEYS = new Set([
  * is typed non-null, but `destroy()` sets the underlying field to
  * `undefined`, so a post-destroy read returns `undefined` at runtime
  * despite the type.
+ *
+ * `new Plugin(options)` / `Plugin.create(options)`: the `options` argument
+ * is optional when (and only when) `Options` has no required properties
+ * (see `PluginCtorArgs` below) — same ergonomics a hand-written
+ * `constructor(options?: Options)` would give. When it's omitted, `setup`
+ * is called with `options === undefined`, not `{}`; a `setup` for an
+ * all-optional `Options` type must default it itself (e.g.
+ * `Object.assign({}, defaultOptions, options)`), exactly as it already had
+ * to for any individually-omitted field.
  */
 export function definePlugin<Options, Events extends BasePluginEvents, Api extends object>(
   name: string,
   setup: PluginSetup<Options, Events, Api>,
 ): DefinedPlugin<Options, Events, Api> {
   class Defined extends BasePlugin<Events, Options> {
-    public static create(options: Options) {
-      return new Defined(options) as Defined & Api
+    // Runtime is permissive for both directions of PluginCtorArgs: a
+    // missing arg is passed through as `undefined` (cast to `Options`).
+    // For an all-optional Options type this is exactly what
+    // `setup(ctx, options)` should see — setup is responsible for
+    // defaulting (e.g. `Object.assign({}, defaultOptions, options)`), the
+    // same way it always had to for any individually-omitted field.
+    public static create(...args: PluginCtorArgs<Options>) {
+      return new Defined(args[0] as Options) as Defined & Api
     }
 
     protected onInit(): void {
@@ -124,16 +152,26 @@ export function definePlugin<Options, Events extends BasePluginEvents, Api exten
     // Decided order: dispose the scope FIRST, then call super.destroy()
     // LAST (as everywhere else). super.destroy() emits 'destroy', drains
     // `subscriptions`, then unAll()s listeners registered on this plugin.
-    // Consequence: scope-owned resources are torn down BEFORE the
+    // Consequence: scope-owned resources — including any root DOM element
+    // removal registered via ctx.scope.add — are torn down BEFORE the
     // 'destroy' event reaches consumers (plugin.on('destroy', ...)).
-    // This matches six of the eight current class-based plugins' destroy()
+    // This matches six of the eight original class-based plugins' destroy()
     // ordering (they tear down their own state before calling
-    // super.destroy()). Two plugins — hover and regions — intentionally
-    // remove their root DOM element AFTER super.destroy() so 'destroy'
-    // listeners still observe an attached node; ports of those plugins
-    // should keep that specific element removal OUT of ctx.scope (do it
-    // manually, after super.destroy(), instead of via ctx.scope.add) to
-    // preserve that behavior.
+    // super.destroy()). Two plugins — hover and regions — historically
+    // removed their root DOM element AFTER super.destroy(), so a
+    // 'destroy' listener could still observe an attached node.
+    //
+    // General rule for ports: default to tearing down the root element via
+    // ctx.scope like everything else — that's simplest and matches most
+    // plugins. Keep an element's removal OUT of ctx.scope (do it manually,
+    // after the equivalent of super.destroy() has run) ONLY when a test or
+    // documented consumer contract for that specific plugin actually pins
+    // post-destroy attachment. This is a per-port decision, not a blanket
+    // rule: hover's port (Task 5) checked its test suite, found nothing
+    // pins the old ordering, and moved wrapper removal onto ctx.scope — a
+    // deliberate, documented behavior change from the original hover.
+    // Regions has not been ported yet (Task 11); its own test suite may
+    // pin the old ordering and warrant keeping its removal manual.
     public destroy(): void {
       this.scope.dispose() // always set (BasePlugin field initializer) — no `?.` needed
       super.destroy()

--- a/src/define-plugin.ts
+++ b/src/define-plugin.ts
@@ -59,9 +59,16 @@ export type DefinedPlugin<Options, Events extends BasePluginEvents, Api extends 
 // but that protection disappears the moment `Api` is `any`/untyped or the
 // plugin is authored in plain JS, which is exactly what this runtime check
 // is for.)
+//
+// `onInit` is on `Defined` itself (below), not BasePlugin/EventEmitter, but
+// the same hazard applies: an api key named `onInit` would shadow it on the
+// instance, so a subsequent destroy() -> _init() re-init cycle would invoke
+// the shadowed api value (if callable) or throw (if not) instead of
+// `Defined.prototype.onInit`, silently breaking re-init.
 const RESERVED_CHASSIS_KEYS = new Set([
   'destroy',
   '_init',
+  'onInit',
   'emit',
   'on',
   'un',

--- a/src/define-plugin.ts
+++ b/src/define-plugin.ts
@@ -170,8 +170,10 @@ export function definePlugin<Options, Events extends BasePluginEvents, Api exten
     // rule: hover's port (Task 5) checked its test suite, found nothing
     // pins the old ordering, and moved wrapper removal onto ctx.scope — a
     // deliberate, documented behavior change from the original hover.
-    // Regions has not been ported yet (Task 11); its own test suite may
-    // pin the old ordering and warrant keeping its removal manual.
+    // Regions' port (Task 11) checked its own test suite (regions.test.ts +
+    // memory-leaks.test.ts's #4243 cases) too, found nothing pins post-destroy
+    // attachment of regionsContainer either, and likewise moved its removal
+    // onto ctx.scope.
     public destroy(): void {
       this.scope.dispose() // always set (BasePlugin field initializer) — no `?.` needed
       super.destroy()

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -1,5 +1,5 @@
-import { Scope } from './scope'
-import { isHTMLElement, createElement } from './dom'
+import { Scope } from './scope.js'
+import { isHTMLElement, createElement } from './dom.js'
 
 /**
  * Resolve a container option: element, selector, or fallback.
@@ -10,7 +10,7 @@ export function resolveContainer(
   fallback: HTMLElement,
   pluginName: string,
 ): HTMLElement {
-  if (option === undefined) {
+  if (!option) {
     return fallback
   }
 

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -1,0 +1,61 @@
+import { Scope } from './scope'
+import { isHTMLElement, createElement } from './dom'
+
+/**
+ * Resolve a container option: element, selector, or fallback.
+ * Throws with the plugin name on failure.
+ */
+export function resolveContainer(
+  option: HTMLElement | string | undefined,
+  fallback: HTMLElement,
+  pluginName: string,
+): HTMLElement {
+  if (option === undefined) {
+    return fallback
+  }
+
+  if (isHTMLElement(option)) {
+    return option
+  }
+
+  // option is a string selector
+  const element = document.querySelector(option)
+  if (!isHTMLElement(element)) {
+    throw new Error(`${pluginName}: container not found: ${option}`)
+  }
+
+  return element
+}
+
+/**
+ * Create an absolutely-positioned overlay div, appended to parent.
+ * Removed on scope dispose.
+ */
+export function overlayElement(scope: Scope, parent: HTMLElement, style?: Partial<CSSStyleDeclaration>): HTMLElement {
+  const el = createElement('div', {}, parent)
+  el.style.position = 'absolute'
+  if (style) {
+    Object.assign(el.style, style)
+  }
+  scope.add(() => el.remove())
+  return el
+}
+
+/**
+ * Forward events from one emitter to another.
+ * Unsubscribes on scope dispose.
+ */
+export function bridgeEvents<Events extends Record<string, unknown[]>>(
+  scope: Scope,
+  from: { on: (e: never, cb: never) => () => void },
+  to: { emit: (e: never, ...args: never[]) => void },
+  names: Array<keyof Events & string>,
+): void {
+  names.forEach((name) => {
+    const unsubscribe = from.on(
+      name as never,
+      ((...args: unknown[]) => to.emit(name as never, ...(args as never[]))) as never,
+    )
+    scope.add(unsubscribe)
+  })
+}

--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -2,7 +2,8 @@
  * Envelope is a visual UI for controlling the audio volume and add fade-in and fade-out effects.
  */
 
-import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
+import { type BasePluginEvents } from '../base-plugin.js'
+import { definePlugin } from '../define-plugin.js'
 import EventEmitter from '../event-emitter.js'
 import createElement from '../dom.js'
 import { createDragStream } from '../reactive/drag-stream.js'
@@ -355,207 +356,61 @@ class Polyline extends EventEmitter<{
 
 const randomId = () => Math.random().toString(36).slice(2)
 
-class EnvelopePlugin extends BasePlugin<EnvelopePluginEvents, EnvelopePluginOptions> {
-  protected options: Options
-  private polyline: Polyline | null = null
-  private polylineSubscriptions: Array<() => void> = []
-  private points: EnvelopePoint[]
-  private throttleTimeout: ReturnType<typeof setTimeout> | null = null
-  private volume = 1
+// The public surface returned by setup() below — VERIFIED against the
+// pre-port class: addPoint/removePoint/getPoints/setPoints/setVolume/
+// getCurrentVolume were its only public methods (destroy is chassis-owned
+// now, not part of the Api — see port-recipe.md).
+type Api = {
+  addPoint: (point: EnvelopePoint) => void
+  removePoint: (point: EnvelopePoint) => void
+  getPoints: () => EnvelopePoint[]
+  setPoints: (newPoints: EnvelopePoint[]) => void
+  setVolume: (floatValue: number) => void
+  getCurrentVolume: () => number
+}
 
-  /**
-   * Create a new Envelope plugin.
-   */
-  constructor(options: EnvelopePluginOptions) {
-    super(options)
+const EnvelopePlugin = definePlugin<EnvelopePluginOptions, EnvelopePluginEvents, Api>('envelope', (ctx, options) => {
+  const opts: Options = Object.assign({}, defaultOptions, options)
+  opts.lineColor = opts.lineColor || defaultOptions.lineColor
+  opts.dragPointFill = opts.dragPointFill || defaultOptions.dragPointFill
+  opts.dragPointStroke = opts.dragPointStroke || defaultOptions.dragPointStroke
+  opts.dragPointSize = opts.dragPointSize || defaultOptions.dragPointSize
 
-    this.points = options.points || []
+  const points: EnvelopePoint[] = options?.points || []
+  let polyline: Polyline | null = null
+  // A child scope dedicated to the current polyline's event subscriptions.
+  // Disposed and replaced (not accumulated) every time initPolyline() runs,
+  // e.g. on every 'decode' — this is the equivalent of the pre-port
+  // `polylineSubscriptions` array plus its manual drain-before-push.
+  let polylineScope = ctx.scope.child()
+  let volume = 1
+  let clearEmitPointsTimeout: (() => void) | null = null
 
-    this.options = Object.assign({}, defaultOptions, options)
-    this.options.lineColor = this.options.lineColor || defaultOptions.lineColor
-    this.options.dragPointFill = this.options.dragPointFill || defaultOptions.dragPointFill
-    this.options.dragPointStroke = this.options.dragPointStroke || defaultOptions.dragPointStroke
-    this.options.dragPointSize = this.options.dragPointSize || defaultOptions.dragPointSize
-  }
-
-  public static create(options: EnvelopePluginOptions) {
-    return new EnvelopePlugin(options)
-  }
-
-  /**
-   * Add an envelope point with a given time and volume.
-   */
-  public addPoint(point: EnvelopePoint) {
-    if (!point.id) point.id = randomId()
-
-    // Insert the point in the correct position to keep the array sorted
-    const index = this.points.findLastIndex((p) => p.time < point.time)
-    this.points.splice(index + 1, 0, point)
-
-    this.emitPoints()
-
-    // Add the point to the polyline if the duration is available
-    const duration = this.wavesurfer?.getDuration()
-    if (duration) {
-      this.addPolyPoint(point, duration)
-    }
-  }
-
-  /**
-   * Remove an envelope point.
-   */
-  public removePoint(point: EnvelopePoint) {
-    const index = this.points.indexOf(point)
-    if (index > -1) {
-      this.points.splice(index, 1)
-      this.polyline?.removePolyPoint(point)
-      this.emitPoints()
-    }
-  }
-
-  /**
-   * Get all envelope points. Should not be modified directly.
-   */
-  public getPoints(): EnvelopePoint[] {
-    return this.points
-  }
-
-  /**
-   * Set new envelope points.
-   */
-  public setPoints(newPoints: EnvelopePoint[]) {
-    this.points.slice().forEach((point) => this.removePoint(point))
-    newPoints.forEach((point) => this.addPoint(point))
-  }
-
-  /**
-   * Destroy the plugin instance.
-   */
-  public destroy() {
-    // Clear pending throttle timeout
-    if (this.throttleTimeout) {
-      clearTimeout(this.throttleTimeout)
-      this.throttleTimeout = null
-    }
-
-    this.polylineSubscriptions.forEach((unsubscribe) => unsubscribe())
-    this.polylineSubscriptions = []
-
-    this.polyline?.destroy()
-    this.polyline = null
-    super.destroy()
-  }
-
-  /**
-   * Get the envelope volume.
-   */
-  public getCurrentVolume(): number {
-    return this.volume
-  }
-
-  /**
-   * Set the envelope volume. 0..1 (more than 1 will boost the volume).
-   */
-  public setVolume(floatValue: number) {
-    this.volume = floatValue
-    this.wavesurfer?.setVolume(floatValue)
-  }
-
-  /** Called by wavesurfer, don't call manually */
-  onInit() {
-    if (!this.wavesurfer) {
-      throw Error('WaveSurfer is not initialized')
-    }
-
-    const { options } = this
-    options.volume = options.volume ?? this.wavesurfer.getVolume()
-
-    this.setVolume(options.volume)
-
-    this.subscriptions.push(
-      this.wavesurfer.on('decode', (duration) => {
-        this.initPolyline()
-
-        this.points.forEach((point) => {
-          this.addPolyPoint(point, duration)
-        })
-      }),
-
-      this.wavesurfer.on('redraw', () => {
-        this.polyline?.update()
-      }),
-
-      this.wavesurfer.on('timeupdate', (time) => {
-        this.onTimeUpdate(time)
-      }),
-    )
-  }
-
-  private emitPoints() {
-    if (this.throttleTimeout) {
-      clearTimeout(this.throttleTimeout)
-    }
-    this.throttleTimeout = setTimeout(() => {
-      this.emit('points-change', this.points)
+  function emitPoints() {
+    // Replace the pending throttle timeout instead of accumulating one per
+    // call (mirrors the old `throttleTimeout` clearTimeout-then-set).
+    clearEmitPointsTimeout?.()
+    clearEmitPointsTimeout = ctx.scope.timeout(() => {
+      ctx.emit('points-change', points)
     }, 200)
   }
 
-  private initPolyline() {
-    // Drop the previous polyline's listeners before replacing it, instead of
-    // accumulating a fresh set of 4 on every decode.
-    this.polylineSubscriptions.forEach((unsubscribe) => unsubscribe())
-    this.polylineSubscriptions = []
-
-    if (this.polyline) this.polyline.destroy()
-    if (!this.wavesurfer) return
-
-    const wrapper = this.wavesurfer.getWrapper()
-
-    this.polyline = new Polyline(this.options, wrapper)
-
-    this.polylineSubscriptions.push(
-      this.polyline.on('point-move', (point, relativeX, relativeY) => {
-        const duration = this.wavesurfer?.getDuration() || 0
-        point.time = relativeX * duration
-        point.volume = 1 - relativeY
-
-        this.emitPoints()
-      }),
-
-      this.polyline.on('point-dragout', (point) => {
-        this.removePoint(point)
-      }),
-
-      this.polyline.on('point-create', (relativeX, relativeY) => {
-        this.addPoint({
-          time: relativeX * (this.wavesurfer?.getDuration() || 0),
-          volume: 1 - relativeY,
-        })
-      }),
-
-      this.polyline.on('line-move', (relativeY) => {
-        this.points.forEach((point) => {
-          point.volume = Math.min(1, Math.max(0, point.volume - relativeY))
-        })
-
-        this.emitPoints()
-
-        this.onTimeUpdate(this.wavesurfer?.getCurrentTime() || 0)
-      }),
-    )
+  function addPolyPoint(point: EnvelopePoint, duration: number) {
+    polyline?.addPolyPoint(point.time / duration, point.volume, point)
   }
 
-  private addPolyPoint(point: EnvelopePoint, duration: number) {
-    this.polyline?.addPolyPoint(point.time / duration, point.volume, point)
-  }
+  function onTimeUpdate(time: number) {
+    // Guards a post-destroy call the same way the pre-port `this.wavesurfer`
+    // optional-chaining did: ctx.wavesurfer is typed non-null but reads
+    // `undefined` at runtime once destroy() has run (see define-plugin.ts).
+    const duration = ctx.wavesurfer?.getDuration()
+    if (duration === undefined) return
 
-  private onTimeUpdate(time: number) {
-    if (!this.wavesurfer) return
-    let nextPoint = this.points.find((point) => point.time > time)
+    let nextPoint = points.find((point) => point.time > time)
     if (!nextPoint) {
-      nextPoint = { time: this.wavesurfer.getDuration() || 0, volume: 0 }
+      nextPoint = { time: duration || 0, volume: 0 }
     }
-    let prevPoint = this.points.findLast((point) => point.time <= time)
+    let prevPoint = points.findLast((point) => point.time <= time)
     if (!prevPoint) {
       prevPoint = { time: 0, volume: 0 }
     }
@@ -565,11 +420,151 @@ class EnvelopePlugin extends BasePlugin<EnvelopePluginEvents, EnvelopePluginOpti
     const clampedVolume = Math.min(1, Math.max(0, newVolume))
     const roundedVolume = Math.round(clampedVolume * 100) / 100
 
-    if (roundedVolume !== this.getCurrentVolume()) {
-      this.setVolume(roundedVolume)
-      this.emit('volume-change', roundedVolume)
+    if (roundedVolume !== volume) {
+      setVolume(roundedVolume)
+      ctx.emit('volume-change', roundedVolume)
     }
   }
-}
+
+  function initPolyline() {
+    // Drop the previous polyline's listeners before replacing it, instead
+    // of accumulating a fresh set of 4 on every decode.
+    polylineScope.dispose()
+    polyline?.destroy()
+    polyline = null
+    polylineScope = ctx.scope.child()
+
+    if (!ctx.wavesurfer) return
+
+    const wrapper = ctx.wavesurfer.getWrapper()
+    polyline = new Polyline(opts, wrapper)
+
+    polylineScope.add(
+      polyline.on('point-move', (point, relativeX, relativeY) => {
+        const duration = ctx.wavesurfer?.getDuration() || 0
+        point.time = relativeX * duration
+        point.volume = 1 - relativeY
+
+        emitPoints()
+      }),
+    )
+
+    polylineScope.add(
+      polyline.on('point-dragout', (point) => {
+        removePoint(point)
+      }),
+    )
+
+    polylineScope.add(
+      polyline.on('point-create', (relativeX, relativeY) => {
+        addPoint({
+          time: relativeX * (ctx.wavesurfer?.getDuration() || 0),
+          volume: 1 - relativeY,
+        })
+      }),
+    )
+
+    polylineScope.add(
+      polyline.on('line-move', (relativeY) => {
+        points.forEach((point) => {
+          point.volume = Math.min(1, Math.max(0, point.volume - relativeY))
+        })
+
+        emitPoints()
+
+        onTimeUpdate(ctx.wavesurfer?.getCurrentTime() || 0)
+      }),
+    )
+  }
+
+  function addPoint(point: EnvelopePoint) {
+    if (!point.id) point.id = randomId()
+
+    // Insert the point in the correct position to keep the array sorted
+    const index = points.findLastIndex((p) => p.time < point.time)
+    points.splice(index + 1, 0, point)
+
+    emitPoints()
+
+    // Add the point to the polyline if the duration is available
+    const duration = ctx.wavesurfer?.getDuration()
+    if (duration) {
+      addPolyPoint(point, duration)
+    }
+  }
+
+  function removePoint(point: EnvelopePoint) {
+    const index = points.indexOf(point)
+    if (index > -1) {
+      points.splice(index, 1)
+      polyline?.removePolyPoint(point)
+      emitPoints()
+    }
+  }
+
+  function getPoints(): EnvelopePoint[] {
+    return points
+  }
+
+  function setPoints(newPoints: EnvelopePoint[]) {
+    points.slice().forEach((point) => removePoint(point))
+    newPoints.forEach((point) => addPoint(point))
+  }
+
+  function getCurrentVolume(): number {
+    return volume
+  }
+
+  function setVolume(floatValue: number) {
+    volume = floatValue
+    ctx.wavesurfer?.setVolume(floatValue)
+  }
+
+  // Equivalent of the pre-port onInit(): default the volume option from the
+  // live wavesurfer and apply it, then subscribe to decode/redraw/timeupdate.
+  opts.volume = opts.volume ?? ctx.wavesurfer.getVolume()
+  setVolume(opts.volume)
+
+  ctx.scope.add(
+    ctx.wavesurfer.on('decode', (duration) => {
+      initPolyline()
+
+      points.forEach((point) => {
+        addPolyPoint(point, duration)
+      })
+    }),
+  )
+
+  ctx.scope.add(
+    ctx.wavesurfer.on('redraw', () => {
+      polyline?.update()
+    }),
+  )
+
+  ctx.scope.add(
+    ctx.wavesurfer.on('timeupdate', (time) => {
+      onTimeUpdate(time)
+    }),
+  )
+
+  // No destroy() override exists anymore — teardown IS scope disposal.
+  // polylineScope (a child of ctx.scope) is disposed automatically as part
+  // of that tree, but `polyline` itself must be explicitly destroyed and
+  // nulled out here so a post-destroy Api call (addPoint/removePoint/...)
+  // can't reach a torn-down Polyline instance.
+  ctx.scope.add(() => {
+    polyline?.destroy()
+    polyline = null
+  })
+
+  return {
+    addPoint,
+    removePoint,
+    getPoints,
+    setPoints,
+    setVolume,
+    getCurrentVolume,
+  }
+})
 
 export default EnvelopePlugin

--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -369,202 +369,205 @@ type Api = {
   getCurrentVolume: () => number
 }
 
-const EnvelopePlugin = definePlugin<EnvelopePluginOptions, EnvelopePluginEvents, Api>('envelope', (ctx, options) => {
-  const opts: Options = Object.assign({}, defaultOptions, options)
-  opts.lineColor = opts.lineColor || defaultOptions.lineColor
-  opts.dragPointFill = opts.dragPointFill || defaultOptions.dragPointFill
-  opts.dragPointStroke = opts.dragPointStroke || defaultOptions.dragPointStroke
-  opts.dragPointSize = opts.dragPointSize || defaultOptions.dragPointSize
+const EnvelopePlugin = definePlugin<EnvelopePluginOptions, EnvelopePluginEvents, Api>(
+  'EnvelopePlugin',
+  (ctx, options) => {
+    const opts: Options = Object.assign({}, defaultOptions, options)
+    opts.lineColor = opts.lineColor || defaultOptions.lineColor
+    opts.dragPointFill = opts.dragPointFill || defaultOptions.dragPointFill
+    opts.dragPointStroke = opts.dragPointStroke || defaultOptions.dragPointStroke
+    opts.dragPointSize = opts.dragPointSize || defaultOptions.dragPointSize
 
-  const points: EnvelopePoint[] = options?.points || []
-  let polyline: Polyline | null = null
-  // A child scope dedicated to the current polyline's event subscriptions.
-  // Disposed and replaced (not accumulated) every time initPolyline() runs,
-  // e.g. on every 'decode' — this is the equivalent of the pre-port
-  // `polylineSubscriptions` array plus its manual drain-before-push.
-  let polylineScope = ctx.scope.child()
-  let volume = 1
-  let clearEmitPointsTimeout: (() => void) | null = null
+    const points: EnvelopePoint[] = options?.points || []
+    let polyline: Polyline | null = null
+    // A child scope dedicated to the current polyline's event subscriptions.
+    // Disposed and replaced (not accumulated) every time initPolyline() runs,
+    // e.g. on every 'decode' — this is the equivalent of the pre-port
+    // `polylineSubscriptions` array plus its manual drain-before-push.
+    let polylineScope = ctx.scope.child()
+    let volume = 1
+    let clearEmitPointsTimeout: (() => void) | null = null
 
-  function emitPoints() {
-    // Replace the pending throttle timeout instead of accumulating one per
-    // call (mirrors the old `throttleTimeout` clearTimeout-then-set).
-    clearEmitPointsTimeout?.()
-    clearEmitPointsTimeout = ctx.scope.timeout(() => {
-      ctx.emit('points-change', points)
-    }, 200)
-  }
-
-  function addPolyPoint(point: EnvelopePoint, duration: number) {
-    polyline?.addPolyPoint(point.time / duration, point.volume, point)
-  }
-
-  function onTimeUpdate(time: number) {
-    // Guards a post-destroy call the same way the pre-port `this.wavesurfer`
-    // optional-chaining did: ctx.wavesurfer is typed non-null but reads
-    // `undefined` at runtime once destroy() has run (see define-plugin.ts).
-    const duration = ctx.wavesurfer?.getDuration()
-    if (duration === undefined) return
-
-    let nextPoint = points.find((point) => point.time > time)
-    if (!nextPoint) {
-      nextPoint = { time: duration || 0, volume: 0 }
+    function emitPoints() {
+      // Replace the pending throttle timeout instead of accumulating one per
+      // call (mirrors the old `throttleTimeout` clearTimeout-then-set).
+      clearEmitPointsTimeout?.()
+      clearEmitPointsTimeout = ctx.scope.timeout(() => {
+        ctx.emit('points-change', points)
+      }, 200)
     }
-    let prevPoint = points.findLast((point) => point.time <= time)
-    if (!prevPoint) {
-      prevPoint = { time: 0, volume: 0 }
+
+    function addPolyPoint(point: EnvelopePoint, duration: number) {
+      polyline?.addPolyPoint(point.time / duration, point.volume, point)
     }
-    const timeDiff = nextPoint.time - prevPoint.time
-    const volumeDiff = nextPoint.volume - prevPoint.volume
-    const newVolume = prevPoint.volume + (time - prevPoint.time) * (volumeDiff / timeDiff)
-    const clampedVolume = Math.min(1, Math.max(0, newVolume))
-    const roundedVolume = Math.round(clampedVolume * 100) / 100
 
-    if (roundedVolume !== volume) {
-      setVolume(roundedVolume)
-      ctx.emit('volume-change', roundedVolume)
+    function onTimeUpdate(time: number) {
+      // Guards a post-destroy call the same way the pre-port `this.wavesurfer`
+      // optional-chaining did: ctx.wavesurfer is typed non-null but reads
+      // `undefined` at runtime once destroy() has run (see define-plugin.ts).
+      const duration = ctx.wavesurfer?.getDuration()
+      if (duration === undefined) return
+
+      let nextPoint = points.find((point) => point.time > time)
+      if (!nextPoint) {
+        nextPoint = { time: duration || 0, volume: 0 }
+      }
+      let prevPoint = points.findLast((point) => point.time <= time)
+      if (!prevPoint) {
+        prevPoint = { time: 0, volume: 0 }
+      }
+      const timeDiff = nextPoint.time - prevPoint.time
+      const volumeDiff = nextPoint.volume - prevPoint.volume
+      const newVolume = prevPoint.volume + (time - prevPoint.time) * (volumeDiff / timeDiff)
+      const clampedVolume = Math.min(1, Math.max(0, newVolume))
+      const roundedVolume = Math.round(clampedVolume * 100) / 100
+
+      if (roundedVolume !== volume) {
+        setVolume(roundedVolume)
+        ctx.emit('volume-change', roundedVolume)
+      }
     }
-  }
 
-  function initPolyline() {
-    // Drop the previous polyline's listeners before replacing it, instead
-    // of accumulating a fresh set of 4 on every decode.
-    polylineScope.dispose()
-    polyline?.destroy()
-    polyline = null
-    polylineScope = ctx.scope.child()
+    function initPolyline() {
+      // Drop the previous polyline's listeners before replacing it, instead
+      // of accumulating a fresh set of 4 on every decode.
+      polylineScope.dispose()
+      polyline?.destroy()
+      polyline = null
+      polylineScope = ctx.scope.child()
 
-    if (!ctx.wavesurfer) return
+      if (!ctx.wavesurfer) return
 
-    const wrapper = ctx.wavesurfer.getWrapper()
-    polyline = new Polyline(opts, wrapper)
+      const wrapper = ctx.wavesurfer.getWrapper()
+      polyline = new Polyline(opts, wrapper)
 
-    polylineScope.add(
-      polyline.on('point-move', (point, relativeX, relativeY) => {
-        const duration = ctx.wavesurfer?.getDuration() || 0
-        point.time = relativeX * duration
-        point.volume = 1 - relativeY
+      polylineScope.add(
+        polyline.on('point-move', (point, relativeX, relativeY) => {
+          const duration = ctx.wavesurfer?.getDuration() || 0
+          point.time = relativeX * duration
+          point.volume = 1 - relativeY
 
-        emitPoints()
-      }),
-    )
+          emitPoints()
+        }),
+      )
 
-    polylineScope.add(
-      polyline.on('point-dragout', (point) => {
-        removePoint(point)
-      }),
-    )
+      polylineScope.add(
+        polyline.on('point-dragout', (point) => {
+          removePoint(point)
+        }),
+      )
 
-    polylineScope.add(
-      polyline.on('point-create', (relativeX, relativeY) => {
-        addPoint({
-          time: relativeX * (ctx.wavesurfer?.getDuration() || 0),
-          volume: 1 - relativeY,
-        })
-      }),
-    )
+      polylineScope.add(
+        polyline.on('point-create', (relativeX, relativeY) => {
+          addPoint({
+            time: relativeX * (ctx.wavesurfer?.getDuration() || 0),
+            volume: 1 - relativeY,
+          })
+        }),
+      )
 
-    polylineScope.add(
-      polyline.on('line-move', (relativeY) => {
-        points.forEach((point) => {
-          point.volume = Math.min(1, Math.max(0, point.volume - relativeY))
-        })
+      polylineScope.add(
+        polyline.on('line-move', (relativeY) => {
+          points.forEach((point) => {
+            point.volume = Math.min(1, Math.max(0, point.volume - relativeY))
+          })
 
-        emitPoints()
+          emitPoints()
 
-        onTimeUpdate(ctx.wavesurfer?.getCurrentTime() || 0)
-      }),
-    )
-  }
-
-  function addPoint(point: EnvelopePoint) {
-    if (!point.id) point.id = randomId()
-
-    // Insert the point in the correct position to keep the array sorted
-    const index = points.findLastIndex((p) => p.time < point.time)
-    points.splice(index + 1, 0, point)
-
-    emitPoints()
-
-    // Add the point to the polyline if the duration is available
-    const duration = ctx.wavesurfer?.getDuration()
-    if (duration) {
-      addPolyPoint(point, duration)
+          onTimeUpdate(ctx.wavesurfer?.getCurrentTime() || 0)
+        }),
+      )
     }
-  }
 
-  function removePoint(point: EnvelopePoint) {
-    const index = points.indexOf(point)
-    if (index > -1) {
-      points.splice(index, 1)
-      polyline?.removePolyPoint(point)
+    function addPoint(point: EnvelopePoint) {
+      if (!point.id) point.id = randomId()
+
+      // Insert the point in the correct position to keep the array sorted
+      const index = points.findLastIndex((p) => p.time < point.time)
+      points.splice(index + 1, 0, point)
+
       emitPoints()
-    }
-  }
 
-  function getPoints(): EnvelopePoint[] {
-    return points
-  }
-
-  function setPoints(newPoints: EnvelopePoint[]) {
-    points.slice().forEach((point) => removePoint(point))
-    newPoints.forEach((point) => addPoint(point))
-  }
-
-  function getCurrentVolume(): number {
-    return volume
-  }
-
-  function setVolume(floatValue: number) {
-    volume = floatValue
-    ctx.wavesurfer?.setVolume(floatValue)
-  }
-
-  // Equivalent of the pre-port onInit(): default the volume option from the
-  // live wavesurfer and apply it, then subscribe to decode/redraw/timeupdate.
-  opts.volume = opts.volume ?? ctx.wavesurfer.getVolume()
-  setVolume(opts.volume)
-
-  ctx.scope.add(
-    ctx.wavesurfer.on('decode', (duration) => {
-      initPolyline()
-
-      points.forEach((point) => {
+      // Add the point to the polyline if the duration is available
+      const duration = ctx.wavesurfer?.getDuration()
+      if (duration) {
         addPolyPoint(point, duration)
-      })
-    }),
-  )
+      }
+    }
 
-  ctx.scope.add(
-    ctx.wavesurfer.on('redraw', () => {
-      polyline?.update()
-    }),
-  )
+    function removePoint(point: EnvelopePoint) {
+      const index = points.indexOf(point)
+      if (index > -1) {
+        points.splice(index, 1)
+        polyline?.removePolyPoint(point)
+        emitPoints()
+      }
+    }
 
-  ctx.scope.add(
-    ctx.wavesurfer.on('timeupdate', (time) => {
-      onTimeUpdate(time)
-    }),
-  )
+    function getPoints(): EnvelopePoint[] {
+      return points
+    }
 
-  // No destroy() override exists anymore — teardown IS scope disposal.
-  // polylineScope (a child of ctx.scope) is disposed automatically as part
-  // of that tree, but `polyline` itself must be explicitly destroyed and
-  // nulled out here so a post-destroy Api call (addPoint/removePoint/...)
-  // can't reach a torn-down Polyline instance.
-  ctx.scope.add(() => {
-    polyline?.destroy()
-    polyline = null
-  })
+    function setPoints(newPoints: EnvelopePoint[]) {
+      points.slice().forEach((point) => removePoint(point))
+      newPoints.forEach((point) => addPoint(point))
+    }
 
-  return {
-    addPoint,
-    removePoint,
-    getPoints,
-    setPoints,
-    setVolume,
-    getCurrentVolume,
-  }
-})
+    function getCurrentVolume(): number {
+      return volume
+    }
+
+    function setVolume(floatValue: number) {
+      volume = floatValue
+      ctx.wavesurfer?.setVolume(floatValue)
+    }
+
+    // Equivalent of the pre-port onInit(): default the volume option from the
+    // live wavesurfer and apply it, then subscribe to decode/redraw/timeupdate.
+    opts.volume = opts.volume ?? ctx.wavesurfer.getVolume()
+    setVolume(opts.volume)
+
+    ctx.scope.add(
+      ctx.wavesurfer.on('decode', (duration) => {
+        initPolyline()
+
+        points.forEach((point) => {
+          addPolyPoint(point, duration)
+        })
+      }),
+    )
+
+    ctx.scope.add(
+      ctx.wavesurfer.on('redraw', () => {
+        polyline?.update()
+      }),
+    )
+
+    ctx.scope.add(
+      ctx.wavesurfer.on('timeupdate', (time) => {
+        onTimeUpdate(time)
+      }),
+    )
+
+    // No destroy() override exists anymore — teardown IS scope disposal.
+    // polylineScope (a child of ctx.scope) is disposed automatically as part
+    // of that tree, but `polyline` itself must be explicitly destroyed and
+    // nulled out here so a post-destroy Api call (addPoint/removePoint/...)
+    // can't reach a torn-down Polyline instance.
+    ctx.scope.add(() => {
+      polyline?.destroy()
+      polyline = null
+    })
+
+    return {
+      addPoint,
+      removePoint,
+      getPoints,
+      setPoints,
+      setVolume,
+      getCurrentVolume,
+    }
+  },
+)
 
 export default EnvelopePlugin

--- a/src/plugins/hover.ts
+++ b/src/plugins/hover.ts
@@ -56,7 +56,7 @@ function addUnits(value: string | number): string {
   return `${value}${units}`
 }
 
-const HoverPlugin = definePlugin<HoverPluginOptions, HoverPluginEvents, object>('hover', (ctx, options) => {
+const HoverPlugin = definePlugin<HoverPluginOptions, HoverPluginEvents, object>('HoverPlugin', (ctx, options) => {
   const opts: HoverPluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
 
   // Create the plugin elements

--- a/src/plugins/hover.ts
+++ b/src/plugins/hover.ts
@@ -2,7 +2,8 @@
  * The Hover plugin follows the mouse and shows a timestamp
  */
 
-import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
+import { type BasePluginEvents } from '../base-plugin.js'
+import { definePlugin } from '../define-plugin.js'
 import createElement from '../dom.js'
 import { cleanup, fromEvent } from '../reactive/event-streams.js'
 import { effect } from '../reactive/store.js'
@@ -50,191 +51,164 @@ export type HoverPluginEvents = BasePluginEvents & {
   hover: [relX: number]
 }
 
-class HoverPlugin extends BasePlugin<HoverPluginEvents, HoverPluginOptions> {
-  protected options: HoverPluginOptions & typeof defaultOptions
-  private wrapper: HTMLElement
-  private label: HTMLElement
-  private lastPointerPosition: { clientX: number; clientY: number } | null = null
-  private isPointerOverWaveform = false
-  private streamCleanups: Array<() => void> = []
-  private transitionEndCleanup: (() => void) | null = null
-
-  constructor(options?: HoverPluginOptions) {
-    super(options || {})
-    this.options = Object.assign({}, defaultOptions, options)
-
-    // Create the plugin elements
-    this.wrapper = createElement('div', { part: 'hover' })
-    this.label = createElement('span', { part: 'hover-label' }, this.wrapper)
-  }
-
-  public static create(options?: HoverPluginOptions) {
-    return new HoverPlugin(options)
-  }
-
-  private addUnits(value: string | number): string {
-    const units = typeof value === 'number' ? 'px' : ''
-    return `${value}${units}`
-  }
-
-  /** Called by wavesurfer, don't call manually */
-  onInit() {
-    if (!this.wavesurfer) {
-      throw Error('WaveSurfer is not initialized')
-    }
-
-    const wsOptions = this.wavesurfer.options
-    const lineColor = this.options.lineColor || wsOptions.cursorColor || wsOptions.progressColor
-
-    // Vertical line
-    Object.assign(this.wrapper.style, {
-      position: 'absolute',
-      zIndex: 10,
-      left: 0,
-      top: 0,
-      height: '100%',
-      pointerEvents: 'none',
-      borderLeft: `${this.addUnits(this.options.lineWidth)} solid ${lineColor}`,
-      opacity: '0',
-      transition: 'opacity .1s ease-in',
-    })
-
-    // Timestamp label
-    Object.assign(this.label.style, {
-      display: 'block',
-      backgroundColor: this.options.labelBackground,
-      color: this.options.labelColor,
-      fontSize: `${this.addUnits(this.options.labelSize)}`,
-      transition: 'transform .1s ease-in',
-      padding: '2px 3px',
-    })
-
-    // Append the wrapper
-    const container = this.wavesurfer.getWrapper()
-    container.appendChild(this.wrapper)
-
-    // Get reactive state
-    const state = this.wavesurfer.getState()
-
-    // Clean up old event streams (from re-initialization)
-    this.streamCleanups.forEach((fn) => fn())
-    this.streamCleanups = []
-
-    // Create event streams for pointer events
-    const pointerMove = fromEvent(container, 'pointermove')
-    const pointerLeave = fromEvent(container, 'pointerleave')
-    this.streamCleanups.push(
-      () => cleanup(pointerMove),
-      () => cleanup(pointerLeave),
-    )
-
-    this.subscriptions.push(
-      effect(() => {
-        const e = pointerMove.value
-        if (!e) return
-
-        this.isPointerOverWaveform = true
-      }, [pointerMove]),
-    )
-
-    // React to pointer movement
-    this.subscriptions.push(
-      effect(() => {
-        const e = pointerMove.value
-        if (!e || !this.wavesurfer || !this.isPointerOverWaveform) return
-
-        // Store only the position data needed for zoom/scroll updates
-        this.lastPointerPosition = { clientX: e.clientX, clientY: e.clientY }
-
-        // Position
-        const bbox = this.wavesurfer.getWrapper().getBoundingClientRect()
-        const { width } = bbox
-        const offsetX = e.clientX - bbox.left
-        const relX = Math.min(1, Math.max(0, offsetX / width))
-        const posX = Math.min(width - this.options.lineWidth - 1, offsetX)
-        this.wrapper.style.transform = `translateX(${posX}px)`
-        this.wrapper.style.opacity = '1'
-
-        // Timestamp
-        const duration = this.wavesurfer.getDuration()
-        this.label.textContent = this.options.formatTimeCallback(duration * relX)
-        const labelWidth = this.label.offsetWidth
-        const transformCondition = this.options.labelPreferLeft ? posX - labelWidth > 0 : posX + labelWidth > width
-        this.label.style.transform = transformCondition ? `translateX(-${labelWidth + this.options.lineWidth}px)` : ''
-
-        // Emit a hover event with the relative X position
-        this.emit('hover', relX)
-      }, [pointerMove, state.duration]),
-    )
-
-    // React to pointer leave
-    this.subscriptions.push(
-      effect(() => {
-        const e = pointerLeave.value
-        if (!e) return
-
-        this.wrapper.style.opacity = '0'
-        this.isPointerOverWaveform = false
-        this.lastPointerPosition = null
-
-        // Remove any previously attached transitionend listener before attaching a
-        // new one, so listeners don't accumulate if the transition never fires
-        // (e.g. element hidden or opacity already 0).
-        if (this.transitionEndCleanup) {
-          this.transitionEndCleanup()
-          this.transitionEndCleanup = null
-        }
-
-        // Reset transform after the opacity fade so the line doesn't jump to position 0
-        // while still visible. Also resets the scrollable overflow area of the scroll
-        // container to prevent improper scrollLeft clamping on zoom changes.
-        const onTransitionEnd = () => {
-          this.transitionEndCleanup = null
-          if (!this.isPointerOverWaveform) {
-            this.wrapper.style.transform = ''
-          }
-        }
-        this.wrapper.addEventListener('transitionend', onTransitionEnd, { once: true })
-        this.transitionEndCleanup = () => this.wrapper.removeEventListener('transitionend', onTransitionEnd)
-      }, [pointerLeave]),
-    )
-
-    // When zoom or scroll happens, re-run the pointer move logic with the last known mouse position
-    const onUpdate = () => {
-      if (this.lastPointerPosition && this.wavesurfer) {
-        // Position
-        const bbox = this.wavesurfer.getWrapper().getBoundingClientRect()
-        const { width } = bbox
-        const offsetX = this.lastPointerPosition.clientX - bbox.left
-        const relX = Math.min(1, Math.max(0, offsetX / width))
-        const posX = Math.min(width - this.options.lineWidth - 1, offsetX)
-        this.wrapper.style.transform = `translateX(${posX}px)`
-
-        // Timestamp
-        const duration = this.wavesurfer.getDuration()
-        this.label.textContent = this.options.formatTimeCallback(duration * relX)
-        const labelWidth = this.label.offsetWidth
-        const transformCondition = this.options.labelPreferLeft ? posX - labelWidth > 0 : posX + labelWidth > width
-        this.label.style.transform = transformCondition ? `translateX(-${labelWidth + this.options.lineWidth}px)` : ''
-      }
-    }
-
-    // Subscribe to zoom and scroll events
-    this.subscriptions.push(this.wavesurfer.on('zoom', onUpdate))
-    this.subscriptions.push(this.wavesurfer.on('scroll', onUpdate))
-  }
-
-  /** Unmount */
-  public destroy() {
-    if (this.transitionEndCleanup) {
-      this.transitionEndCleanup()
-      this.transitionEndCleanup = null
-    }
-    this.streamCleanups.forEach((fn) => fn())
-    this.streamCleanups = []
-    super.destroy()
-    this.wrapper.remove()
-  }
+function addUnits(value: string | number): string {
+  const units = typeof value === 'number' ? 'px' : ''
+  return `${value}${units}`
 }
+
+const HoverPlugin = definePlugin<HoverPluginOptions, HoverPluginEvents, object>('hover', (ctx, options) => {
+  const opts: HoverPluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
+
+  // Create the plugin elements
+  const wrapper = createElement('div', { part: 'hover' })
+  const label = createElement('span', { part: 'hover-label' }, wrapper)
+
+  const wsOptions = ctx.wavesurfer.options
+  const lineColor = opts.lineColor || wsOptions.cursorColor || wsOptions.progressColor
+
+  // Vertical line
+  Object.assign(wrapper.style, {
+    position: 'absolute',
+    zIndex: 10,
+    left: 0,
+    top: 0,
+    height: '100%',
+    pointerEvents: 'none',
+    borderLeft: `${addUnits(opts.lineWidth)} solid ${lineColor}`,
+    opacity: '0',
+    transition: 'opacity .1s ease-in',
+  })
+
+  // Timestamp label
+  Object.assign(label.style, {
+    display: 'block',
+    backgroundColor: opts.labelBackground,
+    color: opts.labelColor,
+    fontSize: `${addUnits(opts.labelSize)}`,
+    transition: 'transform .1s ease-in',
+    padding: '2px 3px',
+  })
+
+  // Append the wrapper
+  const container = ctx.wavesurfer.getWrapper()
+  container.appendChild(wrapper)
+  ctx.scope.add(() => wrapper.remove())
+
+  // Get reactive state
+  const { duration } = ctx.state
+
+  let lastPointerPosition: { clientX: number; clientY: number } | null = null
+  let isPointerOverWaveform = false
+  let transitionEndCleanup: (() => void) | null = null
+
+  // Create event streams for pointer events
+  const pointerMove = fromEvent(container, 'pointermove')
+  const pointerLeave = fromEvent(container, 'pointerleave')
+  ctx.scope.add(() => cleanup(pointerMove))
+  ctx.scope.add(() => cleanup(pointerLeave))
+
+  ctx.scope.add(
+    effect(() => {
+      const e = pointerMove.value
+      if (!e) return
+
+      isPointerOverWaveform = true
+    }, [pointerMove]),
+  )
+
+  // React to pointer movement
+  ctx.scope.add(
+    effect(() => {
+      const e = pointerMove.value
+      if (!e || !isPointerOverWaveform) return
+
+      // Store only the position data needed for zoom/scroll updates
+      lastPointerPosition = { clientX: e.clientX, clientY: e.clientY }
+
+      // Position
+      const bbox = ctx.wavesurfer.getWrapper().getBoundingClientRect()
+      const { width } = bbox
+      const offsetX = e.clientX - bbox.left
+      const relX = Math.min(1, Math.max(0, offsetX / width))
+      const posX = Math.min(width - opts.lineWidth - 1, offsetX)
+      wrapper.style.transform = `translateX(${posX}px)`
+      wrapper.style.opacity = '1'
+
+      // Timestamp
+      const dur = ctx.wavesurfer.getDuration()
+      label.textContent = opts.formatTimeCallback(dur * relX)
+      const labelWidth = label.offsetWidth
+      const transformCondition = opts.labelPreferLeft ? posX - labelWidth > 0 : posX + labelWidth > width
+      label.style.transform = transformCondition ? `translateX(-${labelWidth + opts.lineWidth}px)` : ''
+
+      // Emit a hover event with the relative X position
+      ctx.emit('hover', relX)
+    }, [pointerMove, duration]),
+  )
+
+  // React to pointer leave
+  ctx.scope.add(
+    effect(() => {
+      const e = pointerLeave.value
+      if (!e) return
+
+      wrapper.style.opacity = '0'
+      isPointerOverWaveform = false
+      lastPointerPosition = null
+
+      // Remove any previously attached transitionend listener before attaching a
+      // new one, so listeners don't accumulate if the transition never fires
+      // (e.g. element hidden or opacity already 0).
+      if (transitionEndCleanup) {
+        transitionEndCleanup()
+        transitionEndCleanup = null
+      }
+
+      // Reset transform after the opacity fade so the line doesn't jump to position 0
+      // while still visible. Also resets the scrollable overflow area of the scroll
+      // container to prevent improper scrollLeft clamping on zoom changes.
+      const onTransitionEnd = () => {
+        transitionEndCleanup = null
+        if (!isPointerOverWaveform) {
+          wrapper.style.transform = ''
+        }
+      }
+      wrapper.addEventListener('transitionend', onTransitionEnd, { once: true })
+      transitionEndCleanup = () => wrapper.removeEventListener('transitionend', onTransitionEnd)
+    }, [pointerLeave]),
+  )
+  ctx.scope.add(() => {
+    if (transitionEndCleanup) {
+      transitionEndCleanup()
+      transitionEndCleanup = null
+    }
+  })
+
+  // When zoom or scroll happens, re-run the pointer move logic with the last known mouse position
+  const onUpdate = () => {
+    if (lastPointerPosition) {
+      // Position
+      const bbox = ctx.wavesurfer.getWrapper().getBoundingClientRect()
+      const { width } = bbox
+      const offsetX = lastPointerPosition.clientX - bbox.left
+      const relX = Math.min(1, Math.max(0, offsetX / width))
+      const posX = Math.min(width - opts.lineWidth - 1, offsetX)
+      wrapper.style.transform = `translateX(${posX}px)`
+
+      // Timestamp
+      const dur = ctx.wavesurfer.getDuration()
+      label.textContent = opts.formatTimeCallback(dur * relX)
+      const labelWidth = label.offsetWidth
+      const transformCondition = opts.labelPreferLeft ? posX - labelWidth > 0 : posX + labelWidth > width
+      label.style.transform = transformCondition ? `translateX(-${labelWidth + opts.lineWidth}px)` : ''
+    }
+  }
+
+  // Subscribe to zoom and scroll events
+  ctx.scope.add(ctx.wavesurfer.on('zoom', onUpdate))
+  ctx.scope.add(ctx.wavesurfer.on('scroll', onUpdate))
+
+  return {}
+})
 
 export default HoverPlugin

--- a/src/plugins/minimap.ts
+++ b/src/plugins/minimap.ts
@@ -70,253 +70,256 @@ const FORWARDED_MINI_EVENTS: Array<keyof MinimapPluginEvents & string> = [
   'timeupdate',
 ]
 
-const MinimapPlugin = definePlugin<MinimapPluginOptions, MinimapPluginEvents, object>('minimap', (ctx, options) => {
-  const opts: MinimapPluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
+const MinimapPlugin = definePlugin<MinimapPluginOptions, MinimapPluginEvents, object>(
+  'MinimapPlugin',
+  (ctx, options) => {
+    const opts: MinimapPluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
 
-  const minimapWrapper = createElement('div', {
-    part: 'minimap',
-    style: {
-      position: 'relative',
-    },
-  })
-
-  const overlay = createElement(
-    'div',
-    {
-      part: 'minimap-overlay',
+    const minimapWrapper = createElement('div', {
+      part: 'minimap',
       style: {
-        position: 'absolute',
-        zIndex: '2',
-        left: '0',
-        top: '0',
-        bottom: '0',
-        transition: 'left 100ms ease-out, width 100ms ease-out',
-        pointerEvents: 'none',
-        backgroundColor: opts.overlayColor,
+        position: 'relative',
       },
-    },
-    minimapWrapper,
-  )
-
-  // Resolve and attach the wrapper. A missing/invalid `container` selector
-  // is a SILENT no-op here (matches the pre-port behavior) — unlike
-  // resolveContainer(), which throws. Do not switch this to
-  // resolveContainer().
-  if (opts.container) {
-    let container: HTMLElement | null = null
-    if (typeof opts.container === 'string') {
-      container = document.querySelector(opts.container) as HTMLElement | null
-    } else if (isHTMLElement(opts.container)) {
-      container = opts.container
-    }
-    container?.appendChild(minimapWrapper)
-  } else {
-    const container = ctx.wavesurfer.getWrapper().parentElement
-    container?.insertAdjacentElement(opts.insertPosition, minimapWrapper)
-  }
-  ctx.scope.add(() => minimapWrapper.remove())
-
-  let miniWavesurfer: WaveSurfer | null = null
-  let miniScope = ctx.scope.child()
-  let isInitializing = false
-  let dragTimeout: ReturnType<typeof setTimeout> | null = null
-
-  function renderMainProgress(progress: number) {
-    ctx.wavesurfer.getRenderer().renderProgress(progress, ctx.wavesurfer.isPlaying())
-  }
-
-  function renderMinimapProgress(progress: number) {
-    if (!miniWavesurfer) return
-    miniWavesurfer.getRenderer().renderProgress(progress, ctx.wavesurfer.isPlaying())
-  }
-
-  function syncMinimapPosition(currentTime: number) {
-    if (!miniWavesurfer) return
-
-    const duration = ctx.wavesurfer.getDuration()
-    if (!duration) return
-
-    if (miniWavesurfer.getDuration()) {
-      miniWavesurfer.setTime(currentTime)
-    } else {
-      renderMinimapProgress(currentTime / duration)
-    }
-  }
-
-  function onMinimapDrag(relativeX: number) {
-    renderMainProgress(relativeX)
-
-    if (dragTimeout) {
-      clearTimeout(dragTimeout)
-    }
-
-    let debounceTime = 0
-    const dragToSeek = opts.dragToSeek
-
-    if (!ctx.wavesurfer.isPlaying() && dragToSeek === true) {
-      debounceTime = 200
-    } else if (!ctx.wavesurfer.isPlaying() && dragToSeek && typeof dragToSeek === 'object') {
-      debounceTime = dragToSeek.debounceTime ?? 200
-    }
-
-    dragTimeout = setTimeout(() => {
-      ctx.wavesurfer.seekTo(relativeX)
-      dragTimeout = null
-    }, debounceTime)
-  }
-
-  function updateOverlay(startTime?: number, endTime?: number) {
-    const duration = ctx.wavesurfer.getDuration()
-    if (!duration) return
-
-    if (startTime === undefined || endTime === undefined) {
-      const waveformWidth = ctx.wavesurfer.getWrapper().clientWidth || 1
-      const visibleWidth = ctx.wavesurfer.getWidth()
-      const scrollLeft = ctx.wavesurfer.getScroll()
-
-      startTime = (scrollLeft / waveformWidth) * duration
-      endTime = ((scrollLeft + visibleWidth) / waveformWidth) * duration
-    }
-
-    const clampedStartTime = Math.min(Math.max(startTime, 0), duration)
-    const clampedEndTime = Math.min(Math.max(endTime, clampedStartTime), duration)
-    const overlayLeft = (clampedStartTime / duration) * 100
-    const overlayWidth = ((clampedEndTime - clampedStartTime) / duration) * 100
-
-    overlay.style.left = `${overlayLeft}%`
-    overlay.style.width = `${Math.min(overlayWidth, 100 - overlayLeft)}%`
-  }
-
-  // Dispose the current bridge scope FIRST (unsubscribing the mini
-  // wavesurfer's event forwarders, including its 'destroy' forwarder),
-  // THEN destroy the nested instance, THEN replace miniScope with a fresh
-  // child. This order means the nested instance's own 'destroy' event
-  // fires with no forwarder listening, so recreating the minimap (e.g. on
-  // 'decode') never re-emits the plugin's own 'destroy' event.
-  function destroyMinimap() {
-    const mini = miniWavesurfer
-    miniWavesurfer = null
-    miniScope.dispose()
-    mini?.destroy()
-    miniScope = ctx.scope.child()
-
-    if (dragTimeout) {
-      clearTimeout(dragTimeout)
-      dragTimeout = null
-    }
-  }
-
-  function initMinimap() {
-    // Prevent concurrent initialization
-    if (isInitializing) return
-    isInitializing = true
-
-    destroyMinimap()
-
-    const data = ctx.wavesurfer.getDecodedData()
-    if (!data) {
-      isInitializing = false
-      return
-    }
-
-    const peaks = []
-    for (let i = 0; i < data.numberOfChannels; i++) {
-      peaks.push(data.getChannelData(i))
-    }
-
-    miniWavesurfer = WaveSurfer.create({
-      ...opts,
-      container: minimapWrapper,
-      minPxPerSec: 0,
-      fillParent: true,
-      url: undefined,
-      media: undefined,
-      peaks,
-      duration: data.duration,
     })
 
-    syncMinimapPosition(ctx.wavesurfer.getCurrentTime())
-
-    bridgeEvents<MinimapPluginEvents>(
-      miniScope,
-      miniWavesurfer,
-      { emit: ctx.emit as (event: never, ...args: never[]) => void },
-      FORWARDED_MINI_EVENTS,
+    const overlay = createElement(
+      'div',
+      {
+        part: 'minimap-overlay',
+        style: {
+          position: 'absolute',
+          zIndex: '2',
+          left: '0',
+          top: '0',
+          bottom: '0',
+          transition: 'left 100ms ease-out, width 100ms ease-out',
+          pointerEvents: 'none',
+          backgroundColor: opts.overlayColor,
+        },
+      },
+      minimapWrapper,
     )
 
-    miniScope.add(
-      miniWavesurfer.on('click', (relativeX, relativeY) => {
+    // Resolve and attach the wrapper. A missing/invalid `container` selector
+    // is a SILENT no-op here (matches the pre-port behavior) — unlike
+    // resolveContainer(), which throws. Do not switch this to
+    // resolveContainer().
+    if (opts.container) {
+      let container: HTMLElement | null = null
+      if (typeof opts.container === 'string') {
+        container = document.querySelector(opts.container) as HTMLElement | null
+      } else if (isHTMLElement(opts.container)) {
+        container = opts.container
+      }
+      container?.appendChild(minimapWrapper)
+    } else {
+      const container = ctx.wavesurfer.getWrapper().parentElement
+      container?.insertAdjacentElement(opts.insertPosition, minimapWrapper)
+    }
+    ctx.scope.add(() => minimapWrapper.remove())
+
+    let miniWavesurfer: WaveSurfer | null = null
+    let miniScope = ctx.scope.child()
+    let isInitializing = false
+    let dragTimeout: ReturnType<typeof setTimeout> | null = null
+
+    function renderMainProgress(progress: number) {
+      ctx.wavesurfer.getRenderer().renderProgress(progress, ctx.wavesurfer.isPlaying())
+    }
+
+    function renderMinimapProgress(progress: number) {
+      if (!miniWavesurfer) return
+      miniWavesurfer.getRenderer().renderProgress(progress, ctx.wavesurfer.isPlaying())
+    }
+
+    function syncMinimapPosition(currentTime: number) {
+      if (!miniWavesurfer) return
+
+      const duration = ctx.wavesurfer.getDuration()
+      if (!duration) return
+
+      if (miniWavesurfer.getDuration()) {
+        miniWavesurfer.setTime(currentTime)
+      } else {
+        renderMinimapProgress(currentTime / duration)
+      }
+    }
+
+    function onMinimapDrag(relativeX: number) {
+      renderMainProgress(relativeX)
+
+      if (dragTimeout) {
+        clearTimeout(dragTimeout)
+      }
+
+      let debounceTime = 0
+      const dragToSeek = opts.dragToSeek
+
+      if (!ctx.wavesurfer.isPlaying() && dragToSeek === true) {
+        debounceTime = 200
+      } else if (!ctx.wavesurfer.isPlaying() && dragToSeek && typeof dragToSeek === 'object') {
+        debounceTime = dragToSeek.debounceTime ?? 200
+      }
+
+      dragTimeout = setTimeout(() => {
         ctx.wavesurfer.seekTo(relativeX)
-        ctx.emit('click', relativeX, relativeY)
+        dragTimeout = null
+      }, debounceTime)
+    }
+
+    function updateOverlay(startTime?: number, endTime?: number) {
+      const duration = ctx.wavesurfer.getDuration()
+      if (!duration) return
+
+      if (startTime === undefined || endTime === undefined) {
+        const waveformWidth = ctx.wavesurfer.getWrapper().clientWidth || 1
+        const visibleWidth = ctx.wavesurfer.getWidth()
+        const scrollLeft = ctx.wavesurfer.getScroll()
+
+        startTime = (scrollLeft / waveformWidth) * duration
+        endTime = ((scrollLeft + visibleWidth) / waveformWidth) * duration
+      }
+
+      const clampedStartTime = Math.min(Math.max(startTime, 0), duration)
+      const clampedEndTime = Math.min(Math.max(endTime, clampedStartTime), duration)
+      const overlayLeft = (clampedStartTime / duration) * 100
+      const overlayWidth = ((clampedEndTime - clampedStartTime) / duration) * 100
+
+      overlay.style.left = `${overlayLeft}%`
+      overlay.style.width = `${Math.min(overlayWidth, 100 - overlayLeft)}%`
+    }
+
+    // Dispose the current bridge scope FIRST (unsubscribing the mini
+    // wavesurfer's event forwarders, including its 'destroy' forwarder),
+    // THEN destroy the nested instance, THEN replace miniScope with a fresh
+    // child. This order means the nested instance's own 'destroy' event
+    // fires with no forwarder listening, so recreating the minimap (e.g. on
+    // 'decode') never re-emits the plugin's own 'destroy' event.
+    function destroyMinimap() {
+      const mini = miniWavesurfer
+      miniWavesurfer = null
+      miniScope.dispose()
+      mini?.destroy()
+      miniScope = ctx.scope.child()
+
+      if (dragTimeout) {
+        clearTimeout(dragTimeout)
+        dragTimeout = null
+      }
+    }
+
+    function initMinimap() {
+      // Prevent concurrent initialization
+      if (isInitializing) return
+      isInitializing = true
+
+      destroyMinimap()
+
+      const data = ctx.wavesurfer.getDecodedData()
+      if (!data) {
+        isInitializing = false
+        return
+      }
+
+      const peaks = []
+      for (let i = 0; i < data.numberOfChannels; i++) {
+        peaks.push(data.getChannelData(i))
+      }
+
+      miniWavesurfer = WaveSurfer.create({
+        ...opts,
+        container: minimapWrapper,
+        minPxPerSec: 0,
+        fillParent: true,
+        url: undefined,
+        media: undefined,
+        peaks,
+        duration: data.duration,
+      })
+
+      syncMinimapPosition(ctx.wavesurfer.getCurrentTime())
+
+      bridgeEvents<MinimapPluginEvents>(
+        miniScope,
+        miniWavesurfer,
+        { emit: ctx.emit as (event: never, ...args: never[]) => void },
+        FORWARDED_MINI_EVENTS,
+      )
+
+      miniScope.add(
+        miniWavesurfer.on('click', (relativeX, relativeY) => {
+          ctx.wavesurfer.seekTo(relativeX)
+          ctx.emit('click', relativeX, relativeY)
+        }),
+      )
+
+      miniScope.add(
+        miniWavesurfer.on('drag', (relativeX) => {
+          onMinimapDrag(relativeX)
+          ctx.emit('drag', relativeX)
+        }),
+      )
+
+      miniScope.add(
+        miniWavesurfer.on('ready', () => {
+          syncMinimapPosition(ctx.wavesurfer.getCurrentTime() || 0)
+          ctx.emit('ready')
+        }),
+      )
+
+      // Reset flag after initialization completes
+      isInitializing = false
+    }
+
+    // Final teardown: tear down the nested wavesurfer the same way a
+    // reinit would. `ctx.scope`'s children (the current `miniScope`) are
+    // already disposed by the time this disposer runs (Scope disposes
+    // children before its own disposers), so the `miniScope.dispose()`
+    // inside `destroyMinimap()` is a no-op here — only `mini?.destroy()`
+    // and the timeout clear actually do anything.
+    ctx.scope.add(() => destroyMinimap())
+
+    ctx.scope.add(
+      ctx.wavesurfer.on('decode', () => {
+        initMinimap()
       }),
     )
 
-    miniScope.add(
-      miniWavesurfer.on('drag', (relativeX) => {
-        onMinimapDrag(relativeX)
-        ctx.emit('drag', relativeX)
+    ctx.scope.add(
+      ctx.wavesurfer.on('timeupdate', (currentTime: number) => {
+        syncMinimapPosition(currentTime)
       }),
     )
 
-    miniScope.add(
-      miniWavesurfer.on('ready', () => {
-        syncMinimapPosition(ctx.wavesurfer.getCurrentTime() || 0)
-        ctx.emit('ready')
+    ctx.scope.add(
+      ctx.wavesurfer.on('drag', (relativeX: number) => {
+        renderMinimapProgress(relativeX)
       }),
     )
 
-    // Reset flag after initialization completes
-    isInitializing = false
-  }
+    ctx.scope.add(
+      ctx.wavesurfer.on('scroll', (startTime: number, endTime: number) => {
+        updateOverlay(startTime, endTime)
+      }),
+    )
 
-  // Final teardown: tear down the nested wavesurfer the same way a
-  // reinit would. `ctx.scope`'s children (the current `miniScope`) are
-  // already disposed by the time this disposer runs (Scope disposes
-  // children before its own disposers), so the `miniScope.dispose()`
-  // inside `destroyMinimap()` is a no-op here — only `mini?.destroy()`
-  // and the timeout clear actually do anything.
-  ctx.scope.add(() => destroyMinimap())
+    ctx.scope.add(
+      ctx.wavesurfer.on('redraw', () => {
+        updateOverlay()
+      }),
+    )
 
-  ctx.scope.add(
-    ctx.wavesurfer.on('decode', () => {
+    Promise.resolve().then(() => {
+      // The plugin may have been destroyed before this microtask runs
+      // (e.g. destroy() called synchronously right after registerPlugin());
+      // ctx.scope.disposed mirrors the old `if (!this.wavesurfer) return`
+      // guard for that race.
+      if (ctx.scope.disposed) return
       initMinimap()
-    }),
-  )
+    })
 
-  ctx.scope.add(
-    ctx.wavesurfer.on('timeupdate', (currentTime: number) => {
-      syncMinimapPosition(currentTime)
-    }),
-  )
-
-  ctx.scope.add(
-    ctx.wavesurfer.on('drag', (relativeX: number) => {
-      renderMinimapProgress(relativeX)
-    }),
-  )
-
-  ctx.scope.add(
-    ctx.wavesurfer.on('scroll', (startTime: number, endTime: number) => {
-      updateOverlay(startTime, endTime)
-    }),
-  )
-
-  ctx.scope.add(
-    ctx.wavesurfer.on('redraw', () => {
-      updateOverlay()
-    }),
-  )
-
-  Promise.resolve().then(() => {
-    // The plugin may have been destroyed before this microtask runs
-    // (e.g. destroy() called synchronously right after registerPlugin());
-    // ctx.scope.disposed mirrors the old `if (!this.wavesurfer) return`
-    // guard for that race.
-    if (ctx.scope.disposed) return
-    initMinimap()
-  })
-
-  return {}
-})
+    return {}
+  },
+)
 
 export default MinimapPlugin

--- a/src/plugins/minimap.ts
+++ b/src/plugins/minimap.ts
@@ -2,7 +2,9 @@
  * Minimap is a tiny copy of the main waveform serving as a navigation tool.
  */
 
-import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
+import { type BasePluginEvents } from '../base-plugin.js'
+import { definePlugin } from '../define-plugin.js'
+import { bridgeEvents } from '../plugin-utils.js'
 import WaveSurfer, { type WaveSurferOptions } from '../wavesurfer.js'
 import createElement, { isHTMLElement } from '../dom.js'
 
@@ -48,197 +50,129 @@ export type MinimapPluginEvents = BasePluginEvents & {
   timeupdate: [currentTime: number]
 }
 
-class MinimapPlugin extends BasePlugin<MinimapPluginEvents, MinimapPluginOptions> {
-  protected options: MinimapPluginOptions & typeof defaultOptions
-  private minimapWrapper: HTMLElement
-  private miniWavesurfer: WaveSurfer | null = null
-  private miniSubscriptions: Array<() => void> = []
-  private overlay: HTMLElement
-  private container: HTMLElement | null = null
-  private isInitializing = false
-  private dragTimeout: ReturnType<typeof setTimeout> | null = null
+// Pure 1:1 forwarders from the nested mini wavesurfer to the plugin's own
+// event stream — no side effects beyond re-emitting under the same name.
+// 'click', 'drag' and 'ready' are handled manually below because they carry
+// extra logic (seeking the main waveform, debounced drag-to-seek, syncing
+// the minimap position) in addition to forwarding.
+const FORWARDED_MINI_EVENTS: Array<keyof MinimapPluginEvents & string> = [
+  'audioprocess',
+  'dblclick',
+  'decode',
+  'destroy',
+  'dragend',
+  'dragstart',
+  'interaction',
+  'init',
+  'redraw',
+  'redrawcomplete',
+  'seeking',
+  'timeupdate',
+]
 
-  constructor(options: MinimapPluginOptions) {
-    super(options)
-    this.options = Object.assign({}, defaultOptions, options)
+const MinimapPlugin = definePlugin<MinimapPluginOptions, MinimapPluginEvents, object>('minimap', (ctx, options) => {
+  const opts: MinimapPluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
 
-    this.minimapWrapper = this.initMinimapWrapper()
-    this.overlay = this.initOverlay()
-  }
+  const minimapWrapper = createElement('div', {
+    part: 'minimap',
+    style: {
+      position: 'relative',
+    },
+  })
 
-  public static create(options: MinimapPluginOptions) {
-    return new MinimapPlugin(options)
-  }
-
-  /** Called by wavesurfer, don't call manually */
-  onInit() {
-    if (!this.wavesurfer) {
-      throw Error('WaveSurfer is not initialized')
-    }
-
-    if (this.options.container) {
-      if (typeof this.options.container === 'string') {
-        this.container = document.querySelector(this.options.container) as HTMLElement
-      } else if (isHTMLElement(this.options.container)) {
-        this.container = this.options.container
-      }
-      this.container?.appendChild(this.minimapWrapper)
-    } else {
-      this.container = this.wavesurfer.getWrapper().parentElement
-      this.container?.insertAdjacentElement(this.options.insertPosition, this.minimapWrapper)
-    }
-
-    this.initWaveSurferEvents()
-
-    Promise.resolve().then(() => {
-      this.initMinimap()
-    })
-  }
-
-  private initMinimapWrapper(): HTMLElement {
-    return createElement('div', {
-      part: 'minimap',
+  const overlay = createElement(
+    'div',
+    {
+      part: 'minimap-overlay',
       style: {
-        position: 'relative',
+        position: 'absolute',
+        zIndex: '2',
+        left: '0',
+        top: '0',
+        bottom: '0',
+        transition: 'left 100ms ease-out, width 100ms ease-out',
+        pointerEvents: 'none',
+        backgroundColor: opts.overlayColor,
       },
-    })
+    },
+    minimapWrapper,
+  )
+
+  // Resolve and attach the wrapper. A missing/invalid `container` selector
+  // is a SILENT no-op here (matches the pre-port behavior) — unlike
+  // resolveContainer(), which throws. Do not switch this to
+  // resolveContainer().
+  if (opts.container) {
+    let container: HTMLElement | null = null
+    if (typeof opts.container === 'string') {
+      container = document.querySelector(opts.container) as HTMLElement | null
+    } else if (isHTMLElement(opts.container)) {
+      container = opts.container
+    }
+    container?.appendChild(minimapWrapper)
+  } else {
+    const container = ctx.wavesurfer.getWrapper().parentElement
+    container?.insertAdjacentElement(opts.insertPosition, minimapWrapper)
+  }
+  ctx.scope.add(() => minimapWrapper.remove())
+
+  let miniWavesurfer: WaveSurfer | null = null
+  let miniScope = ctx.scope.child()
+  let isInitializing = false
+  let dragTimeout: ReturnType<typeof setTimeout> | null = null
+
+  function renderMainProgress(progress: number) {
+    ctx.wavesurfer.getRenderer().renderProgress(progress, ctx.wavesurfer.isPlaying())
   }
 
-  private initOverlay(): HTMLElement {
-    return createElement(
-      'div',
-      {
-        part: 'minimap-overlay',
-        style: {
-          position: 'absolute',
-          zIndex: '2',
-          left: '0',
-          top: '0',
-          bottom: '0',
-          transition: 'left 100ms ease-out, width 100ms ease-out',
-          pointerEvents: 'none',
-          backgroundColor: this.options.overlayColor,
-        },
-      },
-      this.minimapWrapper,
-    )
+  function renderMinimapProgress(progress: number) {
+    if (!miniWavesurfer) return
+    miniWavesurfer.getRenderer().renderProgress(progress, ctx.wavesurfer.isPlaying())
   }
 
-  private initMinimap() {
-    // Prevent concurrent initialization
-    if (this.isInitializing) return
-    this.isInitializing = true
+  function syncMinimapPosition(currentTime: number) {
+    if (!miniWavesurfer) return
 
-    this.destroyMinimap()
+    const duration = ctx.wavesurfer.getDuration()
+    if (!duration) return
 
-    if (!this.wavesurfer) {
-      this.isInitializing = false
-      return
+    if (miniWavesurfer.getDuration()) {
+      miniWavesurfer.setTime(currentTime)
+    } else {
+      renderMinimapProgress(currentTime / duration)
     }
-
-    const data = this.wavesurfer.getDecodedData()
-    if (!data) {
-      this.isInitializing = false
-      return
-    }
-
-    const peaks = []
-    for (let i = 0; i < data.numberOfChannels; i++) {
-      peaks.push(data.getChannelData(i))
-    }
-
-    this.miniWavesurfer = WaveSurfer.create({
-      ...this.options,
-      container: this.minimapWrapper,
-      minPxPerSec: 0,
-      fillParent: true,
-      url: undefined,
-      media: undefined,
-      peaks,
-      duration: data.duration,
-    })
-
-    this.syncMinimapPosition(this.wavesurfer.getCurrentTime())
-
-    this.miniSubscriptions.push(
-      this.miniWavesurfer.on('audioprocess', (currentTime) => {
-        this.emit('audioprocess', currentTime)
-      }),
-
-      this.miniWavesurfer.on('click', (relativeX, relativeY) => {
-        this.wavesurfer?.seekTo(relativeX)
-        this.emit('click', relativeX, relativeY)
-      }),
-
-      this.miniWavesurfer.on('dblclick', (relativeX, relativeY) => {
-        this.emit('dblclick', relativeX, relativeY)
-      }),
-
-      this.miniWavesurfer.on('decode', (duration) => {
-        this.emit('decode', duration)
-      }),
-
-      this.miniWavesurfer.on('destroy', () => {
-        this.emit('destroy')
-      }),
-
-      this.miniWavesurfer.on('drag', (relativeX) => {
-        this.onMinimapDrag(relativeX)
-        this.emit('drag', relativeX)
-      }),
-
-      this.miniWavesurfer.on('dragend', (relativeX) => {
-        this.emit('dragend', relativeX)
-      }),
-
-      this.miniWavesurfer.on('dragstart', (relativeX) => {
-        this.emit('dragstart', relativeX)
-      }),
-
-      this.miniWavesurfer.on('interaction', () => {
-        this.emit('interaction')
-      }),
-
-      this.miniWavesurfer.on('init', () => {
-        this.emit('init')
-      }),
-
-      this.miniWavesurfer.on('ready', () => {
-        this.syncMinimapPosition(this.wavesurfer?.getCurrentTime() || 0)
-        this.emit('ready')
-      }),
-
-      this.miniWavesurfer.on('redraw', () => {
-        this.emit('redraw')
-      }),
-
-      this.miniWavesurfer.on('redrawcomplete', () => {
-        this.emit('redrawcomplete')
-      }),
-
-      this.miniWavesurfer.on('seeking', (currentTime) => {
-        this.emit('seeking', currentTime)
-      }),
-
-      this.miniWavesurfer.on('timeupdate', (currentTime) => {
-        this.emit('timeupdate', currentTime)
-      }),
-    )
-
-    // Reset flag after initialization completes
-    this.isInitializing = false
   }
 
-  private updateOverlay(startTime?: number, endTime?: number) {
-    if (!this.wavesurfer) return
+  function onMinimapDrag(relativeX: number) {
+    renderMainProgress(relativeX)
 
-    const duration = this.wavesurfer.getDuration()
+    if (dragTimeout) {
+      clearTimeout(dragTimeout)
+    }
+
+    let debounceTime = 0
+    const dragToSeek = opts.dragToSeek
+
+    if (!ctx.wavesurfer.isPlaying() && dragToSeek === true) {
+      debounceTime = 200
+    } else if (!ctx.wavesurfer.isPlaying() && dragToSeek && typeof dragToSeek === 'object') {
+      debounceTime = dragToSeek.debounceTime ?? 200
+    }
+
+    dragTimeout = setTimeout(() => {
+      ctx.wavesurfer.seekTo(relativeX)
+      dragTimeout = null
+    }, debounceTime)
+  }
+
+  function updateOverlay(startTime?: number, endTime?: number) {
+    const duration = ctx.wavesurfer.getDuration()
     if (!duration) return
 
     if (startTime === undefined || endTime === undefined) {
-      const waveformWidth = this.wavesurfer.getWrapper().clientWidth || 1
-      const visibleWidth = this.wavesurfer.getWidth()
-      const scrollLeft = this.wavesurfer.getScroll()
+      const waveformWidth = ctx.wavesurfer.getWrapper().clientWidth || 1
+      const visibleWidth = ctx.wavesurfer.getWidth()
+      const scrollLeft = ctx.wavesurfer.getScroll()
 
       startTime = (scrollLeft / waveformWidth) * duration
       endTime = ((scrollLeft + visibleWidth) / waveformWidth) * duration
@@ -249,112 +183,140 @@ class MinimapPlugin extends BasePlugin<MinimapPluginEvents, MinimapPluginOptions
     const overlayLeft = (clampedStartTime / duration) * 100
     const overlayWidth = ((clampedEndTime - clampedStartTime) / duration) * 100
 
-    this.overlay.style.left = `${overlayLeft}%`
-    this.overlay.style.width = `${Math.min(overlayWidth, 100 - overlayLeft)}%`
+    overlay.style.left = `${overlayLeft}%`
+    overlay.style.width = `${Math.min(overlayWidth, 100 - overlayLeft)}%`
   }
 
-  private destroyMinimap() {
-    const miniWavesurfer = this.miniWavesurfer
-    this.miniWavesurfer = null
-    this.miniSubscriptions.forEach((unsubscribe) => unsubscribe())
-    this.miniSubscriptions = []
-    miniWavesurfer?.destroy()
+  // Dispose the current bridge scope FIRST (unsubscribing the mini
+  // wavesurfer's event forwarders, including its 'destroy' forwarder),
+  // THEN destroy the nested instance, THEN replace miniScope with a fresh
+  // child. This order means the nested instance's own 'destroy' event
+  // fires with no forwarder listening, so recreating the minimap (e.g. on
+  // 'decode') never re-emits the plugin's own 'destroy' event.
+  function destroyMinimap() {
+    const mini = miniWavesurfer
+    miniWavesurfer = null
+    miniScope.dispose()
+    mini?.destroy()
+    miniScope = ctx.scope.child()
 
-    if (this.dragTimeout) {
-      clearTimeout(this.dragTimeout)
-      this.dragTimeout = null
+    if (dragTimeout) {
+      clearTimeout(dragTimeout)
+      dragTimeout = null
     }
   }
 
-  private renderMainProgress(progress: number) {
-    if (!this.wavesurfer) return
-    this.wavesurfer.getRenderer().renderProgress(progress, this.wavesurfer.isPlaying())
-  }
+  function initMinimap() {
+    // Prevent concurrent initialization
+    if (isInitializing) return
+    isInitializing = true
 
-  private renderMinimapProgress(progress: number) {
-    if (!this.wavesurfer || !this.miniWavesurfer) return
-    this.miniWavesurfer.getRenderer().renderProgress(progress, this.wavesurfer.isPlaying())
-  }
+    destroyMinimap()
 
-  private syncMinimapPosition(currentTime: number) {
-    if (!this.wavesurfer || !this.miniWavesurfer) return
-
-    const duration = this.wavesurfer.getDuration()
-    if (!duration) return
-
-    if (this.miniWavesurfer.getDuration()) {
-      this.miniWavesurfer.setTime(currentTime)
-    } else {
-      this.renderMinimapProgress(currentTime / duration)
-    }
-  }
-
-  private onMinimapDrag(relativeX: number) {
-    if (!this.wavesurfer) return
-
-    this.renderMainProgress(relativeX)
-
-    if (this.dragTimeout) {
-      clearTimeout(this.dragTimeout)
+    const data = ctx.wavesurfer.getDecodedData()
+    if (!data) {
+      isInitializing = false
+      return
     }
 
-    let debounceTime = 0
-    const dragToSeek = this.options.dragToSeek
-
-    if (!this.wavesurfer.isPlaying() && dragToSeek === true) {
-      debounceTime = 200
-    } else if (!this.wavesurfer.isPlaying() && dragToSeek && typeof dragToSeek === 'object') {
-      debounceTime = dragToSeek.debounceTime ?? 200
+    const peaks = []
+    for (let i = 0; i < data.numberOfChannels; i++) {
+      peaks.push(data.getChannelData(i))
     }
 
-    this.dragTimeout = setTimeout(() => {
-      this.wavesurfer?.seekTo(relativeX)
-      this.dragTimeout = null
-    }, debounceTime)
-  }
+    miniWavesurfer = WaveSurfer.create({
+      ...opts,
+      container: minimapWrapper,
+      minPxPerSec: 0,
+      fillParent: true,
+      url: undefined,
+      media: undefined,
+      peaks,
+      duration: data.duration,
+    })
 
-  private onRedraw() {
-    this.updateOverlay()
-  }
+    syncMinimapPosition(ctx.wavesurfer.getCurrentTime())
 
-  private onScroll(startTime: number, endTime: number) {
-    this.updateOverlay(startTime, endTime)
-  }
+    bridgeEvents<MinimapPluginEvents>(
+      miniScope,
+      miniWavesurfer,
+      { emit: ctx.emit as (event: never, ...args: never[]) => void },
+      FORWARDED_MINI_EVENTS,
+    )
 
-  private initWaveSurferEvents() {
-    if (!this.wavesurfer) return
-
-    // Subscribe to decode, scroll and redraw events
-    this.subscriptions.push(
-      this.wavesurfer.on('decode', () => {
-        this.initMinimap()
-      }),
-
-      this.wavesurfer.on('timeupdate', (currentTime: number) => {
-        this.syncMinimapPosition(currentTime)
-      }),
-
-      this.wavesurfer.on('drag', (relativeX: number) => {
-        this.renderMinimapProgress(relativeX)
-      }),
-
-      this.wavesurfer.on('scroll', (startTime: number, endTime: number) => {
-        this.onScroll(startTime, endTime)
-      }),
-
-      this.wavesurfer.on('redraw', () => {
-        this.onRedraw()
+    miniScope.add(
+      miniWavesurfer.on('click', (relativeX, relativeY) => {
+        ctx.wavesurfer.seekTo(relativeX)
+        ctx.emit('click', relativeX, relativeY)
       }),
     )
+
+    miniScope.add(
+      miniWavesurfer.on('drag', (relativeX) => {
+        onMinimapDrag(relativeX)
+        ctx.emit('drag', relativeX)
+      }),
+    )
+
+    miniScope.add(
+      miniWavesurfer.on('ready', () => {
+        syncMinimapPosition(ctx.wavesurfer.getCurrentTime() || 0)
+        ctx.emit('ready')
+      }),
+    )
+
+    // Reset flag after initialization completes
+    isInitializing = false
   }
 
-  /** Unmount */
-  public destroy() {
-    this.destroyMinimap()
-    this.minimapWrapper.remove()
-    this.container = null
-    super.destroy()
-  }
-}
+  // Final teardown: tear down the nested wavesurfer the same way a
+  // reinit would. `ctx.scope`'s children (the current `miniScope`) are
+  // already disposed by the time this disposer runs (Scope disposes
+  // children before its own disposers), so the `miniScope.dispose()`
+  // inside `destroyMinimap()` is a no-op here — only `mini?.destroy()`
+  // and the timeout clear actually do anything.
+  ctx.scope.add(() => destroyMinimap())
+
+  ctx.scope.add(
+    ctx.wavesurfer.on('decode', () => {
+      initMinimap()
+    }),
+  )
+
+  ctx.scope.add(
+    ctx.wavesurfer.on('timeupdate', (currentTime: number) => {
+      syncMinimapPosition(currentTime)
+    }),
+  )
+
+  ctx.scope.add(
+    ctx.wavesurfer.on('drag', (relativeX: number) => {
+      renderMinimapProgress(relativeX)
+    }),
+  )
+
+  ctx.scope.add(
+    ctx.wavesurfer.on('scroll', (startTime: number, endTime: number) => {
+      updateOverlay(startTime, endTime)
+    }),
+  )
+
+  ctx.scope.add(
+    ctx.wavesurfer.on('redraw', () => {
+      updateOverlay()
+    }),
+  )
+
+  Promise.resolve().then(() => {
+    // The plugin may have been destroyed before this microtask runs
+    // (e.g. destroy() called synchronously right after registerPlugin());
+    // ctx.scope.disposed mirrors the old `if (!this.wavesurfer) return`
+    // guard for that race.
+    if (ctx.scope.disposed) return
+    initMinimap()
+  })
+
+  return {}
+})
 
 export default MinimapPlugin

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -3,6 +3,7 @@
  */
 
 import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
+import { Scope } from '../scope.js'
 import Timer from '../timer.js'
 import type { WaveSurferOptions } from '../wavesurfer.js'
 
@@ -65,7 +66,6 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   private lastDuration = 0
   private duration = 0
   private micStream: MicStream | null = null
-  private unsubscribeDestroy?: () => void
   private unsubscribeRecordEnd?: () => void
   private recordedBlobUrl: string | null = null
   // Snapshot of 'record-end' listeners taken at destroy() time when a recording is
@@ -90,7 +90,9 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   }
 
   protected onInit() {
-    this.subscriptions.push(
+    // this.scope is disposed and recreated on every destroy() (see below), so
+    // this re-registers cleanly on _init() after a destroy() + re-init cycle.
+    this.scope.add(
       this.timer.on('tick', () => {
         const currentTime = performance.now() - this.lastStartTime
         this.duration = this.isPaused() ? this.duration : this.lastDuration + currentTime
@@ -222,17 +224,31 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
       }
     }
 
-    const intervalId = setInterval(drawWaveform, 1000 / FPS)
-
-    const cleanup = () => {
-      clearInterval(intervalId)
+    // A child of the plugin's scope: startMic()/stopMic() can run several
+    // times over the plugin's life, so these mic-specific resources need
+    // their own disposable unit rather than living directly on this.scope.
+    // Being a CHILD also means a full plugin destroy() (which disposes
+    // this.scope) cascades to clean this up even if stopMic() was somehow
+    // never called -- a backstop that replaces the previous once('destroy')
+    // wiring, which relied on the same "destroy fires -> clean up mic"
+    // relationship but had to be manually threaded through the event bus.
+    const micScope = this.scope.child()
+    // Registered before the interval so LIFO disposal clears the interval
+    // first and only then disconnects/closes the audio graph, preserving the
+    // original teardown order (stop drawing before tearing down what it reads).
+    micScope.add(() => {
       source?.disconnect()
       audioContext?.close()
-    }
+    })
+    micScope.interval(drawWaveform, 1000 / FPS)
 
     return {
-      onDestroy: cleanup,
+      onDestroy: () => micScope.dispose(),
       onEnd: () => {
+        // Fires when a recording ends on its own (not via an explicit
+        // stopMic()/destroy() call) -- a domain-event reaction, not a
+        // teardown resource, so it stays wired through once('record-end')
+        // below rather than the scope (see startMic()).
         this.isWaveformPaused = true
         this.stopMic()
       },
@@ -257,9 +273,6 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
 
     const micStream = this.renderMicStream(stream)
     this.micStream = micStream
-    // Safety net: cleans up mic resources if 'destroy' fires before stopMic() runs
-    // (stopMic() normally unsubscribes this first, making the common path a no-op).
-    this.unsubscribeDestroy = this.once('destroy', micStream.onDestroy)
     this.unsubscribeRecordEnd = this.once('record-end', micStream.onEnd)
     this.stream = stream
 
@@ -269,10 +282,8 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   /** Stop monitoring incoming audio */
   public stopMic() {
     this.micStream?.onDestroy()
-    this.unsubscribeDestroy?.()
     this.unsubscribeRecordEnd?.()
     this.micStream = null
-    this.unsubscribeDestroy = undefined
     this.unsubscribeRecordEnd = undefined
     if (!this.stream) return
     this.stream.getTracks().forEach((track) => track.stop())
@@ -437,6 +448,14 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
       URL.revokeObjectURL(this.recordedBlobUrl)
       this.recordedBlobUrl = null
     }
+    // Disposes the timer-tick subscription registered in onInit() and
+    // cascades to any mic child scope still attached (normally none --
+    // stopMic() above already detached and disposed it; this is only a
+    // backstop). Recreated because re-init after destroy() is supported
+    // (see record.test.ts): a disposed Scope runs late registrations
+    // immediately, which would silently break a subsequent onInit().
+    this.scope.dispose()
+    this.scope = new Scope()
     super.destroy()
   }
 

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -613,7 +613,7 @@ type Api = {
 }
 
 const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>, RegionsPluginEvents, Api>(
-  'regions',
+  'RegionsPlugin',
   (ctx) => {
     // setup-closure state — replaces the pre-port instance fields `regions` and
     // the onInit()-local `activeRegions`.
@@ -692,11 +692,13 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
     function avoidOverlapping(region: Region) {
       if (!region.content || region.isRemoved) return
 
-      // Schedule on the region's own scope (falling back to ctx.scope for a
-      // not-yet-saved region, though avoidOverlapping is never reached before
-      // a region is saved in practice) so a removal cancels this pending
-      // reflow instead of letting it fire, or accumulate, on the plugin scope.
-      const scope = regionScopes.get(region) ?? ctx.scope
+      // Schedule on the region's own scope so a removal cancels this pending
+      // reflow instead of letting it fire, or accumulate, on the plugin
+      // scope. Both call sites (avoidOverlappingAll, iterating `regions`;
+      // and saveRegion, right after `regionScopes.set`) only ever reach a
+      // region once it's been saved, so the scope is always present here —
+      // no fallback needed.
+      const scope = regionScopes.get(region)!
       scope.timeout(() => {
         if (!region.content) return
 

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -4,14 +4,25 @@
  * You can set the color and content of each region, as well as their HTML content.
  */
 
-import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
+import { type BasePluginEvents } from '../base-plugin.js'
+import { definePlugin } from '../define-plugin.js'
 import EventEmitter from '../event-emitter.js'
 import createElement from '../dom.js'
+import { Scope } from '../scope.js'
 import { createDragStream } from '../reactive/drag-stream.js'
 import { effect } from '../reactive/store.js'
 import { fromEvent, cleanup as cleanupStream } from '../reactive/event-streams.js'
 
-export type RegionsPluginOptions = undefined
+// The pre-port class took no options at all (`constructor(options?: undefined)`).
+// A literal `undefined` Options type does not fit definePlugin's PluginCtorArgs
+// contract (`Record<string, never> extends Options ? [options?: Options] : ...`):
+// `Record<string, never> extends undefined` is false, which would make the
+// generated `create()`/constructor take a REQUIRED `undefined` argument and break
+// every existing zero-arg `RegionsPlugin.create()` call site. `Record<string,
+// never>` (an object with no properties) is the all-optional-fields shape the
+// contract expects, and keeps `create()`/`create({})`/`create(undefined)` all
+// callable, same as before.
+export type RegionsPluginOptions = Record<string, never>
 export type UpdateSide = 'start' | 'end'
 export type RegionsPluginEvents = BasePluginEvents & {
   /** When a new region is initialized but not rendered yet */
@@ -103,23 +114,27 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
   public maxLength = Infinity
   public channelIdx: number
   public contentEditable = false
-  public subscriptions: (() => void)[] = []
   public updatingSide?: UpdateSide = undefined
   public isRemoved = false
-  private contentClickListener?: (e: MouseEvent) => void
-  private contentBlurListener?: () => void
   private resizeHandleCleanup: (() => void) | null = null
+  private contentListenersCleanup: (() => void) | null = null
   /** True once initMouseEvents has run; controls whether setContent must (re)attach listeners itself */
   private mouseEventsInitialized = false
 
   constructor(
     params: RegionParams,
     private totalDuration: number,
+    /**
+     * A scope private to this region, owned by RegionsPlugin (`ctx.scope.child()`).
+     * All of this region's own listener bookkeeping (mouse events, drag/resize
+     * streams, content listeners) lives here instead of a hand-rolled
+     * `subscriptions` array; `remove()` disposes it in one shot.
+     */
+    private scope: Scope,
     private numberOfChannels = 0,
   ) {
     super()
 
-    this.subscriptions = []
     this.id = params.id || `region-${Math.random().toString(32).slice(2)}`
     this.start = this.clampPosition(params.start)
     this.end = this.clampPosition(params.end ?? params.start)
@@ -193,41 +208,48 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     const leftDragStream = createDragStream(leftHandle, { threshold: resizeThreshold })
     const rightDragStream = createDragStream(rightHandle, { threshold: resizeThreshold })
 
-    const unsubscribeLeft = effect(() => {
-      const drag = leftDragStream.signal.value
-      if (!drag) return
-      if (drag.type === 'move' && drag.deltaX !== undefined) {
-        this.onResize(drag.deltaX, 'start')
-      } else if (drag.type === 'end') {
-        this.onEndResizing('start')
-      }
-    }, [leftDragStream.signal])
+    const removeLeftEffect = this.scope.add(
+      effect(() => {
+        const drag = leftDragStream.signal.value
+        if (!drag) return
+        if (drag.type === 'move' && drag.deltaX !== undefined) {
+          this.onResize(drag.deltaX, 'start')
+        } else if (drag.type === 'end') {
+          this.onEndResizing('start')
+        }
+      }, [leftDragStream.signal]),
+    )
 
-    const unsubscribeRight = effect(() => {
-      const drag = rightDragStream.signal.value
-      if (!drag) return
-      if (drag.type === 'move' && drag.deltaX !== undefined) {
-        this.onResize(drag.deltaX, 'end')
-      } else if (drag.type === 'end') {
-        this.onEndResizing('end')
-      }
-    }, [rightDragStream.signal])
+    const removeRightEffect = this.scope.add(
+      effect(() => {
+        const drag = rightDragStream.signal.value
+        if (!drag) return
+        if (drag.type === 'move' && drag.deltaX !== undefined) {
+          this.onResize(drag.deltaX, 'end')
+        } else if (drag.type === 'end') {
+          this.onEndResizing('end')
+        }
+      }, [rightDragStream.signal]),
+    )
 
-    const cleanup = () => {
-      unsubscribeLeft()
-      unsubscribeRight()
+    const removeStreamCleanup = this.scope.add(() => {
       leftDragStream.cleanup()
       rightDragStream.cleanup()
-    }
+    })
 
-    this.resizeHandleCleanup = cleanup
-    this.subscriptions.push(cleanup)
+    // A single handle bundling all three scope registrations above, so
+    // removeResizeHandles() can tear down just the resize-handle listeners
+    // (and deregister them from `scope`) without disposing the whole region.
+    this.resizeHandleCleanup = () => {
+      removeLeftEffect()
+      removeRightEffect()
+      removeStreamCleanup()
+    }
   }
 
   private removeResizeHandles(element: HTMLElement) {
     if (this.resizeHandleCleanup) {
       this.resizeHandleCleanup()
-      this.subscriptions = this.subscriptions.filter((sub) => sub !== this.resizeHandleCleanup)
       this.resizeHandleCleanup = null
     }
 
@@ -296,23 +318,21 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
 
     if (!this.contentEditable || !this.content) return
 
-    this.contentClickListener = (e) => this.onContentClick(e)
-    this.contentBlurListener = () => this.onContentBlur()
-    this.content.addEventListener('click', this.contentClickListener)
-    this.content.addEventListener('blur', this.contentBlurListener)
+    const content = this.content
+    const removeClick = this.scope.listen(content, 'click', (e) => this.onContentClick(e as MouseEvent))
+    const removeBlur = this.scope.listen(content, 'blur', () => this.onContentBlur())
+
+    this.contentListenersCleanup = () => {
+      removeClick()
+      removeBlur()
+    }
   }
 
   /** Remove the content click/blur listeners, if attached */
   private detachContentListeners() {
-    if (!this.content) return
-
-    if (this.contentClickListener) {
-      this.content.removeEventListener('click', this.contentClickListener)
-      this.contentClickListener = undefined
-    }
-    if (this.contentBlurListener) {
-      this.content.removeEventListener('blur', this.contentBlurListener)
-      this.contentBlurListener = undefined
+    if (this.contentListenersCleanup) {
+      this.contentListenersCleanup()
+      this.contentListenersCleanup = null
     }
   }
 
@@ -337,7 +357,7 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     const unsubscribePointerup = pointerups.subscribe((e) => e && this.toggleCursor(false))
 
     // Store cleanup
-    this.subscriptions.push(() => {
+    this.scope.add(() => {
       unsubscribeClick()
       unsubscribeMouseenter()
       unsubscribeMouseleave()
@@ -355,24 +375,22 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     // Drag
     const dragStream = createDragStream(element)
 
-    const unsubscribeDrag = effect(() => {
-      const drag = dragStream.signal.value
-      if (!drag) return
+    this.scope.add(
+      effect(() => {
+        const drag = dragStream.signal.value
+        if (!drag) return
 
-      if (drag.type === 'start') {
-        this.toggleCursor(true)
-      } else if (drag.type === 'move' && drag.deltaX !== undefined) {
-        this.onMove(drag.deltaX)
-      } else if (drag.type === 'end') {
-        this.toggleCursor(false)
-        if (this.drag) this.emit('update-end')
-      }
-    }, [dragStream.signal])
-
-    this.subscriptions.push(() => {
-      unsubscribeDrag()
-      dragStream.cleanup()
-    })
+        if (drag.type === 'start') {
+          this.toggleCursor(true)
+        } else if (drag.type === 'move' && drag.deltaX !== undefined) {
+          this.onMove(drag.deltaX)
+        } else if (drag.type === 'end') {
+          this.toggleCursor(false)
+          if (this.drag) this.emit('update-end')
+        }
+      }, [dragStream.signal]),
+    )
+    this.scope.add(() => dragStream.cleanup())
 
     this.attachContentListeners()
     this.mouseEventsInitialized = true
@@ -557,11 +575,14 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     this.isRemoved = true
     this.emit('remove')
 
-    // Clean up all subscriptions (drag streams, event listeners, etc.)
-    this.subscriptions.forEach((unsubscribe) => unsubscribe())
-    this.subscriptions = []
+    // Clean up all of this region's listener bookkeeping in one shot: mouse
+    // events, drag/resize streams, content listeners (and any plugin-level
+    // per-region listeners registered onto this same scope, e.g. saveRegion's
+    // region.on('update', ...) subscriptions).
+    this.scope.dispose()
 
-    // Clean up content event listeners
+    // Belt-and-braces: detachContentListeners() is idempotent (a no-op once
+    // scope.dispose() has already run the same removers).
     this.detachContentListeners()
 
     // Remove DOM element
@@ -575,89 +596,90 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
   }
 }
 
-class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions> {
-  private regions: Region[] = []
-  private regionsContainer: HTMLElement
+// The public surface returned by setup() below — VERIFIED against the
+// pre-port class: getRegions/addRegion/enableDragSelection/clearRegions were
+// its only public methods (destroy is chassis-owned now, not part of the
+// Api — see port-recipe.md).
+type Api = {
+  getRegions: () => Region[]
+  addRegion: (options: RegionParams) => Region
+  enableDragSelection: (options: Omit<RegionParams, 'start' | 'end'>, threshold?: number) => () => void
+  clearRegions: () => void
+}
 
-  /** Create an instance of RegionsPlugin */
-  constructor(options?: RegionsPluginOptions) {
-    super(options)
-    this.regionsContainer = this.initRegionsContainer()
+const RegionsPlugin = definePlugin<RegionsPluginOptions, RegionsPluginEvents, Api>('regions', (ctx) => {
+  // setup-closure state — replaces the pre-port instance fields `regions` and
+  // the onInit()-local `activeRegions`.
+  let regions: Region[] = []
+  let activeRegions: Region[] = []
+
+  const regionsContainer = createElement('div', {
+    part: 'regions-container',
+    style: {
+      position: 'absolute',
+      top: '0',
+      left: '0',
+      width: '100%',
+      height: '100%',
+      zIndex: '5',
+      pointerEvents: 'none',
+    },
+  })
+  ctx.wavesurfer.getWrapper().appendChild(regionsContainer)
+  // DESTROY-ORDER: the pre-port class removed regionsContainer AFTER
+  // super.destroy() (so a 'destroy' listener could still observe it
+  // attached). Neither regions.test.ts nor memory-leaks.test.ts's regions
+  // cases (#4243) assert anything about post-destroy DOM attachment of the
+  // regions container, so — per the chassis's per-port rule in
+  // define-plugin.ts — this follows hover's precedent (Task 5) and moves
+  // removal onto ctx.scope: a deliberate, documented behavior change
+  // (removal now happens BEFORE the 'destroy' event, alongside every other
+  // scope-owned teardown, instead of after).
+  ctx.scope.add(() => regionsContainer.remove())
+
+  // Update region durations when a new audio file is loaded
+  ctx.scope.add(
+    ctx.wavesurfer.on('ready', (duration) => {
+      regions.forEach((region) => region._setTotalDuration(duration))
+    }),
+  )
+
+  ctx.scope.add(
+    ctx.wavesurfer.on('timeupdate', (currentTime) => {
+      // Detect when regions are being played
+      const playedRegions = regions.filter(
+        (region) =>
+          region.start <= currentTime &&
+          (region.end === region.start ? region.start + 0.05 : region.end) >= currentTime,
+      )
+
+      // Trigger region-in when activeRegions doesn't include a played regions
+      playedRegions.forEach((region) => {
+        if (!activeRegions.includes(region)) {
+          ctx.emit('region-in', region)
+        }
+      })
+
+      // Trigger region-out when activeRegions include a un-played regions
+      activeRegions.forEach((region) => {
+        if (!playedRegions.includes(region)) {
+          ctx.emit('region-out', region)
+        }
+      })
+
+      // Update activeRegions only played regions
+      activeRegions = playedRegions
+    }),
+  )
+
+  function getRegions(): Region[] {
+    return regions
   }
 
-  /** Create an instance of RegionsPlugin */
-  public static create(options?: RegionsPluginOptions) {
-    return new RegionsPlugin(options)
-  }
-
-  /** Called by wavesurfer, don't call manually */
-  onInit() {
-    if (!this.wavesurfer) {
-      throw Error('WaveSurfer is not initialized')
-    }
-    this.wavesurfer.getWrapper().appendChild(this.regionsContainer)
-
-    // Update region durations when a new audio file is loaded
-    this.subscriptions.push(
-      this.wavesurfer.on('ready', (duration) => {
-        this.regions.forEach((region) => region._setTotalDuration(duration))
-      }),
-    )
-
-    let activeRegions: Region[] = []
-    this.subscriptions.push(
-      this.wavesurfer.on('timeupdate', (currentTime) => {
-        // Detect when regions are being played
-        const playedRegions = this.regions.filter(
-          (region) =>
-            region.start <= currentTime &&
-            (region.end === region.start ? region.start + 0.05 : region.end) >= currentTime,
-        )
-
-        // Trigger region-in when activeRegions doesn't include a played regions
-        playedRegions.forEach((region) => {
-          if (!activeRegions.includes(region)) {
-            this.emit('region-in', region)
-          }
-        })
-
-        // Trigger region-out when activeRegions include a un-played regions
-        activeRegions.forEach((region) => {
-          if (!playedRegions.includes(region)) {
-            this.emit('region-out', region)
-          }
-        })
-
-        // Update activeRegions only played regions
-        activeRegions = playedRegions
-      }),
-    )
-  }
-
-  private initRegionsContainer(): HTMLElement {
-    return createElement('div', {
-      part: 'regions-container',
-      style: {
-        position: 'absolute',
-        top: '0',
-        left: '0',
-        width: '100%',
-        height: '100%',
-        zIndex: '5',
-        pointerEvents: 'none',
-      },
-    })
-  }
-
-  /** Get all created regions */
-  public getRegions(): Region[] {
-    return this.regions
-  }
-
-  private avoidOverlapping(region: Region) {
+  function avoidOverlapping(region: Region) {
     if (!region.content || region.isRemoved) return
 
-    setTimeout(() => {
+    ctx.scope.timeout(() => {
       if (!region.content) return
 
       // Check that the label doesn't overlap with other labels
@@ -668,10 +690,10 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       div.style.marginTop = '0'
       const box = div.getBoundingClientRect()
 
-      const regionIndex = this.regions.indexOf(region)
+      const regionIndex = regions.indexOf(region)
       if (regionIndex < 0) return
 
-      const overlap = this.regions
+      const overlap = regions
         .slice(0, regionIndex)
         .filter((reg) => !reg.isRemoved)
         .reduce<DOMRect[]>((boxes, reg) => {
@@ -697,13 +719,13 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     }, 10)
   }
 
-  private avoidOverlappingAll() {
-    this.regions.forEach((region) => this.avoidOverlapping(region))
+  function avoidOverlappingAll() {
+    regions.forEach((region) => avoidOverlapping(region))
   }
 
-  private adjustScroll(region: Region) {
+  function adjustScroll(region: Region) {
     if (!region.element) return
-    const scrollContainer = this.wavesurfer?.getWrapper()?.parentElement
+    const scrollContainer = ctx.wavesurfer?.getWrapper()?.parentElement
     if (!scrollContainer) return
     const { clientWidth, scrollWidth } = scrollContainer
     if (scrollWidth <= clientWidth) return
@@ -718,13 +740,19 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
     }
   }
 
-  private virtualAppend(region: Region, container: HTMLElement, element: HTMLElement) {
+  // `regionScope` is the same child scope SingleRegion itself owns (created
+  // in addRegion/enableDragSelection and passed into its constructor). Once
+  // ('remove'), the three previously hand-rolled `subscriptions`-array splice
+  // sites (virtualAppend, saveRegion, addRegion's once('ready')) are gone:
+  // everything below is torn down for free when region.remove() disposes
+  // this same scope.
+  function virtualAppend(region: Region, regionScope: Scope, container: HTMLElement, element: HTMLElement) {
     const renderIfVisible = () => {
-      if (!this.wavesurfer) return
-      const clientWidth = this.wavesurfer.getWidth()
-      const scrollLeft = this.wavesurfer.getScroll()
+      if (!ctx.wavesurfer) return
+      const clientWidth = ctx.wavesurfer.getWidth()
+      const scrollLeft = ctx.wavesurfer.getScroll()
       const scrollWidth = container.clientWidth
-      const duration = this.wavesurfer.getDuration()
+      const duration = ctx.wavesurfer.getDuration()
       const start = Math.round((region.start / duration) * scrollWidth)
       const width = Math.round(((region.end - region.start) / duration) * scrollWidth) || 1
 
@@ -738,108 +766,105 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       }
     }
 
-    setTimeout(() => {
-      // Check if region was removed before setTimeout executed
-      if (!this.wavesurfer || !region.element) return
+    regionScope.timeout(() => {
+      // Check if region was removed before this timeout executed (defensive;
+      // the timeout itself is cancelled by regionScope.dispose() when the
+      // region is removed first, so this should already be unreachable then).
+      if (!ctx.wavesurfer || !region.element) return
       renderIfVisible()
 
-      const unsubscribeScroll = this.wavesurfer.on('scroll', renderIfVisible)
-      const unsubscribeZoom = this.wavesurfer.on('zoom', renderIfVisible)
-      const unsubscribeResize = this.wavesurfer.on('resize', renderIfVisible)
-      const unsubscribeRender = region.on('render', renderIfVisible)
-
-      // Only push the unsubscribe functions, not the once() return values
-      const virtualAppendSubscriptions = [unsubscribeScroll, unsubscribeZoom, unsubscribeResize, unsubscribeRender]
-      this.subscriptions.push(...virtualAppendSubscriptions)
-
-      // Clean up subscriptions when region is removed
-      region.once('remove', () => {
-        unsubscribeScroll()
-        unsubscribeZoom()
-        unsubscribeResize()
-        unsubscribeRender()
-        // Prune this region's now-dead unsubscribe closures from the plugin-level
-        // subscriptions array; otherwise it only gets emptied in destroy(), so every
-        // removed region stays retained (via its captured closures) for the plugin's lifetime.
-        this.subscriptions = this.subscriptions.filter((sub) => !virtualAppendSubscriptions.includes(sub))
-      })
+      regionScope.add(ctx.wavesurfer.on('scroll', renderIfVisible))
+      regionScope.add(ctx.wavesurfer.on('zoom', renderIfVisible))
+      regionScope.add(ctx.wavesurfer.on('resize', renderIfVisible))
+      regionScope.add(region.on('render', renderIfVisible))
     }, 0)
   }
 
-  private saveRegion(region: Region) {
+  function saveRegion(region: Region, regionScope: Scope) {
     if (!region.element) return
-    this.virtualAppend(region, this.regionsContainer, region.element)
-    this.avoidOverlapping(region)
-    this.regions.push(region)
+    virtualAppend(region, regionScope, regionsContainer, region.element)
+    avoidOverlapping(region)
+    regions.push(region)
 
-    const regionSubscriptions = [
+    regionScope.add(
       region.on('update', (side) => {
         // Undefined side indicates that we are dragging not resizing
         if (!side) {
-          this.adjustScroll(region)
+          adjustScroll(region)
         }
-        this.emit('region-update', region, side)
+        ctx.emit('region-update', region, side)
       }),
+    )
 
+    regionScope.add(
       region.on('update-end', (side) => {
-        this.avoidOverlappingAll()
-        this.emit('region-updated', region, side)
+        avoidOverlappingAll()
+        ctx.emit('region-updated', region, side)
       }),
+    )
 
+    regionScope.add(
       region.on('play', (end?: number) => {
-        this.wavesurfer?.play(region.start, end)
+        ctx.wavesurfer?.play(region.start, end)
       }),
+    )
 
+    regionScope.add(
       region.on('click', (e) => {
-        this.emit('region-clicked', region, e)
+        ctx.emit('region-clicked', region, e)
       }),
+    )
 
+    regionScope.add(
       region.on('dblclick', (e) => {
-        this.emit('region-double-clicked', region, e)
+        ctx.emit('region-double-clicked', region, e)
       }),
+    )
+
+    regionScope.add(
       region.on('content-changed', () => {
-        this.emit('region-content-changed', region)
+        ctx.emit('region-content-changed', region)
       }),
+    )
 
-      // Remove the region from the list when it's removed
-      region.once('remove', () => {
-        regionSubscriptions.forEach((unsubscribe) => unsubscribe())
-        // Prune this region's now-dead unsubscribe closures from the plugin-level
-        // subscriptions array; otherwise it only gets emptied in destroy(), so every
-        // removed region stays retained (via its captured closures) for the plugin's lifetime.
-        this.subscriptions = this.subscriptions.filter((sub) => !regionSubscriptions.includes(sub))
-        this.regions = this.regions.filter((reg) => reg !== region)
-        this.emit('region-removed', region)
-      }),
-    ]
+    // Remove the region from the list when it's removed. This is the only
+    // bookkeeping left that isn't scope-owned teardown (the six listeners
+    // above die automatically with regionScope, disposed by region.remove());
+    // pruning `regions` and emitting 'region-removed' are active side effects
+    // that must run in response to the event itself.
+    region.once('remove', () => {
+      regions = regions.filter((reg) => reg !== region)
+      ctx.emit('region-removed', region)
+    })
 
-    this.subscriptions.push(...regionSubscriptions)
-
-    this.emit('region-created', region)
+    ctx.emit('region-created', region)
   }
 
   /** Create a region with given parameters */
-  public addRegion(options: RegionParams): Region {
-    if (!this.wavesurfer) {
+  function addRegion(options: RegionParams): Region {
+    if (!ctx.wavesurfer) {
       throw Error('WaveSurfer is not initialized')
     }
 
-    const duration = this.wavesurfer.getDuration()
-    const numberOfChannels = this.wavesurfer?.getDecodedData()?.numberOfChannels
-    const region = new SingleRegion(options, duration, numberOfChannels)
-    this.emit('region-initialized', region)
+    const duration = ctx.wavesurfer.getDuration()
+    const numberOfChannels = ctx.wavesurfer.getDecodedData()?.numberOfChannels
+    const regionScope = ctx.scope.child()
+    const region = new SingleRegion(options, duration, regionScope, numberOfChannels)
+    ctx.emit('region-initialized', region)
 
     if (!duration) {
-      // Prune this once('ready') unsubscriber after it fires instead of retaining it
-      // (and the region it captures) in the plugin-level subscriptions array until destroy().
-      const unsubscribeReady = this.wavesurfer.once('ready', (duration) => {
-        region._setTotalDuration(duration)
-        this.saveRegion(region)
-        this.subscriptions = this.subscriptions.filter((sub) => sub !== unsubscribeReady)
-      })
-      this.subscriptions.push(unsubscribeReady)
+      // Registered on regionScope instead of a plugin-level subscriptions
+      // array: if the region is removed before wavesurfer becomes ready,
+      // regionScope.dispose() (via region.remove()) cancels this pending
+      // listener along with everything else — no manual splice needed.
+      regionScope.add(
+        ctx.wavesurfer.once('ready', (readyDuration) => {
+          region._setTotalDuration(readyDuration)
+          saveRegion(region, regionScope)
+        }),
+      )
     } else {
-      this.saveRegion(region)
+      saveRegion(region, regionScope)
     }
 
     return region
@@ -849,12 +874,13 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
    * Enable creation of regions by dragging on an empty space on the waveform.
    * Returns a function to disable the drag selection.
    */
-  public enableDragSelection(options: Omit<RegionParams, 'start' | 'end'>, threshold = 3): () => void {
-    const wrapper = this.wavesurfer?.getWrapper()
+  function enableDragSelection(options: Omit<RegionParams, 'start' | 'end'>, threshold = 3): () => void {
+    const wrapper = ctx.wavesurfer?.getWrapper()
     if (!wrapper || !(wrapper instanceof HTMLElement)) return () => undefined
 
     const initialSize = 5
     let region: Region | null = null
+    let regionScope: Scope | null = null
     let startX = 0
     let startTime = 0
 
@@ -867,10 +893,10 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
       if (drag.type === 'start') {
         // On drag start
         startX = drag.x
-        if (!this.wavesurfer) return
-        const duration = this.wavesurfer.getDuration()
-        const numberOfChannels = this.wavesurfer?.getDecodedData()?.numberOfChannels
-        const { width } = this.wavesurfer.getWrapper().getBoundingClientRect()
+        if (!ctx.wavesurfer) return
+        const duration = ctx.wavesurfer.getDuration()
+        const numberOfChannels = ctx.wavesurfer?.getDecodedData()?.numberOfChannels
+        const { width } = ctx.wavesurfer.getWrapper().getBoundingClientRect()
         startTime = (startX / width) * duration
 
         // Calculate the start time of the region
@@ -879,6 +905,7 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         const end = ((drag.x + initialSize) / width) * duration
 
         // Create a region but don't save it until the drag ends
+        regionScope = ctx.scope.child()
         region = new SingleRegion(
           {
             ...options,
@@ -886,14 +913,15 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
             end,
           },
           duration,
+          regionScope,
           numberOfChannels,
         )
 
-        this.emit('region-initialized', region)
+        ctx.emit('region-initialized', region)
 
         // Just add it to the DOM for now
         if (region.element) {
-          this.regionsContainer.appendChild(region.element)
+          regionsContainer.appendChild(region.element)
         }
       } else if (drag.type === 'move' && drag.deltaX !== undefined) {
         // On drag move
@@ -904,41 +932,45 @@ class RegionsPlugin extends BasePlugin<RegionsPluginEvents, RegionsPluginOptions
         }
       } else if (drag.type === 'end') {
         // On drag end
-        if (region) {
-          this.saveRegion(region)
+        if (region && regionScope) {
+          saveRegion(region, regionScope)
           region.updatingSide = undefined
           region = null
+          regionScope = null
         }
       }
     }, [dragStream.signal])
 
-    const cleanup = () => {
+    // The returned disposer IS the scope.add(...) remover — calling it both
+    // runs the cleanup and deregisters it from ctx.scope, so a manual
+    // splice-out of a plugin-level subscriptions array is no longer needed.
+    return ctx.scope.add(() => {
       unsubscribe()
       dragStream.cleanup()
-    }
-
-    this.subscriptions.push(cleanup)
-
-    return () => {
-      cleanup()
-      this.subscriptions = this.subscriptions.filter((sub) => sub !== cleanup)
-    }
+    })
   }
 
   /** Remove all regions */
-  public clearRegions() {
-    const regions = this.regions.slice()
-    regions.forEach((region) => region.remove())
-    this.regions = []
+  function clearRegions() {
+    const regionsToRemove = regions.slice()
+    regionsToRemove.forEach((region) => region.remove())
+    regions = []
   }
 
-  /** Destroy the plugin and clean up */
-  public destroy() {
-    this.clearRegions()
-    super.destroy()
-    this.regionsContainer.remove()
+  // Equivalent of the pre-port destroy() override's `this.clearRegions()`
+  // call: explicitly remove()s every region (emitting 'remove'/'region-removed'
+  // and clearing region.element) rather than relying solely on the implicit
+  // ctx.scope -> regionScope cascade, which would dispose each region's raw
+  // listeners but skip SingleRegion.remove()'s other side effects.
+  ctx.scope.add(() => clearRegions())
+
+  return {
+    getRegions,
+    addRegion,
+    enableDragSelection,
+    clearRegions,
   }
-}
+})
 
 export default RegionsPlugin
 export type Region = SingleRegion

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -14,15 +14,20 @@ import { effect } from '../reactive/store.js'
 import { fromEvent, cleanup as cleanupStream } from '../reactive/event-streams.js'
 
 // The pre-port class took no options at all (`constructor(options?: undefined)`).
-// A literal `undefined` Options type does not fit definePlugin's PluginCtorArgs
-// contract (`Record<string, never> extends Options ? [options?: Options] : ...`):
+// Kept as `undefined` here (the public alias) rather than widened, since
+// consumers may reference this exported type. A bare `undefined` Options type
+// does not fit definePlugin's PluginCtorArgs contract on its own
+// (`Record<string, never> extends Options ? [options?: Options] : ...`):
 // `Record<string, never> extends undefined` is false, which would make the
-// generated `create()`/constructor take a REQUIRED `undefined` argument and break
-// every existing zero-arg `RegionsPlugin.create()` call site. `Record<string,
-// never>` (an object with no properties) is the all-optional-fields shape the
-// contract expects, and keeps `create()`/`create({})`/`create(undefined)` all
-// callable, same as before.
-export type RegionsPluginOptions = Record<string, never>
+// generated `create()`/constructor take a REQUIRED `undefined` argument and
+// break every existing zero-arg `RegionsPlugin.create()` call site. Instead
+// the `definePlugin(...)` call below widens ONLY its own Options type
+// parameter to `RegionsPluginOptions | Record<string, never>` — a union that
+// still contains `Record<string, never>` as a member, so
+// `Record<string, never> extends Options` is true and `create()` /
+// `create(undefined)` / `create({})` all stay callable — without changing
+// the public `RegionsPluginOptions` alias itself.
+export type RegionsPluginOptions = undefined
 export type UpdateSide = 'start' | 'end'
 export type RegionsPluginEvents = BasePluginEvents & {
   /** When a new region is initialized but not rendered yet */
@@ -607,370 +612,392 @@ type Api = {
   clearRegions: () => void
 }
 
-const RegionsPlugin = definePlugin<RegionsPluginOptions, RegionsPluginEvents, Api>('regions', (ctx) => {
-  // setup-closure state — replaces the pre-port instance fields `regions` and
-  // the onInit()-local `activeRegions`.
-  let regions: Region[] = []
-  let activeRegions: Region[] = []
+const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>, RegionsPluginEvents, Api>(
+  'regions',
+  (ctx) => {
+    // setup-closure state — replaces the pre-port instance fields `regions` and
+    // the onInit()-local `activeRegions`.
+    let regions: Region[] = []
+    let activeRegions: Region[] = []
+    // Maps a saved region to its own child scope, so avoidOverlapping's
+    // reflow timeout (below) can be scheduled on that region's scope instead
+    // of the plugin's — a removed region's pending reflow then dies with it,
+    // rather than firing (harmlessly, but pointlessly) after removal or
+    // accumulating disposers on ctx.scope during an avoidOverlappingAll burst.
+    const regionScopes = new WeakMap<Region, Scope>()
 
-  const regionsContainer = createElement('div', {
-    part: 'regions-container',
-    style: {
-      position: 'absolute',
-      top: '0',
-      left: '0',
-      width: '100%',
-      height: '100%',
-      zIndex: '5',
-      pointerEvents: 'none',
-    },
-  })
-  ctx.wavesurfer.getWrapper().appendChild(regionsContainer)
-  // DESTROY-ORDER: the pre-port class removed regionsContainer AFTER
-  // super.destroy() (so a 'destroy' listener could still observe it
-  // attached). Neither regions.test.ts nor memory-leaks.test.ts's regions
-  // cases (#4243) assert anything about post-destroy DOM attachment of the
-  // regions container, so — per the chassis's per-port rule in
-  // define-plugin.ts — this follows hover's precedent (Task 5) and moves
-  // removal onto ctx.scope: a deliberate, documented behavior change
-  // (removal now happens BEFORE the 'destroy' event, alongside every other
-  // scope-owned teardown, instead of after).
-  ctx.scope.add(() => regionsContainer.remove())
-
-  // Update region durations when a new audio file is loaded
-  ctx.scope.add(
-    ctx.wavesurfer.on('ready', (duration) => {
-      regions.forEach((region) => region._setTotalDuration(duration))
-    }),
-  )
-
-  ctx.scope.add(
-    ctx.wavesurfer.on('timeupdate', (currentTime) => {
-      // Detect when regions are being played
-      const playedRegions = regions.filter(
-        (region) =>
-          region.start <= currentTime &&
-          (region.end === region.start ? region.start + 0.05 : region.end) >= currentTime,
-      )
-
-      // Trigger region-in when activeRegions doesn't include a played regions
-      playedRegions.forEach((region) => {
-        if (!activeRegions.includes(region)) {
-          ctx.emit('region-in', region)
-        }
-      })
-
-      // Trigger region-out when activeRegions include a un-played regions
-      activeRegions.forEach((region) => {
-        if (!playedRegions.includes(region)) {
-          ctx.emit('region-out', region)
-        }
-      })
-
-      // Update activeRegions only played regions
-      activeRegions = playedRegions
-    }),
-  )
-
-  function getRegions(): Region[] {
-    return regions
-  }
-
-  function avoidOverlapping(region: Region) {
-    if (!region.content || region.isRemoved) return
-
-    ctx.scope.timeout(() => {
-      if (!region.content) return
-
-      // Check that the label doesn't overlap with other labels
-      // If it does, push it down until it doesn't
-      // only check regions that are before us in the list -- otherwise
-      // both overlapping regions will try to move down away from each other.
-      const div = region.content as HTMLElement
-      div.style.marginTop = '0'
-      const box = div.getBoundingClientRect()
-
-      const regionIndex = regions.indexOf(region)
-      if (regionIndex < 0) return
-
-      const overlap = regions
-        .slice(0, regionIndex)
-        .filter((reg) => !reg.isRemoved)
-        .reduce<DOMRect[]>((boxes, reg) => {
-          if (reg === region || !reg.content) return boxes
-
-          const otherBox = reg.content.getBoundingClientRect()
-          if (box.left < otherBox.right && otherBox.left < box.right) {
-            boxes.push(otherBox)
-          }
-          return boxes
-        }, [])
-        .sort((a, b) => a.top - b.top)
-        .reduce((marginTop, otherBox) => {
-          const top = box.top + marginTop
-          const bottom = top + box.height
-          if (top < otherBox.bottom && otherBox.top < bottom) {
-            return otherBox.bottom - box.top + 2
-          }
-          return marginTop
-        }, 0)
-
-      div.style.marginTop = `${overlap}px`
-    }, 10)
-  }
-
-  function avoidOverlappingAll() {
-    regions.forEach((region) => avoidOverlapping(region))
-  }
-
-  function adjustScroll(region: Region) {
-    if (!region.element) return
-    const scrollContainer = ctx.wavesurfer?.getWrapper()?.parentElement
-    if (!scrollContainer) return
-    const { clientWidth, scrollWidth } = scrollContainer
-    if (scrollWidth <= clientWidth) return
-    const scrollBbox = scrollContainer.getBoundingClientRect()
-    const bbox = region.element.getBoundingClientRect()
-    const left = bbox.left - scrollBbox.left
-    const right = bbox.right - scrollBbox.left
-    if (left < 0) {
-      scrollContainer.scrollLeft += left
-    } else if (right > clientWidth) {
-      scrollContainer.scrollLeft += right - clientWidth
-    }
-  }
-
-  // `regionScope` is the same child scope SingleRegion itself owns (created
-  // in addRegion/enableDragSelection and passed into its constructor). Once
-  // ('remove'), the three previously hand-rolled `subscriptions`-array splice
-  // sites (virtualAppend, saveRegion, addRegion's once('ready')) are gone:
-  // everything below is torn down for free when region.remove() disposes
-  // this same scope.
-  function virtualAppend(region: Region, regionScope: Scope, container: HTMLElement, element: HTMLElement) {
-    const renderIfVisible = () => {
-      if (!ctx.wavesurfer) return
-      const clientWidth = ctx.wavesurfer.getWidth()
-      const scrollLeft = ctx.wavesurfer.getScroll()
-      const scrollWidth = container.clientWidth
-      const duration = ctx.wavesurfer.getDuration()
-      const start = Math.round((region.start / duration) * scrollWidth)
-      const width = Math.round(((region.end - region.start) / duration) * scrollWidth) || 1
-
-      // Check if the region is between the scrollLeft and scrollLeft + clientWidth
-      const isVisible = start + width > scrollLeft && start < scrollLeft + clientWidth
-
-      if (isVisible && !element.parentElement) {
-        container.appendChild(element)
-      } else if (!isVisible && element.parentElement) {
-        element.remove()
-      }
-    }
-
-    regionScope.timeout(() => {
-      // Check if region was removed before this timeout executed (defensive;
-      // the timeout itself is cancelled by regionScope.dispose() when the
-      // region is removed first, so this should already be unreachable then).
-      if (!ctx.wavesurfer || !region.element) return
-      renderIfVisible()
-
-      regionScope.add(ctx.wavesurfer.on('scroll', renderIfVisible))
-      regionScope.add(ctx.wavesurfer.on('zoom', renderIfVisible))
-      regionScope.add(ctx.wavesurfer.on('resize', renderIfVisible))
-      regionScope.add(region.on('render', renderIfVisible))
-    }, 0)
-  }
-
-  function saveRegion(region: Region, regionScope: Scope) {
-    if (!region.element) return
-    virtualAppend(region, regionScope, regionsContainer, region.element)
-    avoidOverlapping(region)
-    regions.push(region)
-
-    regionScope.add(
-      region.on('update', (side) => {
-        // Undefined side indicates that we are dragging not resizing
-        if (!side) {
-          adjustScroll(region)
-        }
-        ctx.emit('region-update', region, side)
-      }),
-    )
-
-    regionScope.add(
-      region.on('update-end', (side) => {
-        avoidOverlappingAll()
-        ctx.emit('region-updated', region, side)
-      }),
-    )
-
-    regionScope.add(
-      region.on('play', (end?: number) => {
-        ctx.wavesurfer?.play(region.start, end)
-      }),
-    )
-
-    regionScope.add(
-      region.on('click', (e) => {
-        ctx.emit('region-clicked', region, e)
-      }),
-    )
-
-    regionScope.add(
-      region.on('dblclick', (e) => {
-        ctx.emit('region-double-clicked', region, e)
-      }),
-    )
-
-    regionScope.add(
-      region.on('content-changed', () => {
-        ctx.emit('region-content-changed', region)
-      }),
-    )
-
-    // Remove the region from the list when it's removed. This is the only
-    // bookkeeping left that isn't scope-owned teardown (the six listeners
-    // above die automatically with regionScope, disposed by region.remove());
-    // pruning `regions` and emitting 'region-removed' are active side effects
-    // that must run in response to the event itself.
-    region.once('remove', () => {
-      regions = regions.filter((reg) => reg !== region)
-      ctx.emit('region-removed', region)
+    const regionsContainer = createElement('div', {
+      part: 'regions-container',
+      style: {
+        position: 'absolute',
+        top: '0',
+        left: '0',
+        width: '100%',
+        height: '100%',
+        zIndex: '5',
+        pointerEvents: 'none',
+      },
     })
+    ctx.wavesurfer.getWrapper().appendChild(regionsContainer)
+    // DESTROY-ORDER: the pre-port class removed regionsContainer AFTER
+    // super.destroy() (so a 'destroy' listener could still observe it
+    // attached). Neither regions.test.ts nor memory-leaks.test.ts's regions
+    // cases (#4243) assert anything about post-destroy DOM attachment of the
+    // regions container, so — per the chassis's per-port rule in
+    // define-plugin.ts — this follows hover's precedent (Task 5) and moves
+    // removal onto ctx.scope: a deliberate, documented behavior change
+    // (removal now happens BEFORE the 'destroy' event, alongside every other
+    // scope-owned teardown, instead of after).
+    ctx.scope.add(() => regionsContainer.remove())
 
-    ctx.emit('region-created', region)
-  }
+    // Update region durations when a new audio file is loaded
+    ctx.scope.add(
+      ctx.wavesurfer.on('ready', (duration) => {
+        regions.forEach((region) => region._setTotalDuration(duration))
+      }),
+    )
 
-  /** Create a region with given parameters */
-  function addRegion(options: RegionParams): Region {
-    if (!ctx.wavesurfer) {
-      throw Error('WaveSurfer is not initialized')
-    }
-
-    const duration = ctx.wavesurfer.getDuration()
-    const numberOfChannels = ctx.wavesurfer.getDecodedData()?.numberOfChannels
-    const regionScope = ctx.scope.child()
-    const region = new SingleRegion(options, duration, regionScope, numberOfChannels)
-    ctx.emit('region-initialized', region)
-
-    if (!duration) {
-      // Registered on regionScope instead of a plugin-level subscriptions
-      // array: if the region is removed before wavesurfer becomes ready,
-      // regionScope.dispose() (via region.remove()) cancels this pending
-      // listener along with everything else — no manual splice needed.
-      regionScope.add(
-        ctx.wavesurfer.once('ready', (readyDuration) => {
-          region._setTotalDuration(readyDuration)
-          saveRegion(region, regionScope)
-        }),
-      )
-    } else {
-      saveRegion(region, regionScope)
-    }
-
-    return region
-  }
-
-  /**
-   * Enable creation of regions by dragging on an empty space on the waveform.
-   * Returns a function to disable the drag selection.
-   */
-  function enableDragSelection(options: Omit<RegionParams, 'start' | 'end'>, threshold = 3): () => void {
-    const wrapper = ctx.wavesurfer?.getWrapper()
-    if (!wrapper || !(wrapper instanceof HTMLElement)) return () => undefined
-
-    const initialSize = 5
-    let region: Region | null = null
-    let regionScope: Scope | null = null
-    let startX = 0
-    let startTime = 0
-
-    const dragStream = createDragStream(wrapper, { threshold })
-
-    const unsubscribe = effect(() => {
-      const drag = dragStream.signal.value
-      if (!drag) return
-
-      if (drag.type === 'start') {
-        // On drag start
-        startX = drag.x
-        if (!ctx.wavesurfer) return
-        const duration = ctx.wavesurfer.getDuration()
-        const numberOfChannels = ctx.wavesurfer?.getDecodedData()?.numberOfChannels
-        const { width } = ctx.wavesurfer.getWrapper().getBoundingClientRect()
-        startTime = (startX / width) * duration
-
-        // Calculate the start time of the region
-        const start = (drag.x / width) * duration
-        // Give the region a small initial size
-        const end = ((drag.x + initialSize) / width) * duration
-
-        // Create a region but don't save it until the drag ends
-        regionScope = ctx.scope.child()
-        region = new SingleRegion(
-          {
-            ...options,
-            start,
-            end,
-          },
-          duration,
-          regionScope,
-          numberOfChannels,
+    ctx.scope.add(
+      ctx.wavesurfer.on('timeupdate', (currentTime) => {
+        // Detect when regions are being played
+        const playedRegions = regions.filter(
+          (region) =>
+            region.start <= currentTime &&
+            (region.end === region.start ? region.start + 0.05 : region.end) >= currentTime,
         )
 
-        ctx.emit('region-initialized', region)
+        // Trigger region-in when activeRegions doesn't include a played regions
+        playedRegions.forEach((region) => {
+          if (!activeRegions.includes(region)) {
+            ctx.emit('region-in', region)
+          }
+        })
 
-        // Just add it to the DOM for now
-        if (region.element) {
-          regionsContainer.appendChild(region.element)
-        }
-      } else if (drag.type === 'move' && drag.deltaX !== undefined) {
-        // On drag move
-        if (region) {
-          // Update the end position of the region
-          // If we're dragging to the left, we need to update the start instead
-          region._onUpdate(drag.deltaX, drag.x > startX ? 'end' : 'start', startTime)
-        }
-      } else if (drag.type === 'end') {
-        // On drag end
-        if (region && regionScope) {
-          saveRegion(region, regionScope)
-          region.updatingSide = undefined
-          region = null
-          regionScope = null
+        // Trigger region-out when activeRegions include a un-played regions
+        activeRegions.forEach((region) => {
+          if (!playedRegions.includes(region)) {
+            ctx.emit('region-out', region)
+          }
+        })
+
+        // Update activeRegions only played regions
+        activeRegions = playedRegions
+      }),
+    )
+
+    function getRegions(): Region[] {
+      return regions
+    }
+
+    function avoidOverlapping(region: Region) {
+      if (!region.content || region.isRemoved) return
+
+      // Schedule on the region's own scope (falling back to ctx.scope for a
+      // not-yet-saved region, though avoidOverlapping is never reached before
+      // a region is saved in practice) so a removal cancels this pending
+      // reflow instead of letting it fire, or accumulate, on the plugin scope.
+      const scope = regionScopes.get(region) ?? ctx.scope
+      scope.timeout(() => {
+        if (!region.content) return
+
+        // Check that the label doesn't overlap with other labels
+        // If it does, push it down until it doesn't
+        // only check regions that are before us in the list -- otherwise
+        // both overlapping regions will try to move down away from each other.
+        const div = region.content as HTMLElement
+        div.style.marginTop = '0'
+        const box = div.getBoundingClientRect()
+
+        const regionIndex = regions.indexOf(region)
+        if (regionIndex < 0) return
+
+        const overlap = regions
+          .slice(0, regionIndex)
+          .filter((reg) => !reg.isRemoved)
+          .reduce<DOMRect[]>((boxes, reg) => {
+            if (reg === region || !reg.content) return boxes
+
+            const otherBox = reg.content.getBoundingClientRect()
+            if (box.left < otherBox.right && otherBox.left < box.right) {
+              boxes.push(otherBox)
+            }
+            return boxes
+          }, [])
+          .sort((a, b) => a.top - b.top)
+          .reduce((marginTop, otherBox) => {
+            const top = box.top + marginTop
+            const bottom = top + box.height
+            if (top < otherBox.bottom && otherBox.top < bottom) {
+              return otherBox.bottom - box.top + 2
+            }
+            return marginTop
+          }, 0)
+
+        div.style.marginTop = `${overlap}px`
+      }, 10)
+    }
+
+    function avoidOverlappingAll() {
+      regions.forEach((region) => avoidOverlapping(region))
+    }
+
+    function adjustScroll(region: Region) {
+      if (!region.element) return
+      const scrollContainer = ctx.wavesurfer?.getWrapper()?.parentElement
+      if (!scrollContainer) return
+      const { clientWidth, scrollWidth } = scrollContainer
+      if (scrollWidth <= clientWidth) return
+      const scrollBbox = scrollContainer.getBoundingClientRect()
+      const bbox = region.element.getBoundingClientRect()
+      const left = bbox.left - scrollBbox.left
+      const right = bbox.right - scrollBbox.left
+      if (left < 0) {
+        scrollContainer.scrollLeft += left
+      } else if (right > clientWidth) {
+        scrollContainer.scrollLeft += right - clientWidth
+      }
+    }
+
+    // `regionScope` is the same child scope SingleRegion itself owns (created
+    // in addRegion/enableDragSelection and passed into its constructor). Once
+    // ('remove'), the three previously hand-rolled `subscriptions`-array splice
+    // sites (virtualAppend, saveRegion, addRegion's once('ready')) are gone:
+    // everything below is torn down for free when region.remove() disposes
+    // this same scope.
+    function virtualAppend(region: Region, regionScope: Scope, container: HTMLElement, element: HTMLElement) {
+      const renderIfVisible = () => {
+        if (!ctx.wavesurfer) return
+        const clientWidth = ctx.wavesurfer.getWidth()
+        const scrollLeft = ctx.wavesurfer.getScroll()
+        const scrollWidth = container.clientWidth
+        const duration = ctx.wavesurfer.getDuration()
+        const start = Math.round((region.start / duration) * scrollWidth)
+        const width = Math.round(((region.end - region.start) / duration) * scrollWidth) || 1
+
+        // Check if the region is between the scrollLeft and scrollLeft + clientWidth
+        const isVisible = start + width > scrollLeft && start < scrollLeft + clientWidth
+
+        if (isVisible && !element.parentElement) {
+          container.appendChild(element)
+        } else if (!isVisible && element.parentElement) {
+          element.remove()
         }
       }
-    }, [dragStream.signal])
 
-    // The returned disposer IS the scope.add(...) remover — calling it both
-    // runs the cleanup and deregisters it from ctx.scope, so a manual
-    // splice-out of a plugin-level subscriptions array is no longer needed.
-    return ctx.scope.add(() => {
-      unsubscribe()
-      dragStream.cleanup()
-    })
-  }
+      regionScope.timeout(() => {
+        // Check if region was removed before this timeout executed (defensive;
+        // the timeout itself is cancelled by regionScope.dispose() when the
+        // region is removed first, so this should already be unreachable then).
+        if (!ctx.wavesurfer || !region.element) return
+        renderIfVisible()
 
-  /** Remove all regions */
-  function clearRegions() {
-    const regionsToRemove = regions.slice()
-    regionsToRemove.forEach((region) => region.remove())
-    regions = []
-  }
+        regionScope.add(ctx.wavesurfer.on('scroll', renderIfVisible))
+        regionScope.add(ctx.wavesurfer.on('zoom', renderIfVisible))
+        regionScope.add(ctx.wavesurfer.on('resize', renderIfVisible))
+        regionScope.add(region.on('render', renderIfVisible))
+      }, 0)
+    }
 
-  // Equivalent of the pre-port destroy() override's `this.clearRegions()`
-  // call: explicitly remove()s every region (emitting 'remove'/'region-removed'
-  // and clearing region.element) rather than relying solely on the implicit
-  // ctx.scope -> regionScope cascade, which would dispose each region's raw
-  // listeners but skip SingleRegion.remove()'s other side effects.
-  ctx.scope.add(() => clearRegions())
+    function saveRegion(region: Region, regionScope: Scope) {
+      if (!region.element) return
+      regionScopes.set(region, regionScope)
+      virtualAppend(region, regionScope, regionsContainer, region.element)
+      avoidOverlapping(region)
+      regions.push(region)
 
-  return {
-    getRegions,
-    addRegion,
-    enableDragSelection,
-    clearRegions,
-  }
-})
+      regionScope.add(
+        region.on('update', (side) => {
+          // Undefined side indicates that we are dragging not resizing
+          if (!side) {
+            adjustScroll(region)
+          }
+          ctx.emit('region-update', region, side)
+        }),
+      )
+
+      regionScope.add(
+        region.on('update-end', (side) => {
+          avoidOverlappingAll()
+          ctx.emit('region-updated', region, side)
+        }),
+      )
+
+      regionScope.add(
+        region.on('play', (end?: number) => {
+          ctx.wavesurfer?.play(region.start, end)
+        }),
+      )
+
+      regionScope.add(
+        region.on('click', (e) => {
+          ctx.emit('region-clicked', region, e)
+        }),
+      )
+
+      regionScope.add(
+        region.on('dblclick', (e) => {
+          ctx.emit('region-double-clicked', region, e)
+        }),
+      )
+
+      regionScope.add(
+        region.on('content-changed', () => {
+          ctx.emit('region-content-changed', region)
+        }),
+      )
+
+      // Remove the region from the list when it's removed. This is the only
+      // bookkeeping left that isn't scope-owned teardown (the six listeners
+      // above die automatically with regionScope, disposed by region.remove());
+      // pruning `regions` and emitting 'region-removed' are active side effects
+      // that must run in response to the event itself.
+      region.once('remove', () => {
+        regions = regions.filter((reg) => reg !== region)
+        ctx.emit('region-removed', region)
+      })
+
+      ctx.emit('region-created', region)
+    }
+
+    /** Create a region with given parameters */
+    function addRegion(options: RegionParams): Region {
+      if (!ctx.wavesurfer) {
+        throw Error('WaveSurfer is not initialized')
+      }
+
+      const duration = ctx.wavesurfer.getDuration()
+      const numberOfChannels = ctx.wavesurfer.getDecodedData()?.numberOfChannels
+      const regionScope = ctx.scope.child()
+      const region = new SingleRegion(options, duration, regionScope, numberOfChannels)
+      ctx.emit('region-initialized', region)
+
+      if (!duration) {
+        // Registered on regionScope instead of a plugin-level subscriptions
+        // array: if the region is removed before wavesurfer becomes ready,
+        // regionScope.dispose() (via region.remove()) cancels this pending
+        // listener along with everything else — no manual splice needed.
+        regionScope.add(
+          ctx.wavesurfer.once('ready', (readyDuration) => {
+            region._setTotalDuration(readyDuration)
+            saveRegion(region, regionScope)
+          }),
+        )
+      } else {
+        saveRegion(region, regionScope)
+      }
+
+      return region
+    }
+
+    /**
+     * Enable creation of regions by dragging on an empty space on the waveform.
+     * Returns a function to disable the drag selection.
+     */
+    function enableDragSelection(options: Omit<RegionParams, 'start' | 'end'>, threshold = 3): () => void {
+      const wrapper = ctx.wavesurfer?.getWrapper()
+      if (!wrapper || !(wrapper instanceof HTMLElement)) return () => undefined
+
+      const initialSize = 5
+      let region: Region | null = null
+      let regionScope: Scope | null = null
+      let startX = 0
+      let startTime = 0
+
+      const dragStream = createDragStream(wrapper, { threshold })
+
+      const unsubscribe = effect(() => {
+        const drag = dragStream.signal.value
+        if (!drag) return
+
+        if (drag.type === 'start') {
+          // On drag start
+
+          // A previous gesture's region/scope, if any, was never saved (no
+          // matching 'end' arrived — e.g. an aborted or superseded drag).
+          // Dispose it now rather than leaving it retained until the plugin
+          // itself is destroyed.
+          regionScope?.dispose()
+
+          startX = drag.x
+          if (!ctx.wavesurfer) return
+          const duration = ctx.wavesurfer.getDuration()
+          const numberOfChannels = ctx.wavesurfer?.getDecodedData()?.numberOfChannels
+          const { width } = ctx.wavesurfer.getWrapper().getBoundingClientRect()
+          startTime = (startX / width) * duration
+
+          // Calculate the start time of the region
+          const start = (drag.x / width) * duration
+          // Give the region a small initial size
+          const end = ((drag.x + initialSize) / width) * duration
+
+          // Create a region but don't save it until the drag ends
+          regionScope = ctx.scope.child()
+          region = new SingleRegion(
+            {
+              ...options,
+              start,
+              end,
+            },
+            duration,
+            regionScope,
+            numberOfChannels,
+          )
+
+          ctx.emit('region-initialized', region)
+
+          // Just add it to the DOM for now
+          if (region.element) {
+            regionsContainer.appendChild(region.element)
+          }
+        } else if (drag.type === 'move' && drag.deltaX !== undefined) {
+          // On drag move
+          if (region) {
+            // Update the end position of the region
+            // If we're dragging to the left, we need to update the start instead
+            region._onUpdate(drag.deltaX, drag.x > startX ? 'end' : 'start', startTime)
+          }
+        } else if (drag.type === 'end') {
+          // On drag end
+          if (region && regionScope) {
+            saveRegion(region, regionScope)
+            region.updatingSide = undefined
+            region = null
+            regionScope = null
+          }
+        }
+      }, [dragStream.signal])
+
+      // The returned disposer IS the scope.add(...) remover — calling it both
+      // runs the cleanup and deregisters it from ctx.scope, so a manual
+      // splice-out of a plugin-level subscriptions array is no longer needed.
+      return ctx.scope.add(() => {
+        unsubscribe()
+        dragStream.cleanup()
+      })
+    }
+
+    /** Remove all regions */
+    function clearRegions() {
+      const regionsToRemove = regions.slice()
+      regionsToRemove.forEach((region) => region.remove())
+      regions = []
+    }
+
+    // Equivalent of the pre-port destroy() override's `this.clearRegions()`
+    // call: explicitly remove()s every region (emitting 'remove'/'region-removed'
+    // and clearing region.element) rather than relying solely on the implicit
+    // ctx.scope -> regionScope cascade, which would dispose each region's raw
+    // listeners but skip SingleRegion.remove()'s other side effects.
+    ctx.scope.add(() => clearRegions())
+
+    return {
+      getRegions,
+      addRegion,
+      enableDragSelection,
+      clearRegions,
+    }
+  },
+)
 
 export default RegionsPlugin
 export type Region = SingleRegion

--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -57,228 +57,231 @@ export type TimelinePluginEvents = BasePluginEvents & {
   ready: []
 }
 
-const TimelinePlugin = definePlugin<TimelinePluginOptions, TimelinePluginEvents, object>('timeline', (ctx, options) => {
-  const opts: TimelinePluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
+const TimelinePlugin = definePlugin<TimelinePluginOptions, TimelinePluginEvents, object>(
+  'TimelinePlugin',
+  (ctx, options) => {
+    const opts: TimelinePluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
 
-  const timelineWrapper = createElement('div', { part: 'timeline-wrapper', style: { pointerEvents: 'none' } })
+    const timelineWrapper = createElement('div', { part: 'timeline-wrapper', style: { pointerEvents: 'none' } })
 
-  // Notch metadata for batch visibility updates, and the currently rendered
-  // timeline element (rebuilt on every initTimeline() call).
-  const notchElements: Map<HTMLElement, { start: number; width: number; wasVisible: boolean }> = new Map()
-  let currentTimeline: HTMLElement | undefined = undefined
+    // Notch metadata for batch visibility updates, and the currently rendered
+    // timeline element (rebuilt on every initTimeline() call).
+    const notchElements: Map<HTMLElement, { start: number; width: number; wasVisible: boolean }> = new Map()
+    let currentTimeline: HTMLElement | undefined = undefined
 
-  // Return how many seconds should be between each notch
-  function defaultTimeInterval(pxPerSec: number): number {
-    if (pxPerSec >= 25) {
-      return 1
-    } else if (pxPerSec * 5 >= 25) {
-      return 5
-    } else if (pxPerSec * 15 >= 25) {
-      return 15
+    // Return how many seconds should be between each notch
+    function defaultTimeInterval(pxPerSec: number): number {
+      if (pxPerSec >= 25) {
+        return 1
+      } else if (pxPerSec * 5 >= 25) {
+        return 5
+      } else if (pxPerSec * 15 >= 25) {
+        return 15
+      }
+      return Math.ceil(0.5 / pxPerSec) * 60
     }
-    return Math.ceil(0.5 / pxPerSec) * 60
-  }
 
-  // Return the cadence of notches that get labels in the primary color.
-  function defaultPrimaryLabelInterval(pxPerSec: number): number {
-    if (pxPerSec >= 25) {
-      return 10
-    } else if (pxPerSec * 5 >= 25) {
-      return 6
-    } else if (pxPerSec * 15 >= 25) {
+    // Return the cadence of notches that get labels in the primary color.
+    function defaultPrimaryLabelInterval(pxPerSec: number): number {
+      if (pxPerSec >= 25) {
+        return 10
+      } else if (pxPerSec * 5 >= 25) {
+        return 6
+      } else if (pxPerSec * 15 >= 25) {
+        return 4
+      }
       return 4
     }
-    return 4
-  }
 
-  // Return the cadence of notches that get labels in the secondary color.
-  function defaultSecondaryLabelInterval(pxPerSec: number): number {
-    if (pxPerSec >= 25) {
-      return 5
-    } else if (pxPerSec * 5 >= 25) {
-      return 2
-    } else if (pxPerSec * 15 >= 25) {
+    // Return the cadence of notches that get labels in the secondary color.
+    function defaultSecondaryLabelInterval(pxPerSec: number): number {
+      if (pxPerSec >= 25) {
+        return 5
+      } else if (pxPerSec * 5 >= 25) {
+        return 2
+      } else if (pxPerSec * 15 >= 25) {
+        return 2
+      }
       return 2
     }
-    return 2
-  }
 
-  function virtualAppend(start: number, container: HTMLElement, element: HTMLElement) {
-    // Store notch metadata for batch updates
-    notchElements.set(element, {
-      start,
-      width: element.clientWidth,
-      wasVisible: false,
-    })
+    function virtualAppend(start: number, container: HTMLElement, element: HTMLElement) {
+      // Store notch metadata for batch updates
+      notchElements.set(element, {
+        start,
+        width: element.clientWidth,
+        wasVisible: false,
+      })
 
-    // Initial render check
-    const scrollLeft = ctx.wavesurfer.getScroll()
-    const scrollRight = scrollLeft + ctx.wavesurfer.getWidth()
+      // Initial render check
+      const scrollLeft = ctx.wavesurfer.getScroll()
+      const scrollRight = scrollLeft + ctx.wavesurfer.getWidth()
 
-    const notchData = notchElements.get(element)!
-    const isVisible = start >= scrollLeft && start + notchData.width < scrollRight
-    notchData.wasVisible = isVisible
-
-    if (isVisible) {
-      container.appendChild(element)
-    }
-  }
-
-  function updateVisibleNotches(scrollLeft: number, scrollRight: number, container: HTMLElement) {
-    notchElements.forEach((notchData, element) => {
-      const isVisible = notchData.start >= scrollLeft && notchData.start + notchData.width < scrollRight
-
-      if (isVisible === notchData.wasVisible) return
+      const notchData = notchElements.get(element)!
+      const isVisible = start >= scrollLeft && start + notchData.width < scrollRight
       notchData.wasVisible = isVisible
 
       if (isVisible) {
         container.appendChild(element)
-      } else {
-        element.remove()
       }
-    })
-  }
-
-  function initTimeline() {
-    notchElements.clear()
-
-    const duration = ctx.wavesurfer.getDuration() ?? opts.duration ?? 0
-    const pxPerSec = (ctx.wavesurfer.getWrapper().scrollWidth || timelineWrapper.scrollWidth) / duration
-    const timeInterval = opts.timeInterval ?? defaultTimeInterval(pxPerSec)
-    const primaryLabelInterval = opts.primaryLabelInterval ?? defaultPrimaryLabelInterval(pxPerSec)
-    const primaryLabelSpacing = opts.primaryLabelSpacing
-    const secondaryLabelInterval = opts.secondaryLabelInterval ?? defaultSecondaryLabelInterval(pxPerSec)
-    const secondaryLabelSpacing = opts.secondaryLabelSpacing
-    const isTop = opts.insertPosition === 'beforebegin'
-
-    const timeline = createElement('div', {
-      style: {
-        height: `${opts.height}px`,
-        overflow: 'hidden',
-        fontSize: `${opts.height / 2}px`,
-        whiteSpace: 'nowrap',
-        ...(isTop
-          ? {
-              position: 'absolute',
-              top: '0',
-              left: '0',
-              right: '0',
-              zIndex: '2',
-            }
-          : {
-              position: 'relative',
-            }),
-      },
-    })
-
-    timeline.setAttribute('part', 'timeline')
-
-    if (typeof opts.style === 'string') {
-      timeline.setAttribute('style', timeline.getAttribute('style') + opts.style)
-    } else if (typeof opts.style === 'object') {
-      Object.assign(timeline.style, opts.style)
     }
 
-    const notchEl = createElement('div', {
-      style: {
-        width: '0',
-        height: '50%',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: isTop ? 'flex-start' : 'flex-end',
-        top: isTop ? '0' : 'auto',
-        bottom: isTop ? 'auto' : '0',
-        overflow: 'visible',
-        borderLeft: '1px solid currentColor',
-        opacity: `${opts.secondaryLabelOpacity ?? 0.25}`,
-        position: 'absolute',
-        zIndex: '1',
-      },
-    })
+    function updateVisibleNotches(scrollLeft: number, scrollRight: number, container: HTMLElement) {
+      notchElements.forEach((notchData, element) => {
+        const isVisible = notchData.start >= scrollLeft && notchData.start + notchData.width < scrollRight
 
-    for (let i = 0, notches = 0; i < duration; i += timeInterval, notches++) {
-      const notch = notchEl.cloneNode() as HTMLElement
-      const isPrimary =
-        Math.round(i * 100) % Math.round(primaryLabelInterval * 100) === 0 ||
-        (primaryLabelSpacing && notches % primaryLabelSpacing === 0)
-      const isSecondary =
-        Math.round(i * 100) % Math.round(secondaryLabelInterval * 100) === 0 ||
-        (secondaryLabelSpacing && notches % secondaryLabelSpacing === 0)
+        if (isVisible === notchData.wasVisible) return
+        notchData.wasVisible = isVisible
 
-      if (isPrimary || isSecondary) {
-        notch.style.height = '100%'
-        notch.style.textIndent = '3px'
-        notch.textContent = opts.formatTimeCallback(i)
-        if (isPrimary) notch.style.opacity = '1'
-      }
-
-      const mode = isPrimary ? 'primary' : isSecondary ? 'secondary' : 'tick'
-      notch.setAttribute('part', `timeline-notch timeline-notch-${mode}`)
-
-      const offset = (i + opts.timeOffset) * pxPerSec
-      notch.style.left = `${offset}px`
-      virtualAppend(offset, timeline, notch)
+        if (isVisible) {
+          container.appendChild(element)
+        } else {
+          element.remove()
+        }
+      })
     }
 
-    timelineWrapper.innerHTML = ''
-    timelineWrapper.appendChild(timeline)
-    currentTimeline = timeline
+    function initTimeline() {
+      notchElements.clear()
 
-    ctx.emit('ready')
-  }
+      const duration = ctx.wavesurfer.getDuration() ?? opts.duration ?? 0
+      const pxPerSec = (ctx.wavesurfer.getWrapper().scrollWidth || timelineWrapper.scrollWidth) / duration
+      const timeInterval = opts.timeInterval ?? defaultTimeInterval(pxPerSec)
+      const primaryLabelInterval = opts.primaryLabelInterval ?? defaultPrimaryLabelInterval(pxPerSec)
+      const primaryLabelSpacing = opts.primaryLabelSpacing
+      const secondaryLabelInterval = opts.secondaryLabelInterval ?? defaultSecondaryLabelInterval(pxPerSec)
+      const secondaryLabelSpacing = opts.secondaryLabelSpacing
+      const isTop = opts.insertPosition === 'beforebegin'
 
-  const container = resolveContainer(opts.container, ctx.wavesurfer.getWrapper(), 'timeline')
+      const timeline = createElement('div', {
+        style: {
+          height: `${opts.height}px`,
+          overflow: 'hidden',
+          fontSize: `${opts.height / 2}px`,
+          whiteSpace: 'nowrap',
+          ...(isTop
+            ? {
+                position: 'absolute',
+                top: '0',
+                left: '0',
+                right: '0',
+                zIndex: '2',
+              }
+            : {
+                position: 'relative',
+              }),
+        },
+      })
 
-  if (opts.insertPosition) {
-    ;(container.firstElementChild || container).insertAdjacentElement(opts.insertPosition, timelineWrapper)
-  } else {
-    container.appendChild(timelineWrapper)
-  }
-  ctx.scope.add(() => timelineWrapper.remove())
+      timeline.setAttribute('part', 'timeline')
 
-  // Get reactive state
-  const { duration } = ctx.state
-
-  // React to duration changes and redraw events to initialize timeline
-  ctx.scope.add(
-    effect(() => {
-      const dur = duration.value
-      if (dur > 0 || opts.duration) {
-        initTimeline()
+      if (typeof opts.style === 'string') {
+        timeline.setAttribute('style', timeline.getAttribute('style') + opts.style)
+      } else if (typeof opts.style === 'object') {
+        Object.assign(timeline.style, opts.style)
       }
-    }, [duration]),
-  )
 
-  ctx.scope.add(ctx.wavesurfer.on('redraw', () => initTimeline()))
+      const notchEl = createElement('div', {
+        style: {
+          width: '0',
+          height: '50%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: isTop ? 'flex-start' : 'flex-end',
+          top: isTop ? '0' : 'auto',
+          bottom: isTop ? 'auto' : '0',
+          overflow: 'visible',
+          borderLeft: '1px solid currentColor',
+          opacity: `${opts.secondaryLabelOpacity ?? 0.25}`,
+          position: 'absolute',
+          zIndex: '1',
+        },
+      })
 
-  // Re-window notches off the renderer's visibleRange (derived from scroll
-  // position + duration) rather than hand-rolling scroll math off the raw
-  // 'scroll' event. Registered once, not on every redraw.
-  const renderer = ctx.wavesurfer.getRenderer()
-  ctx.scope.add(
-    effect(() => {
-      if (currentTimeline) {
-        const scrollLeft = ctx.wavesurfer.getScroll()
-        // getWidth() is the container width minus its inline padding (see
-        // Renderer.getWidth()), matching virtualAppend()'s initial-visibility
-        // check below. This is intentional: it keeps the scroll-driven
-        // re-window consistent with the initial-render window, both derived
-        // from the same padding-adjusted width. The legacy 'scroll' event
-        // this replaced reported unpadded bounds (scrollLeft + clientWidth),
-        // which was inconsistent with virtualAppend -- with non-zero
-        // container padding the visible window now differs slightly (by the
-        // padding amount) from that old, inconsistent behavior.
-        const scrollRight = scrollLeft + ctx.wavesurfer.getWidth()
-        updateVisibleNotches(scrollLeft, scrollRight, currentTimeline)
+      for (let i = 0, notches = 0; i < duration; i += timeInterval, notches++) {
+        const notch = notchEl.cloneNode() as HTMLElement
+        const isPrimary =
+          Math.round(i * 100) % Math.round(primaryLabelInterval * 100) === 0 ||
+          (primaryLabelSpacing && notches % primaryLabelSpacing === 0)
+        const isSecondary =
+          Math.round(i * 100) % Math.round(secondaryLabelInterval * 100) === 0 ||
+          (secondaryLabelSpacing && notches % secondaryLabelSpacing === 0)
+
+        if (isPrimary || isSecondary) {
+          notch.style.height = '100%'
+          notch.style.textIndent = '3px'
+          notch.textContent = opts.formatTimeCallback(i)
+          if (isPrimary) notch.style.opacity = '1'
+        }
+
+        const mode = isPrimary ? 'primary' : isSecondary ? 'secondary' : 'tick'
+        notch.setAttribute('part', `timeline-notch timeline-notch-${mode}`)
+
+        const offset = (i + opts.timeOffset) * pxPerSec
+        notch.style.left = `${offset}px`
+        virtualAppend(offset, timeline, notch)
       }
-    }, [renderer.getVisibleRange()]),
-  )
 
-  if (ctx.wavesurfer.getDuration() || opts.duration) {
-    initTimeline()
-  }
+      timelineWrapper.innerHTML = ''
+      timelineWrapper.appendChild(timeline)
+      currentTimeline = timeline
 
-  return {}
-})
+      ctx.emit('ready')
+    }
+
+    const container = resolveContainer(opts.container, ctx.wavesurfer.getWrapper(), 'timeline')
+
+    if (opts.insertPosition) {
+      ;(container.firstElementChild || container).insertAdjacentElement(opts.insertPosition, timelineWrapper)
+    } else {
+      container.appendChild(timelineWrapper)
+    }
+    ctx.scope.add(() => timelineWrapper.remove())
+
+    // Get reactive state
+    const { duration } = ctx.state
+
+    // React to duration changes and redraw events to initialize timeline
+    ctx.scope.add(
+      effect(() => {
+        const dur = duration.value
+        if (dur > 0 || opts.duration) {
+          initTimeline()
+        }
+      }, [duration]),
+    )
+
+    ctx.scope.add(ctx.wavesurfer.on('redraw', () => initTimeline()))
+
+    // Re-window notches off the renderer's visibleRange (derived from scroll
+    // position + duration) rather than hand-rolling scroll math off the raw
+    // 'scroll' event. Registered once, not on every redraw.
+    const renderer = ctx.wavesurfer.getRenderer()
+    ctx.scope.add(
+      effect(() => {
+        if (currentTimeline) {
+          const scrollLeft = ctx.wavesurfer.getScroll()
+          // getWidth() is the container width minus its inline padding (see
+          // Renderer.getWidth()), matching virtualAppend()'s initial-visibility
+          // check below. This is intentional: it keeps the scroll-driven
+          // re-window consistent with the initial-render window, both derived
+          // from the same padding-adjusted width. The legacy 'scroll' event
+          // this replaced reported unpadded bounds (scrollLeft + clientWidth),
+          // which was inconsistent with virtualAppend -- with non-zero
+          // container padding the visible window now differs slightly (by the
+          // padding amount) from that old, inconsistent behavior.
+          const scrollRight = scrollLeft + ctx.wavesurfer.getWidth()
+          updateVisibleNotches(scrollLeft, scrollRight, currentTimeline)
+        }
+      }, [renderer.getVisibleRange()]),
+    )
+
+    if (ctx.wavesurfer.getDuration() || opts.duration) {
+      initTimeline()
+    }
+
+    return {}
+  },
+)
 
 export default TimelinePlugin

--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -2,8 +2,10 @@
  * The Timeline plugin adds timestamps and notches under the waveform.
  */
 
-import BasePlugin, { type BasePluginEvents } from '../base-plugin.js'
-import createElement, { isHTMLElement } from '../dom.js'
+import { type BasePluginEvents } from '../base-plugin.js'
+import { definePlugin } from '../define-plugin.js'
+import { resolveContainer } from '../plugin-utils.js'
+import createElement from '../dom.js'
 import { effect } from '../reactive/store.js'
 
 export type TimelinePluginOptions = {
@@ -55,104 +57,18 @@ export type TimelinePluginEvents = BasePluginEvents & {
   ready: []
 }
 
-class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOptions> {
-  private timelineWrapper: HTMLElement
-  protected options: TimelinePluginOptions & typeof defaultOptions
-  private notchElements: Map<HTMLElement, { start: number; width: number; wasVisible: boolean }> = new Map()
-  private currentTimeline: HTMLElement | undefined = undefined
+const TimelinePlugin = definePlugin<TimelinePluginOptions, TimelinePluginEvents, object>('timeline', (ctx, options) => {
+  const opts: TimelinePluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
 
-  constructor(options?: TimelinePluginOptions) {
-    super(options || {})
+  const timelineWrapper = createElement('div', { part: 'timeline-wrapper', style: { pointerEvents: 'none' } })
 
-    this.options = Object.assign({}, defaultOptions, options)
-    this.timelineWrapper = this.initTimelineWrapper()
-  }
-
-  public static create(options?: TimelinePluginOptions) {
-    return new TimelinePlugin(options)
-  }
-
-  /** Called by wavesurfer, don't call manually */
-  onInit() {
-    if (!this.wavesurfer) {
-      throw Error('WaveSurfer is not initialized')
-    }
-
-    let container = this.wavesurfer.getWrapper()
-    if (isHTMLElement(this.options.container)) {
-      container = this.options.container
-    } else if (typeof this.options.container === 'string') {
-      const el = document.querySelector(this.options.container)
-      if (!el) throw Error(`No Timeline container found matching ${this.options.container}`)
-      container = el as HTMLElement
-    }
-
-    if (this.options.insertPosition) {
-      ;(container.firstElementChild || container).insertAdjacentElement(
-        this.options.insertPosition,
-        this.timelineWrapper,
-      )
-    } else {
-      container.appendChild(this.timelineWrapper)
-    }
-
-    // Get reactive state
-    const state = this.wavesurfer.getState()
-
-    // React to duration changes and redraw events to initialize timeline
-    this.subscriptions.push(
-      effect(() => {
-        const duration = state.duration.value
-        if (duration > 0 || this.options.duration) {
-          this.initTimeline()
-        }
-      }, [state.duration]),
-    )
-
-    this.subscriptions.push(this.wavesurfer.on('redraw', () => this.initTimeline()))
-
-    // Re-window notches off the renderer's visibleRange (derived from scroll
-    // position + duration) rather than hand-rolling scroll math off the raw
-    // 'scroll' event. Registered once, not on every redraw.
-    const renderer = this.wavesurfer.getRenderer()
-    this.subscriptions.push(
-      effect(() => {
-        if (this.currentTimeline) {
-          const scrollLeft = this.wavesurfer!.getScroll()
-          // getWidth() is the container width minus its inline padding (see
-          // Renderer.getWidth()), matching virtualAppend()'s initial-visibility
-          // check below. This is intentional: it keeps the scroll-driven
-          // re-window consistent with the initial-render window, both derived
-          // from the same padding-adjusted width. The legacy 'scroll' event
-          // this replaced reported unpadded bounds (scrollLeft + clientWidth),
-          // which was inconsistent with virtualAppend -- with non-zero
-          // container padding the visible window now differs slightly (by the
-          // padding amount) from that old, inconsistent behavior.
-          const scrollRight = scrollLeft + this.wavesurfer!.getWidth()
-          this.updateVisibleNotches(scrollLeft, scrollRight, this.currentTimeline)
-        }
-      }, [renderer.getVisibleRange()]),
-    )
-
-    if (this.wavesurfer?.getDuration() || this.options.duration) {
-      this.initTimeline()
-    }
-  }
-
-  /** Unmount */
-  public destroy() {
-    this.notchElements.clear()
-    this.currentTimeline = undefined
-    this.timelineWrapper.remove()
-    super.destroy()
-  }
-
-  private initTimelineWrapper(): HTMLElement {
-    return createElement('div', { part: 'timeline-wrapper', style: { pointerEvents: 'none' } })
-  }
+  // Notch metadata for batch visibility updates, and the currently rendered
+  // timeline element (rebuilt on every initTimeline() call).
+  const notchElements: Map<HTMLElement, { start: number; width: number; wasVisible: boolean }> = new Map()
+  let currentTimeline: HTMLElement | undefined = undefined
 
   // Return how many seconds should be between each notch
-  private defaultTimeInterval(pxPerSec: number): number {
+  function defaultTimeInterval(pxPerSec: number): number {
     if (pxPerSec >= 25) {
       return 1
     } else if (pxPerSec * 5 >= 25) {
@@ -164,7 +80,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
   }
 
   // Return the cadence of notches that get labels in the primary color.
-  private defaultPrimaryLabelInterval(pxPerSec: number): number {
+  function defaultPrimaryLabelInterval(pxPerSec: number): number {
     if (pxPerSec >= 25) {
       return 10
     } else if (pxPerSec * 5 >= 25) {
@@ -176,7 +92,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
   }
 
   // Return the cadence of notches that get labels in the secondary color.
-  private defaultSecondaryLabelInterval(pxPerSec: number): number {
+  function defaultSecondaryLabelInterval(pxPerSec: number): number {
     if (pxPerSec >= 25) {
       return 5
     } else if (pxPerSec * 5 >= 25) {
@@ -187,20 +103,19 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     return 2
   }
 
-  private virtualAppend(start: number, container: HTMLElement, element: HTMLElement) {
+  function virtualAppend(start: number, container: HTMLElement, element: HTMLElement) {
     // Store notch metadata for batch updates
-    this.notchElements.set(element, {
+    notchElements.set(element, {
       start,
       width: element.clientWidth,
       wasVisible: false,
     })
 
     // Initial render check
-    if (!this.wavesurfer) return
-    const scrollLeft = this.wavesurfer.getScroll()
-    const scrollRight = scrollLeft + this.wavesurfer.getWidth()
+    const scrollLeft = ctx.wavesurfer.getScroll()
+    const scrollRight = scrollLeft + ctx.wavesurfer.getWidth()
 
-    const notchData = this.notchElements.get(element)!
+    const notchData = notchElements.get(element)!
     const isVisible = start >= scrollLeft && start + notchData.width < scrollRight
     notchData.wasVisible = isVisible
 
@@ -209,8 +124,8 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     }
   }
 
-  private updateVisibleNotches(scrollLeft: number, scrollRight: number, container: HTMLElement) {
-    this.notchElements.forEach((notchData, element) => {
+  function updateVisibleNotches(scrollLeft: number, scrollRight: number, container: HTMLElement) {
+    notchElements.forEach((notchData, element) => {
       const isVisible = notchData.start >= scrollLeft && notchData.start + notchData.width < scrollRight
 
       if (isVisible === notchData.wasVisible) return
@@ -224,23 +139,23 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
     })
   }
 
-  private initTimeline() {
-    this.notchElements.clear()
+  function initTimeline() {
+    notchElements.clear()
 
-    const duration = this.wavesurfer?.getDuration() ?? this.options.duration ?? 0
-    const pxPerSec = (this.wavesurfer?.getWrapper().scrollWidth || this.timelineWrapper.scrollWidth) / duration
-    const timeInterval = this.options.timeInterval ?? this.defaultTimeInterval(pxPerSec)
-    const primaryLabelInterval = this.options.primaryLabelInterval ?? this.defaultPrimaryLabelInterval(pxPerSec)
-    const primaryLabelSpacing = this.options.primaryLabelSpacing
-    const secondaryLabelInterval = this.options.secondaryLabelInterval ?? this.defaultSecondaryLabelInterval(pxPerSec)
-    const secondaryLabelSpacing = this.options.secondaryLabelSpacing
-    const isTop = this.options.insertPosition === 'beforebegin'
+    const duration = ctx.wavesurfer.getDuration() ?? opts.duration ?? 0
+    const pxPerSec = (ctx.wavesurfer.getWrapper().scrollWidth || timelineWrapper.scrollWidth) / duration
+    const timeInterval = opts.timeInterval ?? defaultTimeInterval(pxPerSec)
+    const primaryLabelInterval = opts.primaryLabelInterval ?? defaultPrimaryLabelInterval(pxPerSec)
+    const primaryLabelSpacing = opts.primaryLabelSpacing
+    const secondaryLabelInterval = opts.secondaryLabelInterval ?? defaultSecondaryLabelInterval(pxPerSec)
+    const secondaryLabelSpacing = opts.secondaryLabelSpacing
+    const isTop = opts.insertPosition === 'beforebegin'
 
     const timeline = createElement('div', {
       style: {
-        height: `${this.options.height}px`,
+        height: `${opts.height}px`,
         overflow: 'hidden',
-        fontSize: `${this.options.height / 2}px`,
+        fontSize: `${opts.height / 2}px`,
         whiteSpace: 'nowrap',
         ...(isTop
           ? {
@@ -258,10 +173,10 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
 
     timeline.setAttribute('part', 'timeline')
 
-    if (typeof this.options.style === 'string') {
-      timeline.setAttribute('style', timeline.getAttribute('style') + this.options.style)
-    } else if (typeof this.options.style === 'object') {
-      Object.assign(timeline.style, this.options.style)
+    if (typeof opts.style === 'string') {
+      timeline.setAttribute('style', timeline.getAttribute('style') + opts.style)
+    } else if (typeof opts.style === 'object') {
+      Object.assign(timeline.style, opts.style)
     }
 
     const notchEl = createElement('div', {
@@ -275,7 +190,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
         bottom: isTop ? 'auto' : '0',
         overflow: 'visible',
         borderLeft: '1px solid currentColor',
-        opacity: `${this.options.secondaryLabelOpacity ?? 0.25}`,
+        opacity: `${opts.secondaryLabelOpacity ?? 0.25}`,
         position: 'absolute',
         zIndex: '1',
       },
@@ -293,24 +208,77 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
       if (isPrimary || isSecondary) {
         notch.style.height = '100%'
         notch.style.textIndent = '3px'
-        notch.textContent = this.options.formatTimeCallback(i)
+        notch.textContent = opts.formatTimeCallback(i)
         if (isPrimary) notch.style.opacity = '1'
       }
 
       const mode = isPrimary ? 'primary' : isSecondary ? 'secondary' : 'tick'
       notch.setAttribute('part', `timeline-notch timeline-notch-${mode}`)
 
-      const offset = (i + this.options.timeOffset) * pxPerSec
+      const offset = (i + opts.timeOffset) * pxPerSec
       notch.style.left = `${offset}px`
-      this.virtualAppend(offset, timeline, notch)
+      virtualAppend(offset, timeline, notch)
     }
 
-    this.timelineWrapper.innerHTML = ''
-    this.timelineWrapper.appendChild(timeline)
-    this.currentTimeline = timeline
+    timelineWrapper.innerHTML = ''
+    timelineWrapper.appendChild(timeline)
+    currentTimeline = timeline
 
-    this.emit('ready')
+    ctx.emit('ready')
   }
-}
+
+  const container = resolveContainer(opts.container, ctx.wavesurfer.getWrapper(), 'timeline')
+
+  if (opts.insertPosition) {
+    ;(container.firstElementChild || container).insertAdjacentElement(opts.insertPosition, timelineWrapper)
+  } else {
+    container.appendChild(timelineWrapper)
+  }
+  ctx.scope.add(() => timelineWrapper.remove())
+
+  // Get reactive state
+  const { duration } = ctx.state
+
+  // React to duration changes and redraw events to initialize timeline
+  ctx.scope.add(
+    effect(() => {
+      const dur = duration.value
+      if (dur > 0 || opts.duration) {
+        initTimeline()
+      }
+    }, [duration]),
+  )
+
+  ctx.scope.add(ctx.wavesurfer.on('redraw', () => initTimeline()))
+
+  // Re-window notches off the renderer's visibleRange (derived from scroll
+  // position + duration) rather than hand-rolling scroll math off the raw
+  // 'scroll' event. Registered once, not on every redraw.
+  const renderer = ctx.wavesurfer.getRenderer()
+  ctx.scope.add(
+    effect(() => {
+      if (currentTimeline) {
+        const scrollLeft = ctx.wavesurfer.getScroll()
+        // getWidth() is the container width minus its inline padding (see
+        // Renderer.getWidth()), matching virtualAppend()'s initial-visibility
+        // check below. This is intentional: it keeps the scroll-driven
+        // re-window consistent with the initial-render window, both derived
+        // from the same padding-adjusted width. The legacy 'scroll' event
+        // this replaced reported unpadded bounds (scrollLeft + clientWidth),
+        // which was inconsistent with virtualAppend -- with non-zero
+        // container padding the visible window now differs slightly (by the
+        // padding amount) from that old, inconsistent behavior.
+        const scrollRight = scrollLeft + ctx.wavesurfer.getWidth()
+        updateVisibleNotches(scrollLeft, scrollRight, currentTimeline)
+      }
+    }, [renderer.getVisibleRange()]),
+  )
+
+  if (ctx.wavesurfer.getDuration() || opts.duration) {
+    initTimeline()
+  }
+
+  return {}
+})
 
 export default TimelinePlugin

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -21,7 +21,8 @@
  * });
  */
 
-import { BasePlugin, BasePluginEvents } from '../base-plugin.js'
+import { type BasePluginEvents } from '../base-plugin.js'
+import { definePlugin } from '../define-plugin.js'
 import { effect } from '../reactive/store.js'
 import { cleanup, fromEvent } from '../reactive/event-streams.js'
 
@@ -64,264 +65,232 @@ const defaultOptions = {
 
 export type ZoomPluginEvents = BasePluginEvents
 
-class ZoomPlugin extends BasePlugin<ZoomPluginEvents, ZoomPluginOptions> {
-  protected options: ZoomPluginOptions & typeof defaultOptions
-  private wrapper: HTMLElement | undefined = undefined
-  private container: HTMLElement | null = null
-  private streamCleanups: Array<() => void> = []
+function getTouchDistance(e: TouchEvent): number {
+  const touch1 = e.touches[0]
+  const touch2 = e.touches[1]
+  return Math.sqrt(Math.pow(touch2.clientX - touch1.clientX, 2) + Math.pow(touch2.clientY - touch1.clientY, 2))
+}
+
+function getTouchCenterX(e: TouchEvent): number {
+  const touch1 = e.touches[0]
+  const touch2 = e.touches[1]
+  return (touch1.clientX + touch2.clientX) / 2
+}
+
+const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('zoom', (ctx, options) => {
+  const opts: ZoomPluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
+
+  const container = ctx.wavesurfer.getWrapper().parentElement as HTMLElement
+
+  if (typeof opts.maxZoom === 'undefined') {
+    opts.maxZoom = container.clientWidth
+  }
+  const endZoom = opts.maxZoom
 
   // State for wheel zoom
-  private accumulatedDelta = 0
-  private pointerTime: number = 0
-  private oldX: number = 0
-  private endZoom: number = 0
-  private startZoom: number = 0
+  let accumulatedDelta = 0
+  let pointerTime = 0
+  let oldX = 0
+  let startZoom = 0
 
   // State for proportional pinch-to-zoom
-  private isPinching = false
-  private initialPinchDistance = 0
-  private initialZoom = 0
+  let isPinching = false
+  let initialPinchDistance = 0
+  let initialZoom = 0
 
-  constructor(options?: ZoomPluginOptions) {
-    super(options || {})
-    this.options = Object.assign({}, defaultOptions, options)
+  const calculateNewZoom = (oldZoom: number, delta: number) => {
+    let newZoom
+    if (opts.exponentialZooming) {
+      const zoomFactor =
+        delta > 0
+          ? Math.pow(endZoom / startZoom, 1 / (opts.iterations - 1))
+          : Math.pow(startZoom / endZoom, 1 / (opts.iterations - 1))
+      newZoom = Math.max(0, oldZoom * zoomFactor)
+    } else {
+      // Default linear zooming
+      newZoom = Math.max(0, oldZoom + delta * opts.scale)
+    }
+    return Math.min(newZoom, opts.maxZoom!)
   }
 
-  public static create(options?: ZoomPluginOptions) {
-    return new ZoomPlugin(options)
-  }
-
-  onInit() {
-    this.wrapper = this.wavesurfer?.getWrapper()
-    if (!this.wrapper) {
-      return
-    }
-    this.container = this.wrapper.parentElement as HTMLElement
-
-    if (typeof this.options.maxZoom === 'undefined') {
-      this.options.maxZoom = this.container.clientWidth
-    }
-    this.endZoom = this.options.maxZoom
-
-    // Get reactive state
-    const state = this.wavesurfer?.getState()
-
-    // React to zoom state changes to update internal state
-    if (state) {
-      this.subscriptions.push(
-        effect(() => {
-          const zoom = state.zoom.value
-          if (zoom > 0 && this.startZoom === 0 && this.options.exponentialZooming) {
-            const duration = state.duration.value
-            if (duration > 0 && this.container) {
-              this.startZoom = this.container.clientWidth / duration
-            }
-          }
-        }, [state.zoom, state.duration]),
-      )
-    }
-
-    // Clean up old event streams (from re-initialization)
-    this.streamCleanups.forEach((fn) => fn())
-    this.streamCleanups = []
-
-    // Create event streams
-    const wheelStream = fromEvent(this.container, 'wheel')
-    const touchStartStream = fromEvent(this.container, 'touchstart')
-    const touchMoveStream = fromEvent(this.container, 'touchmove')
-    const touchEndStream = fromEvent(this.container, 'touchend')
-    const touchCancelStream = fromEvent(this.container, 'touchcancel')
-    this.streamCleanups.push(
-      () => cleanup(wheelStream),
-      () => cleanup(touchStartStream),
-      () => cleanup(touchMoveStream),
-      () => cleanup(touchEndStream),
-      () => cleanup(touchCancelStream),
-    )
-
-    // React to wheel events
-    this.subscriptions.push(
-      effect(() => {
-        const e = wheelStream.value
-        if (e) this.onWheel(e)
-      }, [wheelStream]),
-    )
-
-    // React to touch events
-    this.subscriptions.push(
-      effect(() => {
-        const e = touchStartStream.value
-        if (e) this.onTouchStart(e)
-      }, [touchStartStream]),
-    )
-
-    this.subscriptions.push(
-      effect(() => {
-        const e = touchMoveStream.value
-        if (e) this.onTouchMove(e)
-      }, [touchMoveStream]),
-    )
-
-    this.subscriptions.push(
-      effect(() => {
-        const e = touchEndStream.value
-        if (e) this.onTouchEnd(e)
-      }, [touchEndStream]),
-    )
-
-    this.subscriptions.push(
-      effect(() => {
-        const e = touchCancelStream.value
-        if (e) this.onTouchEnd(e)
-      }, [touchCancelStream]),
-    )
-  }
-
-  private onWheel = (e: WheelEvent) => {
-    if (!this.wavesurfer || !this.container || Math.abs(e.deltaX) >= Math.abs(e.deltaY)) {
+  const onWheel = (e: WheelEvent) => {
+    if (Math.abs(e.deltaX) >= Math.abs(e.deltaY)) {
       return
     }
     // prevent scrolling the sidebar while zooming
     e.preventDefault()
 
     // Update the accumulated delta...
-    this.accumulatedDelta += -e.deltaY
+    accumulatedDelta += -e.deltaY
 
-    if (this.startZoom === 0 && this.options.exponentialZooming) {
-      this.startZoom = this.wavesurfer.getWrapper().clientWidth / this.wavesurfer.getDuration()
+    if (startZoom === 0 && opts.exponentialZooming) {
+      startZoom = ctx.wavesurfer.getWrapper().clientWidth / ctx.wavesurfer.getDuration()
     }
 
     // ...and only scroll once we've hit our threshold
-    if (this.options.deltaThreshold === 0 || Math.abs(this.accumulatedDelta) >= this.options.deltaThreshold) {
-      const duration = this.wavesurfer.getDuration()
+    if (opts.deltaThreshold === 0 || Math.abs(accumulatedDelta) >= opts.deltaThreshold) {
+      const duration = ctx.wavesurfer.getDuration()
       const oldMinPxPerSec =
-        this.wavesurfer.options.minPxPerSec === 0
-          ? this.wavesurfer.getWrapper().scrollWidth / duration
-          : this.wavesurfer.options.minPxPerSec
-      const x = e.clientX - this.container.getBoundingClientRect().left
-      const width = this.container.clientWidth
-      const scrollX = this.wavesurfer.getScroll()
+        ctx.wavesurfer.options.minPxPerSec === 0
+          ? ctx.wavesurfer.getWrapper().scrollWidth / duration
+          : ctx.wavesurfer.options.minPxPerSec
+      const x = e.clientX - container.getBoundingClientRect().left
+      const width = container.clientWidth
+      const scrollX = ctx.wavesurfer.getScroll()
 
       // Update pointerTime only if the pointer position has changed. This prevents the waveform from drifting during fixed zooming.
-      if (x !== this.oldX || this.oldX === 0) {
-        this.pointerTime = (scrollX + x) / oldMinPxPerSec
+      if (x !== oldX || oldX === 0) {
+        pointerTime = (scrollX + x) / oldMinPxPerSec
       }
-      this.oldX = x
+      oldX = x
 
-      const newMinPxPerSec = this.calculateNewZoom(oldMinPxPerSec, this.accumulatedDelta)
+      const newMinPxPerSec = calculateNewZoom(oldMinPxPerSec, accumulatedDelta)
       const newLeftSec = (width / newMinPxPerSec) * (x / width)
 
       if (newMinPxPerSec * duration < width) {
-        this.wavesurfer.zoom(width / duration)
-        this.container.scrollLeft = 0
+        ctx.wavesurfer.zoom(width / duration)
+        container.scrollLeft = 0
       } else {
-        this.wavesurfer.zoom(newMinPxPerSec)
-        this.container.scrollLeft = (this.pointerTime - newLeftSec) * newMinPxPerSec
+        ctx.wavesurfer.zoom(newMinPxPerSec)
+        container.scrollLeft = (pointerTime - newLeftSec) * newMinPxPerSec
       }
 
       // Reset the accumulated delta
-      this.accumulatedDelta = 0
+      accumulatedDelta = 0
     }
   }
 
-  private calculateNewZoom = (oldZoom: number, delta: number) => {
-    let newZoom
-    if (this.options.exponentialZooming) {
-      const zoomFactor =
-        delta > 0
-          ? Math.pow(this.endZoom / this.startZoom, 1 / (this.options.iterations - 1))
-          : Math.pow(this.startZoom / this.endZoom, 1 / (this.options.iterations - 1))
-      newZoom = Math.max(0, oldZoom * zoomFactor)
-    } else {
-      // Default linear zooming
-      newZoom = Math.max(0, oldZoom + delta * this.options.scale)
-    }
-    return Math.min(newZoom, this.options.maxZoom!)
-  }
-
-  private getTouchDistance(e: TouchEvent): number {
-    const touch1 = e.touches[0]
-    const touch2 = e.touches[1]
-    return Math.sqrt(Math.pow(touch2.clientX - touch1.clientX, 2) + Math.pow(touch2.clientY - touch1.clientY, 2))
-  }
-
-  private getTouchCenterX(e: TouchEvent): number {
-    const touch1 = e.touches[0]
-    const touch2 = e.touches[1]
-    return (touch1.clientX + touch2.clientX) / 2
-  }
-
-  private onTouchStart = (e: TouchEvent) => {
-    if (!this.wavesurfer || !this.container) return
+  const onTouchStart = (e: TouchEvent) => {
     // Check if two fingers are used
     if (e.touches.length === 2) {
       e.preventDefault()
-      this.isPinching = true
+      isPinching = true
 
       // Store initial pinch distance
-      this.initialPinchDistance = this.getTouchDistance(e)
+      initialPinchDistance = getTouchDistance(e)
 
       // Store initial zoom level
-      const duration = this.wavesurfer.getDuration()
-      this.initialZoom =
-        this.wavesurfer.options.minPxPerSec === 0
-          ? this.wavesurfer.getWrapper().scrollWidth / duration
-          : this.wavesurfer.options.minPxPerSec
+      const duration = ctx.wavesurfer.getDuration()
+      initialZoom =
+        ctx.wavesurfer.options.minPxPerSec === 0
+          ? ctx.wavesurfer.getWrapper().scrollWidth / duration
+          : ctx.wavesurfer.options.minPxPerSec
 
       // Store anchor point for zooming
-      const x = this.getTouchCenterX(e) - this.container.getBoundingClientRect().left
-      const scrollX = this.wavesurfer.getScroll()
-      this.pointerTime = (scrollX + x) / this.initialZoom
-      this.oldX = x // Use oldX to store the anchor X position
+      const x = getTouchCenterX(e) - container.getBoundingClientRect().left
+      const scrollX = ctx.wavesurfer.getScroll()
+      pointerTime = (scrollX + x) / initialZoom
+      oldX = x // Use oldX to store the anchor X position
     }
   }
 
-  private onTouchMove = (e: TouchEvent) => {
-    if (!this.isPinching || e.touches.length !== 2 || !this.wavesurfer || !this.container) {
+  const onTouchMove = (e: TouchEvent) => {
+    if (!isPinching || e.touches.length !== 2) {
       return
     }
     e.preventDefault()
 
     // Calculate new zoom level
-    const newDistance = this.getTouchDistance(e)
-    const scaleFactor = newDistance / this.initialPinchDistance
-    let newMinPxPerSec = this.initialZoom * scaleFactor
+    const newDistance = getTouchDistance(e)
+    const scaleFactor = newDistance / initialPinchDistance
+    let newMinPxPerSec = initialZoom * scaleFactor
 
     // Constrain the zoom
-    newMinPxPerSec = Math.min(newMinPxPerSec, this.options.maxZoom!)
+    newMinPxPerSec = Math.min(newMinPxPerSec, opts.maxZoom!)
 
     // Calculate minimum zoom (fit to width)
-    const duration = this.wavesurfer.getDuration()
-    const width = this.container.clientWidth
+    const duration = ctx.wavesurfer.getDuration()
+    const width = container.clientWidth
     const minZoom = width / duration
     if (newMinPxPerSec < minZoom) {
       newMinPxPerSec = minZoom
     }
 
     // Apply zoom and scroll
-    const newLeftSec = (width / newMinPxPerSec) * (this.oldX / width)
+    const newLeftSec = (width / newMinPxPerSec) * (oldX / width)
     if (newMinPxPerSec === minZoom) {
-      this.wavesurfer.zoom(minZoom)
-      this.container.scrollLeft = 0
+      ctx.wavesurfer.zoom(minZoom)
+      container.scrollLeft = 0
     } else {
-      this.wavesurfer.zoom(newMinPxPerSec)
-      this.container.scrollLeft = (this.pointerTime - newLeftSec) * newMinPxPerSec
+      ctx.wavesurfer.zoom(newMinPxPerSec)
+      container.scrollLeft = (pointerTime - newLeftSec) * newMinPxPerSec
     }
   }
 
-  private onTouchEnd = (e: TouchEvent) => {
-    if (this.isPinching && e.touches.length < 2) {
-      this.isPinching = false
-      this.initialPinchDistance = 0
-      this.initialZoom = 0
+  const onTouchEnd = (e: TouchEvent) => {
+    if (isPinching && e.touches.length < 2) {
+      isPinching = false
+      initialPinchDistance = 0
+      initialZoom = 0
     }
   }
 
-  destroy() {
-    this.streamCleanups.forEach((fn) => fn())
-    this.streamCleanups = []
-    super.destroy()
-  }
-}
+  // Get reactive state
+  const { zoom, duration } = ctx.state
+
+  // React to zoom state changes to update internal state
+  ctx.scope.add(
+    effect(() => {
+      const z = zoom.value
+      if (z > 0 && startZoom === 0 && opts.exponentialZooming) {
+        const dur = duration.value
+        if (dur > 0) {
+          startZoom = container.clientWidth / dur
+        }
+      }
+    }, [zoom, duration]),
+  )
+
+  // Create event streams
+  const wheelStream = fromEvent(container, 'wheel')
+  const touchStartStream = fromEvent(container, 'touchstart')
+  const touchMoveStream = fromEvent(container, 'touchmove')
+  const touchEndStream = fromEvent(container, 'touchend')
+  const touchCancelStream = fromEvent(container, 'touchcancel')
+  ctx.scope.add(() => cleanup(wheelStream))
+  ctx.scope.add(() => cleanup(touchStartStream))
+  ctx.scope.add(() => cleanup(touchMoveStream))
+  ctx.scope.add(() => cleanup(touchEndStream))
+  ctx.scope.add(() => cleanup(touchCancelStream))
+
+  // React to wheel events
+  ctx.scope.add(
+    effect(() => {
+      const e = wheelStream.value
+      if (e) onWheel(e)
+    }, [wheelStream]),
+  )
+
+  // React to touch events
+  ctx.scope.add(
+    effect(() => {
+      const e = touchStartStream.value
+      if (e) onTouchStart(e)
+    }, [touchStartStream]),
+  )
+
+  ctx.scope.add(
+    effect(() => {
+      const e = touchMoveStream.value
+      if (e) onTouchMove(e)
+    }, [touchMoveStream]),
+  )
+
+  ctx.scope.add(
+    effect(() => {
+      const e = touchEndStream.value
+      if (e) onTouchEnd(e)
+    }, [touchEndStream]),
+  )
+
+  ctx.scope.add(
+    effect(() => {
+      const e = touchCancelStream.value
+      if (e) onTouchEnd(e)
+    }, [touchCancelStream]),
+  )
+
+  return {}
+})
 
 export default ZoomPlugin

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -82,6 +82,14 @@ const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('zo
 
   const container = ctx.wavesurfer.getWrapper().parentElement as HTMLElement
 
+  // When the caller doesn't pass `maxZoom`, derive it from the container's
+  // CURRENT width. `opts` is a fresh object built fresh on every (re-)init
+  // (setup() reruns from scratch), so this recomputes from the live
+  // container on each init rather than being cached across a
+  // destroy -> re-init cycle — unlike the pre-port class, which stored the
+  // default on the long-lived `this.options` and only computed it once, on
+  // the first init. Deliberate behavior change: a container resized
+  // between init cycles gets an accurate cap instead of a stale one.
   if (typeof opts.maxZoom === 'undefined') {
     opts.maxZoom = container.clientWidth
   }

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -77,7 +77,7 @@ function getTouchCenterX(e: TouchEvent): number {
   return (touch1.clientX + touch2.clientX) / 2
 }
 
-const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('zoom', (ctx, options) => {
+const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('ZoomPlugin', (ctx, options) => {
   const opts: ZoomPluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
 
   const container = ctx.wavesurfer.getWrapper().parentElement as HTMLElement

--- a/src/reactive/README.md
+++ b/src/reactive/README.md
@@ -156,27 +156,35 @@ console.log('Progress:', state.progressPercent.value)
 
 ### In Plugins
 
+First-party plugins are built with `definePlugin()` (see `src/define-plugin.ts`), whose `setup(ctx, options)` receives a `ctx.scope: Scope` for the current init — register every subscription on it instead of hand-rolling a `subscriptions` array; `ctx.scope` is disposed automatically on plugin destroy (and a fresh one is created on re-init):
+
 ```typescript
-class MyPlugin extends BasePlugin {
-  onInit() {
-    const state = this.wavesurfer.getState()
+import { definePlugin } from './define-plugin.js'
 
-    // Subscribe to state changes
-    this.subscriptions.push(
-      state.isPlaying.subscribe((playing) => {
-        if (playing) {
-          this.startAnimation()
-        } else {
-          this.stopAnimation()
-        }
-      })
-    )
+const MyPlugin = definePlugin<MyPluginOptions, MyPluginEvents, MyApi>('my-plugin', (ctx, options) => {
+  const state = ctx.state // ctx.wavesurfer.getState()
 
-    // Access current time
-    const currentTime = state.currentTime.value
+  // Subscribe to state changes; released when ctx.scope is disposed
+  ctx.scope.add(
+    state.isPlaying.subscribe((playing) => {
+      if (playing) {
+        startAnimation()
+      } else {
+        stopAnimation()
+      }
+    }),
+  )
+
+  // Access current time
+  const currentTime = state.currentTime.value
+
+  return {
+    /* public api */
   }
-}
+})
 ```
+
+`BasePlugin` (the chassis `definePlugin` builds on) still exists for third-party class-based plugins and exposes a `protected scope: Scope` for the same pattern.
 
 ## Testing
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -54,6 +54,14 @@ class Renderer extends EventEmitter<RendererEvents> {
   private containerInlinePadding = 0
   private audioDuration = signal(0)
   private visibleRange: ComputedSignal<{ startTime: number; endTime: number }>
+  // initEvents() (click/dblclick listeners, scrollStream, dragStream,
+  // resize observer) only ever ran from the constructor, historically. But
+  // destroy() disposes+recreates this.scope and tears the DOM listeners
+  // down manually, so a reused instance (destroy() -> load() -> render())
+  // needs its input pipeline rebuilt too. ensureInputEvents() makes that
+  // idempotent: the constructor and the top of render() both call it, and
+  // destroy() flips the flag back off so the next render() re-runs it.
+  private inputEventsInitialized = false
 
   constructor(options: WaveSurferOptions, audioElement?: HTMLElement) {
     super()
@@ -77,34 +85,41 @@ class Renderer extends EventEmitter<RendererEvents> {
       shadow.appendChild(audioElement)
     }
 
-    // initEvents() creates this.scrollStream, so visibleRange must be built
-    // after it.
-    this.initEvents()
+    // ensureInputEvents() creates this.scrollStream, so visibleRange must be
+    // built after it.
+    this.ensureInputEvents()
 
     // visibleRange is instance-lifetime state, deliberately NOT disposed via
     // this.scope -- mirroring the WaveSurferState computeds precedent (see
     // wavesurfer.ts's constructor comment near createWaveSurferState). Why:
     // destroy() disposes and recreates `this.scope` to support the documented
-    // destroy -> load() reuse contract, but this.scrollStream/initEvents()
-    // only ever run once, from this constructor. If visibleRange's dispose
-    // were registered on this.scope, it would be permanently disposed after
-    // the FIRST destroy() with nothing left to recreate it -- breaking
-    // getVisibleRange() forever for any reused instance (and for future
-    // consumers like minimap/spectrogram). So visibleRange itself is never
-    // disposed; it depends on this.audioDuration (owned by this instance,
-    // never disposed) and, transitively through the recompute body below, on
-    // this.scrollStream.percentages, which the scope cleanup below DOES
-    // dispose at destroy() (and nulls out this.scrollStream). The recompute
-    // body defends against that by falling back to the non-scrollable
-    // {0, duration} shape whenever this.scrollStream is null, instead of
-    // throwing. Net effect after a destroy(): visibleRange freezes at its
-    // last live value until the next render() (which still fires, since
-    // audioDuration.set() is unaffected by the scope reset) recomputes it to
-    // {startTime: 0, endTime: newDuration} -- the same "not scrollable"
-    // shape reported before any scroll ever happened. This mirrors the
-    // pre-existing behavior of the 'scroll' event itself, which also stops
-    // firing after the first destroy() for the same reason (scrollStream is
-    // never recreated) -- not a regression introduced by visibleRange.
+    // destroy -> load() reuse contract, and ensureInputEvents() rebuilds
+    // this.scrollStream on the next render() after a destroy(). If
+    // visibleRange's dispose were registered on this.scope, it would be
+    // permanently disposed after the FIRST destroy() with nothing left to
+    // recreate it -- breaking getVisibleRange() forever for any reused
+    // instance (and for future consumers like minimap/spectrogram). So
+    // visibleRange itself is never disposed; it depends on this.audioDuration
+    // (owned by this instance, never disposed) and, transitively through the
+    // recompute body below, on this.scrollStream.percentages, which the scope
+    // cleanup in initEvents() DOES dispose at destroy() (and nulls out
+    // this.scrollStream). The recompute body defends against that by falling
+    // back to the non-scrollable {0, duration} shape whenever
+    // this.scrollStream is null, instead of throwing.
+    //
+    // Deliberately built with NO explicit dependency array (auto-tracking):
+    // computed()'s auto mode re-collects dependencies from the signals
+    // actually read on each recompute (see store.ts). An explicit
+    // `[this.audioDuration, this.scrollStream.percentages]` array would pin
+    // the subscription to whichever percentages signal object existed at
+    // construction time; once ensureInputEvents() rebuilds this.scrollStream
+    // on a post-destroy render(), that pinned subscription would keep
+    // pointing at the old, now-orphaned percentages signal forever, and
+    // visibleRange would never react to scroll again after the first
+    // destroy(). Auto-tracking re-subscribes to whatever this.scrollStream
+    // currently is every time the computed reruns (e.g. on the
+    // audioDuration.set() in render()), so it picks up the freshly created
+    // percentages signal after a reuse.
     this.visibleRange = computed(() => {
       const duration = this.audioDuration.value
       if (!this.isScrollable || duration === 0 || !this.scrollStream) {
@@ -112,7 +127,21 @@ class Renderer extends EventEmitter<RendererEvents> {
       }
       const { startX, endX } = this.scrollStream.percentages.value
       return { startTime: startX * duration, endTime: endX * duration }
-    }, [this.audioDuration, this.scrollStream!.percentages])
+    })
+  }
+
+  /**
+   * Idempotently (re)establishes the input pipeline: click/dblclick DOM
+   * listeners, the scroll stream (and its 'scroll' event bridge), the
+   * optional drag stream, and the resize observer. Runs once from the
+   * constructor; destroy() flips inputEventsInitialized back to false so the
+   * next render() call re-runs initEvents() and revives the pipeline for a
+   * reused instance.
+   */
+  private ensureInputEvents(): void {
+    if (this.inputEventsInitialized) return
+    this.inputEventsInitialized = true
+    this.initEvents()
   }
 
   private parentFromOptionsContainer(container: WaveSurferOptions['container']) {
@@ -381,6 +410,11 @@ class Renderer extends EventEmitter<RendererEvents> {
     this.scope = new Scope()
     this.scrollRenderScope = this.scope.child()
     this.delayScope = this.scope.child()
+
+    // Flip so the next render() re-runs initEvents() via ensureInputEvents(),
+    // reviving the click/dblclick listeners just removed above along with
+    // the scroll/drag streams and resize observer disposed via this.scope.
+    this.inputEventsInitialized = false
 
     this.container.remove()
     if (this.resizeObserver) {
@@ -689,6 +723,10 @@ class Renderer extends EventEmitter<RendererEvents> {
   }
 
   async render(audioData: AudioBuffer) {
+    // Revive the input pipeline if this instance is being reused after a
+    // destroy() (no-op otherwise, see ensureInputEvents()).
+    this.ensureInputEvents()
+
     // Clear previous timeouts
     this.delayScope.dispose()
     this.delayScope = this.scope.child()

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -562,35 +562,42 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     // in-flight loads from before destroy() are still cancelled by the
     // loadScope.disposed guard below.
 
-    this.emit('load', url)
-
-    // Only the fetch path goes through 'fetching' -- pre-decoded data
-    // (blob/channelData already provided) skips straight to 'decoding' below.
-    if (!loadScope.disposed && !blob && !channelData) {
-      this.wavesurferActions.setLoadPhase('fetching')
-    }
-
-    this.wavesurferActions.setUrl(url || '')
-    if (channelData) {
-      this.wavesurferActions.setPeaks(channelData)
-    } else {
-      this.wavesurferActions.setPeaks(null)
-    }
-
-    if (!this.options.media && this.isPlaying()) this.pause()
-
-    this.decodedData = null
-    this.wavesurferActions.setAudioBuffer(null)
-    this.stopAtPosition = null
-
-    // The fetch/decode pipeline below can reject when this load is superseded
-    // by a newer load() (e.g. an aborted fetch rejects with AbortError). Such
-    // rejections must never escape loadAudio -- they aren't genuine failures,
-    // just noise from cancelling a stale load. A destroy-triggered abort is
-    // different: it must still propagate (see the catch below), so
+    // The pipeline below -- starting with the 'load' emit -- can throw or
+    // reject when this load is superseded by a newer load() (e.g. an aborted
+    // fetch rejects with AbortError) or when a user's synchronous listener
+    // (e.g. on 'load') throws. Such failures must never escape loadAudio
+    // unhandled -- they're either noise from cancelling a stale load, or a
+    // genuine failure that must be classified and reported the same way
+    // regardless of where in the pipeline it originated. A destroy-triggered
+    // abort is different: it must still propagate (see the catch below), so
     // load()/loadBlob()'s catch blocks only ever see "supersession, already
-    // filtered" or "a real failure/destroy, handle it."
+    // filtered" or "a real failure/destroy, handle it." The try opens here,
+    // above the emit/setUrl/setPeaks/pause section, so a synchronous throw
+    // from any of those is covered by the same catch as the async pipeline --
+    // the catch's supersede/destroy classification only consults `loadScope`
+    // and the WeakSet, so it's correct regardless of where the throw came from.
     try {
+      this.emit('load', url)
+
+      // Only the fetch path goes through 'fetching' -- pre-decoded data
+      // (blob/channelData already provided) skips straight to 'decoding' below.
+      if (!loadScope.disposed && !blob && !channelData) {
+        this.wavesurferActions.setLoadPhase('fetching')
+      }
+
+      this.wavesurferActions.setUrl(url || '')
+      if (channelData) {
+        this.wavesurferActions.setPeaks(channelData)
+      } else {
+        this.wavesurferActions.setPeaks(null)
+      }
+
+      if (!this.options.media && this.isPlaying()) this.pause()
+
+      this.decodedData = null
+      this.wavesurferActions.setAudioBuffer(null)
+      this.stopAtPosition = null
+
       // Fetch the entire audio as a blob if pre-decoded data is not provided
       if (!blob && !channelData) {
         // Shallow-copy: this.options.fetchParams is a user-owned object that may be
@@ -626,6 +633,19 @@ class WaveSurfer extends Player<WaveSurferEvents> {
           this.mediaEventScope.add(
             this.onMediaEvent('loadedmetadata', () => resolve(this.getDuration()), { once: true }),
           )
+          // Settle if this load is superseded or the instance is destroyed
+          // before 'loadedmetadata' ever fires (e.g. never emitted by the
+          // test/media environment) -- otherwise this promise, and thus
+          // loadAudio()/load(), would hang forever. Registered on loadScope
+          // (not mediaEventScope, which the 'loadedmetadata' listener above
+          // must stay on -- moving it there would remove it, and thus resolve
+          // this promise, on every load's disposal, not just this one's).
+          // Late registration on an already-disposed scope runs immediately
+          // (see Scope.add), so this is safe even if loadScope somehow
+          // disposes synchronously before this line runs. The resolved value
+          // is discarded either way: the very next `if (loadScope.disposed)
+          // return` bails before audioDuration is used.
+          loadScope.add(() => resolve(0))
         }
       })
 

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -1,5 +1,6 @@
 import BasePlugin, { type GenericPlugin } from './base-plugin.js'
 import Decoder from './decoder.js'
+import { definePlugin } from './define-plugin.js'
 import * as dom from './dom.js'
 import Fetcher from './fetcher.js'
 import { FrameScheduler } from './frame-scheduler.js'
@@ -179,6 +180,7 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 
   public static readonly BasePlugin = BasePlugin
   public static readonly dom = dom
+  public static readonly definePlugin = definePlugin
 
   /** Create a new WaveSurfer instance */
   public static create(options: WaveSurferOptions) {
@@ -903,8 +905,12 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 export type { Signal, WritableSignal } from './reactive/store.js'
 export type { WaveSurferState, WaveSurferActions, LoadPhase } from './state/wavesurfer-state.js'
 
-// Export the functional plugin API for plugin authors
-export { definePlugin } from './define-plugin.js'
+// The functional plugin API (`definePlugin`) is exposed as a static on the
+// WaveSurfer class (`WaveSurfer.definePlugin`), not as a runtime named
+// export here: the main-entry rollup outputs (cjs/umd) use
+// `output.exports: 'default'`, which hard-errors if a runtime named export
+// exists alongside the default export. Only type-only re-exports are safe
+// here since types are erased before rollup sees them.
 export type { PluginContext, PluginSetup, DefinedPlugin } from './define-plugin.js'
 
 export default WaveSurfer

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -903,4 +903,8 @@ class WaveSurfer extends Player<WaveSurferEvents> {
 export type { Signal, WritableSignal } from './reactive/store.js'
 export type { WaveSurferState, WaveSurferActions, LoadPhase } from './state/wavesurfer-state.js'
 
+// Export the functional plugin API for plugin authors
+export { definePlugin } from './define-plugin.js'
+export type { PluginContext, PluginSetup, DefinedPlugin } from './define-plugin.js'
+
 export default WaveSurfer


### PR DESCRIPTION
## Short description

Phase 3 of the declarative refactor (follow-up to #4340/#4341): a functional plugin API — `definePlugin(name, setup)` — whose teardown is scope disposal, shared plugin utilities, and six first-party plugins rebuilt on it with their public surfaces preserved. Plus the carried-forward load fixes and renderer post-destroy revival.

## Implementation details

- **`definePlugin`** (`WaveSurfer.definePlugin`, also importable via `dist/define-plugin.js`): plugins become `setup(ctx, options) => api` functions; `ctx = { wavesurfer, state, scope, emit }` with lazy getters (no destroyed-instance retention), a per-init `Scope` whose disposal IS the teardown, an api-key collision guard (including runtime-visible TS-private chassis fields), and conditionally-optional options typing (`create()` stays argument-free where options are all-optional).
- **Ported**: hover, zoom, timeline, minimap, envelope, regions. Regions gives every region a child scope — region removal is one `dispose()`; three hand-maintained subscription-splice sites are gone. Minimap's 15 event forwarders collapsed into one `bridgeEvents` call. Envelope's per-decode subscription replacement became a child-scope swap.
- **Record deliberately not ported**: it supports standalone use (record without registering on a wavesurfer), which a setup-at-init model can't express. It adopts scope ownership internally; its tests are byte-unmodified.
- **Shared utils** (`plugin-utils.ts`): `resolveContainer` (one error behavior), `overlayElement`, `bridgeEvents`.
- **Core fixes**: superseded load promises always settle (no more forever-pending `load()`); synchronous pre-fetch throws set `loadPhase='error'`; the renderer's input pipeline and `visibleRange` revive on destroy→`load()` reuse (previously scroll/click/drag stayed dead).
- `BasePlugin` remains fully functional for third-party plugins (it's the chassis; it gained a `protected scope`).
- Behavior notes (details in `docs/RELEASE_NOTES-scope-refactor.md`): pre-init api calls throw `TypeError`; hover/regions root elements are removed during scope disposal (before the `destroy` event); zoom's derived `maxZoom` recomputes per re-init; `SingleRegion.subscriptions` (public field) removed; minimap/envelope `create()` argument became optional.

## How to test it

```
yarn && yarn tsc --noEmit && npx jest && npx eslint "src/**/*.ts" && yarn build
```
36 suites / 466 tests green; tsc, eslint, and the full rollup build clean (the build is part of verification — an earlier revision of the export wiring broke `output.exports: 'default'` and was caught and fixed).

## Screenshots

N/A (no visual changes).

## Checklist
* [ ] This PR is covered by e2e tests (existing cypress suite; port behavior pinned by the unit suites)
* [x] It introduces no breaking API changes (runtime surfaces preserved; type-level notes in release notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m5srLP9Jps5svV6NA1XeB
