### PR TITLE
fix(Record): exclude paused time from duration

### DIFF
--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -196,4 +196,36 @@ describe('RecordPlugin destroy-time record-end delivery (realistic async onstop)
 
     expect(onEnd).toHaveBeenCalledTimes(1)
   })
+
+  it('does not include paused time in record duration after resuming', async () => {
+    let now = 1_000
+    const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => now)
+    const plugin = RecordPlugin.create()
+    const onProgress = jest.fn()
+    plugin.on('record-progress', onProgress)
+
+    try {
+      await plugin.startRecording()
+
+      now = 1_500
+      ;(plugin as any).handleTick()
+      expect(plugin.getDuration()).toBe(500)
+
+      plugin.pauseRecording()
+      now = 16_500
+      onProgress.mockClear()
+      plugin.resumeRecording()
+
+      expect(plugin.getDuration()).toBe(500)
+      expect(onProgress).toHaveBeenLastCalledWith(500)
+
+      now = 16_600
+      ;(plugin as any).handleTick()
+      expect(plugin.getDuration()).toBe(600)
+    } finally {
+      plugin.destroy()
+      await flushMicrotasks()
+      nowSpy.mockRestore()
+    }
+  })
 })

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -413,8 +413,8 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     if (this.isPaused()) {
       this.isWaveformPaused = false
       this.mediaRecorder?.resume()
-      this.frameScheduler.start(this.handleTick)
       this.lastStartTime = performance.now()
+      this.frameScheduler.start(this.handleTick)
       this.emit('record-resume')
     }
   }


### PR DESCRIPTION
## Short description

Fixes #4277 by keeping paused time out of the recording duration immediately after resume.

## Implementation details

- Reset `lastStartTime` before restarting `FrameScheduler`, whose first tick is intentionally synchronous.
- Add a regression test covering 500 ms of recording, a 15 second pause, resume, and the next progress tick.
- Verify that duration remains monotonic after recording continues.

## How to test it

- `npx --no-install jest --selectProjects default --runTestsByPath src/__tests__/record.test.ts --runInBand --coverage=false`
- `npx --no-install jest --coverage --selectProjects default --runInBand` (571 tests passed)
- `npx --no-install eslint "src/**/*.ts" --fix`
- `npx --no-install tsc --noEmit`

The full `npm run build` reached Rollup successfully for the main bundles, then hit the existing Windows plugin-output path constraint (`outDir` versus the Rollup `file` path). No generated build files are included.

## Screenshots

Not applicable. This fixes recording timer behavior.

## Checklist

* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes
