### PR TITLE
fix(Envelope): hold the last point's volume instead of dividing by a zero time span

### DIFF
--- a/src/__tests__/envelope.test.ts
+++ b/src/__tests__/envelope.test.ts
@@ -1,0 +1,99 @@
+import EnvelopePlugin from '../plugins/envelope.js'
+import { createEmitter } from './helpers/create-emitter.js'
+import { installMatchMediaStub } from './helpers/match-media.js'
+
+// Only the slice of WaveSurfer that EnvelopePlugin's volume path reads. The polyline is never
+// built here (that needs 'decode' plus the SVG geometry jsdom lacks — see envelope-leaks.test.ts);
+// onTimeUpdate works off the points array alone, which is what these tests drive.
+const createWaveSurfer = (duration: number, currentTime = 0) => {
+  const wrapper = document.createElement('div')
+  document.body.appendChild(wrapper)
+
+  return {
+    ...createEmitter(),
+    getWrapper: () => wrapper,
+    getDuration: () => duration,
+    getDecodedData: () => null,
+    getVolume: () => 1,
+    getCurrentTime: () => currentTime,
+    setVolume: jest.fn(),
+  }
+}
+
+describe('EnvelopePlugin volume interpolation', () => {
+  beforeAll(() => {
+    installMatchMediaStub()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('interpolates linearly between two points', () => {
+    const ws = createWaveSurfer(10)
+    const plugin = EnvelopePlugin.create({
+      points: [
+        { time: 0, volume: 0.2 },
+        { time: 10, volume: 1 },
+      ],
+    })
+    plugin._init(ws as any)
+
+    ws.emit('timeupdate', 5)
+
+    expect(plugin.getCurrentVolume()).toBe(0.6)
+  })
+
+  // A point at the very end of the track makes the synthesized end point coincide with it, so the
+  // interpolation divided by a zero time difference. NaN survived the 0..1 clamp and reached
+  // setVolume(), where both backends reject it: HTMLMediaElement.volume and AudioParam.value are
+  // restricted doubles, so assigning NaN throws a TypeError out of the 'timeupdate' emit.
+  it('holds the last point volume when it sits at the end of the track', () => {
+    const ws = createWaveSurfer(10)
+    const plugin = EnvelopePlugin.create({
+      points: [
+        { time: 0, volume: 1 },
+        { time: 10, volume: 0 },
+      ],
+    })
+    plugin._init(ws as any)
+
+    const emitted: number[] = []
+    plugin.on('volume-change', (volume) => emitted.push(volume))
+
+    ws.emit('timeupdate', 10)
+
+    expect(plugin.getCurrentVolume()).toBe(0)
+    expect(emitted).toEqual([0])
+    expect(ws.setVolume).not.toHaveBeenCalledWith(NaN)
+  })
+
+  it('keeps the volume finite across the whole timeline', () => {
+    const ws = createWaveSurfer(10)
+    const plugin = EnvelopePlugin.create({
+      points: [
+        { time: 0, volume: 1 },
+        { time: 4, volume: 0.5 },
+        { time: 10, volume: 0 },
+      ],
+    })
+    plugin._init(ws as any)
+
+    for (let time = 0; time <= 10; time += 0.25) {
+      ws.emit('timeupdate', time)
+    }
+
+    const volumes = ws.setVolume.mock.calls.map(([volume]) => volume)
+    expect(volumes.every(Number.isFinite)).toBe(true)
+  })
+
+  it('does not set a NaN volume when the duration is not known yet', () => {
+    const ws = createWaveSurfer(0)
+    const plugin = EnvelopePlugin.create({ points: [] })
+    plugin._init(ws as any)
+
+    ws.emit('timeupdate', 0)
+
+    expect(ws.setVolume).not.toHaveBeenCalledWith(NaN)
+  })
+})

--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -391,7 +391,11 @@ const EnvelopePlugin = definePlugin<EnvelopePluginOptions, EnvelopePluginEvents,
       }
       const timeDiff = nextPoint.time - prevPoint.time
       const volumeDiff = nextPoint.volume - prevPoint.volume
-      const newVolume = prevPoint.volume + (time - prevPoint.time) * (volumeDiff / timeDiff)
+      // The synthesized end point above collapses onto the last real point when that point sits
+      // at the very end of the track, making timeDiff 0. Interpolating then yields NaN, which the
+      // clamp below cannot undo, so hold the last point's volume instead of dividing.
+      const newVolume =
+        timeDiff > 0 ? prevPoint.volume + (time - prevPoint.time) * (volumeDiff / timeDiff) : prevPoint.volume
       const clampedVolume = Math.min(1, Math.max(0, newVolume))
       const roundedVolume = Math.round(clampedVolume * 100) / 100
 


### PR DESCRIPTION
## Short description

If the last envelope point sits at the very end of the track, `wavesurfer.seekTo(1)` throws
`TypeError: Failed to set the 'volume' property on 'HTMLMediaElement': The provided double value is non-finite`,
and the fade-out never reaches the volume it was drawn to reach.

That is the canonical fade-out shape — a point at `time: 0` and one at `time: wavesurfer.getDuration()` —
so it also fires on its own whenever playback runs to the end, since `currentTime` lands exactly on
`duration` there.

## Implementation details

`onTimeUpdate` synthesizes an end point when no real point lies after the current time:

```js
let nextPoint = points.find((point) => point.time > time)
if (!nextPoint) {
  nextPoint = { time: duration || 0, volume: 0 }
}
```

When the last real point is at `duration`, that synthesized point coincides with it, so
`timeDiff` is `0` and the interpolation divides by zero:

```js
const newVolume = prevPoint.volume + (time - prevPoint.time) * (volumeDiff / timeDiff)
```

`0 * ±Infinity` (or `0 / 0`) is `NaN`, and the clamp on the next line cannot undo it —
`Math.min(1, Math.max(0, NaN))` is `NaN`. It reaches `setVolume()`, where both backends reject it:
`HTMLMediaElement.volume` and `AudioParam.value` are restricted `double`/`float` in WebIDL, so
assigning `NaN` throws. Because the throw happens inside `EventEmitter#emit`'s `Set.forEach`, it also
aborts the rest of that `'timeupdate'` dispatch, so listeners registered after the plugin are skipped:

```
at WaveSurfer.setVolume        (dist/player.js)
at ...                         (dist/plugins/envelope.js)
at Set.forEach
at WaveSurfer.emit             (dist/event-emitter.js)
at WaveSurfer.setTime          (dist/wavesurfer.js:626)
at WaveSurfer.seekTo           (dist/wavesurfer.js:631)
```

And it does not recover: `setVolume` assigns the module-level `volume` before the throw, so the
`roundedVolume !== volume` guard is comparing against `NaN` from then on and every subsequent
`timeupdate` throws again.

The fix holds the last point's volume when the span is not positive, rather than dividing. At
`timeDiff === 0` the two points are the same instant and `prevPoint` is the authored one, so its
volume is the value the envelope actually specifies there; the synthesized point is a fabrication.
Using `> 0` rather than `!== 0` also avoids extrapolating with a wrong sign if `duration` ever comes
back smaller than a point's time. Normal interpolation is untouched.

This is a different path from the `NaN` fixed in #3033 — that one was `invertNaturalVolume`, which no
longer exists.

## How to test it

Measured in Chromium against the built bundle (`examples/audio/demo.wav`, duration 21.77s), envelope
points `[{time: 0, volume: 1}, {time: duration, volume: 0}]`, with a second `'timeupdate'` listener
registered after the plugin:

| | `seekTo(0.5)` | `seekTo(1)` |
|---|---|---|
| **before** | ok | **throws `TypeError`**; later `timeupdate` listener not called; `getVolume()` stuck at `0.5`; `envelope.getCurrentVolume()` is `NaN` |
| **after** | ok | ok; later listener called; `getVolume()` is `0`; `envelope.getCurrentVolume()` is `0` |

Unit coverage is in the new `src/__tests__/envelope.test.ts` — three of its four tests fail on
`master` and pass with this change:

```
✕ holds the last point volume when it sits at the end of the track
✕ keeps the volume finite across the whole timeline
✕ does not set a NaN volume when the duration is not known yet
✓ interpolates linearly between two points     <- passes both ways, pins the unchanged behaviour
```

Gates run locally on Node 24: `yarn lint` clean, `npx prettier -c` clean, `npx tsc --noEmit` clean,
`jest --selectProjects default` 570 passed / 39 suites, `jest --selectProjects leaks` 7 passed.

## Screenshots

n/a — no visual change.

## Checklist

* [ ] This PR is covered by e2e tests — covered by unit tests instead, matching how the other plugin
  fixes here are tested (#4348, #4318, #4316). The before/after in the table above was measured in a
  real browser but is not committed as a spec; happy to add a Cypress case if you would prefer one.
* [x] It introduces no breaking API changes
