### PR TITLE
fix(Player): defer early media seeks until canplay

### DIFF
--- a/cypress/e2e/player.cy.js
+++ b/cypress/e2e/player.cy.js
@@ -1,52 +1,58 @@
 describe('WaveSurfer player', () => {
+  let wavesurfer
+  let media
+
+  afterEach(() => {
+    wavesurfer?.destroy()
+    wavesurfer = undefined
+    media = undefined
+  })
+
   it('preserves a seek requested from ready before media can play', () => {
     cy.visit('cypress/e2e/player.html')
     cy.window().its('WaveSurfer').should('exist')
 
-    cy.window().then((win) => {
-      return new Cypress.Promise((resolve, reject) => {
-        const wavesurfer = win.WaveSurfer.create({
-          container: '#waveform',
-          url: '../../examples/audio/demo.wav',
-          peaks: [[0, 0.5, -0.5, 0]],
-          duration: 21.77,
-        })
+    cy.window()
+      .then((win) => {
+        return new Cypress.Promise((resolve, reject) => {
+          wavesurfer = win.WaveSurfer.create({
+            container: '#waveform',
+            url: '../../examples/audio/demo.wav',
+            peaks: [[0, 0.5, -0.5, 0]],
+            duration: 21.77,
+          })
 
-        wavesurfer.once('ready', () => {
-          const media = wavesurfer.getMediaElement()
-
-          try {
-            expect(media.readyState).to.be.lessThan(HTMLMediaElement.HAVE_FUTURE_DATA)
-            wavesurfer.setTime(10)
-            expect(wavesurfer.getCurrentTime()).to.equal(10)
-          } catch (error) {
-            reject(error)
-            return
-          }
-
-          media.addEventListener(
-            'canplay',
-            async () => {
+          wavesurfer.once('ready', () => {
+            media = wavesurfer.getMediaElement()
+            const onCanPlay = () => {
               try {
                 expect(media.currentTime).to.be.closeTo(10, 0.01)
-                await wavesurfer.play()
-                setTimeout(() => {
-                  try {
-                    wavesurfer.pause()
-                    expect(media.currentTime).to.be.greaterThan(10)
-                    resolve()
-                  } catch (error) {
-                    reject(error)
-                  }
-                }, 200)
+                resolve()
               } catch (error) {
                 reject(error)
               }
-            },
-            { once: true },
-          )
+            }
+
+            media.addEventListener('canplay', onCanPlay, { once: true })
+
+            try {
+              expect(media.readyState).to.be.lessThan(HTMLMediaElement.HAVE_FUTURE_DATA)
+              wavesurfer.setTime(10)
+              expect(wavesurfer.getCurrentTime()).to.equal(10)
+            } catch (error) {
+              media.removeEventListener('canplay', onCanPlay)
+              reject(error)
+            }
+          })
         })
       })
-    })
+      .then(() => {
+        return wavesurfer.play()
+      })
+      .then(() => {
+        cy.wrap(null, { timeout: 5000 }).should(() => {
+          expect(media.currentTime).to.be.greaterThan(10)
+        })
+      })
   })
 })

--- a/cypress/e2e/player.cy.js
+++ b/cypress/e2e/player.cy.js
@@ -1,0 +1,52 @@
+describe('WaveSurfer player', () => {
+  it('preserves a seek requested from ready before media can play', () => {
+    cy.visit('cypress/e2e/player.html')
+    cy.window().its('WaveSurfer').should('exist')
+
+    cy.window().then((win) => {
+      return new Cypress.Promise((resolve, reject) => {
+        const wavesurfer = win.WaveSurfer.create({
+          container: '#waveform',
+          url: '../../examples/audio/demo.wav',
+          peaks: [[0, 0.5, -0.5, 0]],
+          duration: 21.77,
+        })
+
+        wavesurfer.once('ready', () => {
+          const media = wavesurfer.getMediaElement()
+
+          try {
+            expect(media.readyState).to.be.lessThan(HTMLMediaElement.HAVE_FUTURE_DATA)
+            wavesurfer.setTime(10)
+            expect(wavesurfer.getCurrentTime()).to.equal(10)
+          } catch (error) {
+            reject(error)
+            return
+          }
+
+          media.addEventListener(
+            'canplay',
+            async () => {
+              try {
+                expect(media.currentTime).to.be.closeTo(10, 0.01)
+                await wavesurfer.play()
+                setTimeout(() => {
+                  try {
+                    wavesurfer.pause()
+                    expect(media.currentTime).to.be.greaterThan(10)
+                    resolve()
+                  } catch (error) {
+                    reject(error)
+                  }
+                }, 200)
+              } catch (error) {
+                reject(error)
+              }
+            },
+            { once: true },
+          )
+        })
+      })
+    })
+  })
+})

--- a/cypress/e2e/player.html
+++ b/cypress/e2e/player.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WaveSurfer Player Test</title>
+  </head>
+  <body>
+    <div id="waveform"></div>
+
+    <script type="module">
+      import WaveSurfer from '../../dist/wavesurfer.js'
+
+      window.WaveSurfer = WaveSurfer
+    </script>
+  </body>
+</html>

--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -12,6 +12,10 @@ class TestPlayer extends Player<Events> {
   public replaceMedia(element: HTMLMediaElement) {
     this.setMediaElement(element)
   }
+
+  public dispose() {
+    this.destroy()
+  }
 }
 
 describe('Player', () => {
@@ -234,6 +238,7 @@ describe('Player', () => {
     media.dispatchEvent(new Event('canplay'))
 
     expect(currentTime).toBe(0)
+    expect(player.getCurrentTime()).toBe(0)
   })
 
   test('clears a pending seek when the media element changes', () => {
@@ -251,6 +256,31 @@ describe('Player', () => {
     replacement.dispatchEvent(new Event('canplay'))
 
     expect(replacement.currentTime).toBe(0)
+    expect(player.getCurrentTime()).toBe(0)
+  })
+
+  test('clears a pending seek when the player is destroyed', () => {
+    const media = createMedia()
+    let currentTime = 0
+    let readyState = 0
+    Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(media, 'readyState', { configurable: true, get: () => readyState })
+    Object.defineProperty(media, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (value: number) => {
+        currentTime = value
+      },
+    })
+
+    const player = new TestPlayer({ media })
+    player.setTime(10)
+    player.dispose()
+    readyState = 3
+    media.dispatchEvent(new Event('canplay'))
+
+    expect(currentTime).toBe(0)
+    expect(player.getCurrentTime()).toBe(0)
   })
 
   test('setSinkId uses media method', async () => {

--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -4,6 +4,16 @@ interface Events {
   [key: string]: unknown[]
 }
 
+class TestPlayer extends Player<Events> {
+  public setSource(url: string) {
+    this.setSrc(url)
+  }
+
+  public replaceMedia(element: HTMLMediaElement) {
+    this.setMediaElement(element)
+  }
+}
+
 describe('Player', () => {
   const createMedia = () => {
     const media = document.createElement('audio') as HTMLMediaElement & {
@@ -62,11 +72,89 @@ describe('Player', () => {
     expect(player.getCurrentTime()).toBe(10)
   })
 
-  test('reapplies a seek made before metadata immediately before playback', async () => {
+  test('defers a seek until canplay without assigning currentTime during loadedmetadata', () => {
     const media = createMedia()
     let currentTime = 0
+    let readyState = 0
+    const assignedTimes: number[] = []
     Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
-    Object.defineProperty(media, 'readyState', { configurable: true, value: 0 })
+    Object.defineProperty(media, 'readyState', { configurable: true, get: () => readyState })
+    Object.defineProperty(media, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (value: number) => {
+        assignedTimes.push(value)
+        currentTime = value
+      },
+    })
+
+    const player = new Player<Events>({ media })
+    player.setTime(10)
+    expect(assignedTimes).toEqual([])
+    expect(player.getCurrentTime()).toBe(10)
+
+    media.dispatchEvent(new Event('loadedmetadata'))
+    expect(assignedTimes).toEqual([])
+
+    readyState = 3
+    media.dispatchEvent(new Event('canplay'))
+    expect(assignedTimes).toEqual([10])
+    expect(currentTime).toBe(10)
+  })
+
+  test('applies only the latest seek requested before canplay', () => {
+    const media = createMedia()
+    let currentTime = 0
+    let readyState = 0
+    Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(media, 'readyState', { configurable: true, get: () => readyState })
+    Object.defineProperty(media, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (value: number) => {
+        currentTime = value
+      },
+    })
+
+    const player = new Player<Events>({ media })
+    player.setTime(10)
+    player.setTime(20)
+    readyState = 3
+    media.dispatchEvent(new Event('canplay'))
+
+    expect(currentTime).toBe(20)
+  })
+
+  test('does not overwrite an external seek made before canplay', () => {
+    const media = createMedia()
+    let currentTime = 0
+    let readyState = 0
+    Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(media, 'readyState', { configurable: true, get: () => readyState })
+    Object.defineProperty(media, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (value: number) => {
+        currentTime = value
+      },
+    })
+
+    const player = new Player<Events>({ media })
+    player.setTime(10)
+    currentTime = 20
+    media.dispatchEvent(new Event('seeking'))
+    readyState = 3
+    media.dispatchEvent(new Event('canplay'))
+
+    expect(currentTime).toBe(20)
+  })
+
+  test('applies a pending seek before play when the media is already playable', async () => {
+    const media = createMedia()
+    let currentTime = 0
+    let readyState = 0
+    Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(media, 'readyState', { configurable: true, get: () => readyState })
     Object.defineProperty(media, 'currentTime', {
       configurable: true,
       get: () => currentTime,
@@ -80,17 +168,57 @@ describe('Player', () => {
 
     const player = new Player<Events>({ media })
     player.setTime(10)
-    currentTime = 0 // iOS can discard a seek made before the media has metadata
+    readyState = 3
+
+    await player.play()
+
+    expect(currentTime).toBe(10)
+  })
+
+  test('applies a pending seek when play advances the media to canplay', async () => {
+    const media = createMedia()
+    let currentTime = 0
+    let readyState = 0
+    Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(media, 'readyState', { configurable: true, get: () => readyState })
+    Object.defineProperty(media, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (value: number) => {
+        currentTime = value
+      },
+    })
+    media.play.mockImplementation(async () => {
+      readyState = 3
+      media.dispatchEvent(new Event('canplay'))
+      expect(currentTime).toBe(10)
+    })
+
+    const player = new Player<Events>({ media })
+    player.setTime(10)
 
     await player.play()
     expect(currentTime).toBe(10)
   })
 
-  test('reapplies a pending seek when metadata becomes available', () => {
+  test('sets currentTime immediately when the media can play', () => {
+    const media = createMedia()
+    Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(media, 'readyState', { configurable: true, value: 3 })
+    Object.defineProperty(media, 'currentTime', { configurable: true, value: 0, writable: true })
+
+    const player = new Player<Events>({ media })
+    player.setTime(10)
+
+    expect(media.currentTime).toBe(10)
+  })
+
+  test('clears a pending seek when the source changes', () => {
     const media = createMedia()
     let currentTime = 0
+    let readyState = 0
     Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
-    Object.defineProperty(media, 'readyState', { configurable: true, value: 0 })
+    Object.defineProperty(media, 'readyState', { configurable: true, get: () => readyState })
     Object.defineProperty(media, 'currentTime', {
       configurable: true,
       get: () => currentTime,
@@ -99,12 +227,30 @@ describe('Player', () => {
       },
     })
 
-    const player = new Player<Events>({ media })
+    const player = new TestPlayer({ media })
     player.setTime(10)
-    currentTime = 0
-    media.dispatchEvent(new Event('loadedmetadata'))
+    player.setSource('https://example.com/replacement.mp3')
+    readyState = 3
+    media.dispatchEvent(new Event('canplay'))
 
-    expect(currentTime).toBe(10)
+    expect(currentTime).toBe(0)
+  })
+
+  test('clears a pending seek when the media element changes', () => {
+    const media = createMedia()
+    Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(media, 'readyState', { configurable: true, value: 0 })
+    const replacement = createMedia()
+    Object.defineProperty(replacement, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(replacement, 'readyState', { configurable: true, value: 3 })
+    Object.defineProperty(replacement, 'currentTime', { configurable: true, value: 0, writable: true })
+
+    const player = new TestPlayer({ media })
+    player.setTime(10)
+    player.replaceMedia(replacement)
+    replacement.dispatchEvent(new Event('canplay'))
+
+    expect(replacement.currentTime).toBe(0)
   })
 
   test('setSinkId uses media method', async () => {

--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -62,6 +62,51 @@ describe('Player', () => {
     expect(player.getCurrentTime()).toBe(10)
   })
 
+  test('reapplies a seek made before metadata immediately before playback', async () => {
+    const media = createMedia()
+    let currentTime = 0
+    Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(media, 'readyState', { configurable: true, value: 0 })
+    Object.defineProperty(media, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (value: number) => {
+        currentTime = value
+      },
+    })
+    media.play.mockImplementation(async () => {
+      expect(currentTime).toBe(10)
+    })
+
+    const player = new Player<Events>({ media })
+    player.setTime(10)
+    currentTime = 0 // iOS can discard a seek made before the media has metadata
+
+    await player.play()
+    expect(currentTime).toBe(10)
+  })
+
+  test('reapplies a pending seek when metadata becomes available', () => {
+    const media = createMedia()
+    let currentTime = 0
+    Object.defineProperty(media, 'duration', { configurable: true, value: 100 })
+    Object.defineProperty(media, 'readyState', { configurable: true, value: 0 })
+    Object.defineProperty(media, 'currentTime', {
+      configurable: true,
+      get: () => currentTime,
+      set: (value: number) => {
+        currentTime = value
+      },
+    })
+
+    const player = new Player<Events>({ media })
+    player.setTime(10)
+    currentTime = 0
+    media.dispatchEvent(new Event('loadedmetadata'))
+
+    expect(currentTime).toBe(10)
+  })
+
   test('setSinkId uses media method', async () => {
     const media = createMedia()
     const player = new Player<Events>({ media })

--- a/src/player.ts
+++ b/src/player.ts
@@ -9,6 +9,8 @@ type PlayerOptions = {
   playbackRate?: number
 }
 
+const HAVE_FUTURE_DATA = 3
+
 class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   protected media: HTMLMediaElement
   private isExternalMedia = false
@@ -22,7 +24,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   private _muted: WritableSignal<boolean>
   private _playbackRate: WritableSignal<number>
   private _seeking: WritableSignal<boolean>
-  // iOS can discard a media seek made before metadata is available.
+  // WebKit can discard or corrupt a seek made before the media can play.
   private pendingTime: number | null = null
   // Note: Player has no separate "root" scope of its own -- mediaScope IS its
   // whole ownership tree. (A wrapper root named `scope`, as a plain mechanical
@@ -169,15 +171,17 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     this.mediaScope.add(
       this.onMediaEvent('loadedmetadata', () => {
         this._duration.set(this.media.duration || 0)
-        if (this.pendingTime != null) {
-          this.media.currentTime = this.pendingTime
-        }
       }),
     )
+
+    this.mediaScope.add(this.onMediaEvent('canplay', () => this.applyPendingTime()))
 
     // Seeking state
     this.mediaScope.add(
       this.onMediaEvent('seeking', () => {
+        if (this.pendingTime != null && Math.abs(this.media.currentTime - this.pendingTime) > 0.01) {
+          this.pendingTime = null
+        }
         this._seeking.set(true)
       }),
     )
@@ -233,6 +237,13 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     return this.media.canPlayType(type) !== ''
   }
 
+  private applyPendingTime(): void {
+    if (this.pendingTime == null) return
+    const time = this.pendingTime
+    this.media.currentTime = time
+    this.pendingTime = null
+  }
+
   protected setSrc(url: string, blob?: Blob) {
     const prevSrc = this.getSrc()
     if (url && prevSrc === url) return // no need to change the source
@@ -261,6 +272,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   }
 
   protected destroy() {
+    this.pendingTime = null
     // Cleanup reactive media event listeners
     this.mediaScope.dispose()
     // Player instances are reused after destroy (see WaveSurfer's loadAudio
@@ -292,6 +304,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   }
 
   protected setMediaElement(element: HTMLMediaElement) {
+    this.pendingTime = null
     // Cleanup reactive event listeners from old media element
     this.mediaScope.dispose()
     this.mediaScope = new Scope()
@@ -314,11 +327,11 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   /** Start playing the audio */
   public async play(): Promise<void> {
     try {
-      if (this.pendingTime != null) {
-        this.media.currentTime = this.pendingTime
-      }
+      if (this.media.readyState >= HAVE_FUTURE_DATA) this.applyPendingTime()
       const result = await this.media.play()
-      this.pendingTime = null
+      // A resolved play promise means playback is possible. `canplay` normally
+      // applies the seek first; this also supports custom media implementations.
+      this.applyPendingTime()
       return result
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') {
@@ -341,8 +354,12 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   /** Jump to a specific time in the audio (in seconds) */
   public setTime(time: number) {
     const currentTime = Math.max(0, Math.min(time, this.getDuration()))
+    if (this.media.readyState < HAVE_FUTURE_DATA) {
+      this.pendingTime = currentTime
+      return
+    }
+    this.pendingTime = null
     this.media.currentTime = currentTime
-    this.pendingTime = this.media.readyState < 1 ? currentTime : null
   }
 
   /** Get the duration of the audio in seconds */
@@ -352,7 +369,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
 
   /** Get the current audio position in seconds */
   public getCurrentTime(): number {
-    return this.media.currentTime
+    return this.pendingTime ?? this.media.currentTime
   }
 
   /** Get the audio volume */

--- a/src/player.ts
+++ b/src/player.ts
@@ -22,6 +22,8 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   private _muted: WritableSignal<boolean>
   private _playbackRate: WritableSignal<number>
   private _seeking: WritableSignal<boolean>
+  // iOS can discard a media seek made before metadata is available.
+  private pendingTime: number | null = null
   // Note: Player has no separate "root" scope of its own -- mediaScope IS its
   // whole ownership tree. (A wrapper root named `scope`, as a plain mechanical
   // reading of the plan might suggest, would collide with WaveSurfer's own
@@ -167,6 +169,9 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
     this.mediaScope.add(
       this.onMediaEvent('loadedmetadata', () => {
         this._duration.set(this.media.duration || 0)
+        if (this.pendingTime != null) {
+          this.media.currentTime = this.pendingTime
+        }
       }),
     )
 
@@ -234,6 +239,7 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
 
     this.revokeSrc()
     const newSrc = blob instanceof Blob && (this.canPlayType(blob.type) || !url) ? URL.createObjectURL(blob) : url
+    this.pendingTime = null
 
     // Track blob URLs we created so we can revoke them on destroy
     if (newSrc !== url) {
@@ -308,7 +314,12 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
   /** Start playing the audio */
   public async play(): Promise<void> {
     try {
-      return await this.media.play()
+      if (this.pendingTime != null) {
+        this.media.currentTime = this.pendingTime
+      }
+      const result = await this.media.play()
+      this.pendingTime = null
+      return result
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') {
         return
@@ -329,7 +340,9 @@ class Player<T extends GeneralEventTypes> extends EventEmitter<T> {
 
   /** Jump to a specific time in the audio (in seconds) */
   public setTime(time: number) {
-    this.media.currentTime = Math.max(0, Math.min(time, this.getDuration()))
+    const currentTime = Math.max(0, Math.min(time, this.getDuration()))
+    this.media.currentTime = currentTime
+    this.pendingTime = this.media.readyState < 1 ? currentTime : null
   }
 
   /** Get the duration of the audio in seconds */


### PR DESCRIPTION
## Short description

Addresses the pre-playback MediaElement seek path reported in #4043.

WebKit has open defects where assigning `currentTime` during `loadedmetadata` can start playback at zero and leave seeking unusable ([WebKit #261512](https://bugs.webkit.org/show_bug.cgi?id=261512), [WebKit #201216](https://bugs.webkit.org/show_bug.cgi?id=201216)). This change avoids that unsafe timing window: an early WaveSurfer seek remains visible through `getCurrentTime()`, then reaches the native media element once it emits `canplay`.

The previous head passed all required checks. This test-only follow-up is ready for review, and its new fork workflows are awaiting repository approval. Physical iOS confirmation of the original scenario remains welcome as an additional validation.

## Implementation details

- Keeps only the latest seek requested before `HAVE_FUTURE_DATA`.
- Applies the pending time on `canplay`, immediately before playback when already playable, or after a resolved custom-media `play()` fallback.
- Avoids assigning `currentTime` from `loadedmetadata`.
- Cancels a stale pending value when an external seek chooses a different time.
- Clears pending state when the source, media element, or player lifecycle changes.
- Preserves immediate seeks for already-playable and WebAudio-backed media.

## Regression coverage

Unit tests cover:

- no native assignment during `loadedmetadata`
- application at `canplay`
- latest-request-wins behavior
- external seek cancellation
- play-before-`canplay` and already-playable paths
- source and media-element replacement
- existing stop-position clamping behavior

A focused Cypress test uses precomputed peaks so `ready` fires before the media can play, registers `canplay` before calling `setTime(10)`, verifies the deferred seek reaches the media element, then uses a retrying assertion to confirm playback advances from the requested position. The WaveSurfer instance is destroyed after each test.

## Verification

- `yarn test:unit --runInBand`: 39 suites, 580 tests passed
- leak suite: 7 tests passed
- `yarn tsc`: passed
- `yarn lint`: passed
- Prettier check: passed
- focused Cypress regression: passed repeatedly in Edge 151 and Electron 118
- additional local Player probe: passed 5/5 in Playwright WebKit

`yarn build` emits the main ESM, CJS, and minified bundles, then hits the repository's existing Windows Rollup plugin path constraint: the TypeScript `outDir` is outside the plugin output directory.

## Screenshots

Not applicable. This changes media timing behavior and adds automated browser coverage.

## Checklist

- [x] This PR is covered by e2e tests
- [x] It introduces no breaking API changes