### PR TITLE
fix!: v8 pre-release R6 minor findings across core, renderer, plugins, and spectrogram

### DIFF
--- a/V8_REFACTORING_SPEC.md
+++ b/V8_REFACTORING_SPEC.md
@@ -307,8 +307,13 @@ before or alongside the refactors above, ordered by severity.
 - `createBuffer`'s fake AudioBuffer has `copyFrom/ToChannel` methods that throw
   "Illegal invocation" (`decoder.ts:71-72`) — implement or drop for v8.
 - `empty()` is fire-and-forget → unhandled rejection path (`wavesurfer.ts:895-897`).
-- **Superseded `load()` resolves as success** — decide consciously for v8: rejecting
-  with a canonical `AbortError` is more conventional than silently fulfilling.
+- **Superseded `load()` resolves as success** — decided for v8: a `load()` superseded
+  by a newer `load()`/`loadBlob()` on a live instance now rejects with a canonical
+  `AbortError` (`DOMException`, name `'AbortError'`). No public `'error'` event is
+  emitted for supersession (it is normal control flow, unlike destroy-mid-load, which
+  keeps rejecting AND emitting `'error'` per #3637/abort.cy.js); an internal no-op
+  rejection handler is attached to the returned promise so fire-and-forget callers get
+  no unhandled-rejection noise, while awaiting callers still observe the rejection.
 - `BasePlugin` exposes `scope` but `BasePlugin.destroy()` never disposes it — a
   third-party class plugin using `this.scope.listen()` with inherited destroy leaks
   everything (`base-plugin.ts:22, 49-59`). Dispose it in `BasePlugin.destroy()` (safe:

--- a/V8_REFACTORING_SPEC.md
+++ b/V8_REFACTORING_SPEC.md
@@ -152,6 +152,8 @@ interface PlaybackBackend {
   export surface; it was never a documented entry point).
 - Protected internals (`this.media` etc.) disappear for subclassers — subclassing
   WaveSurfer was never supported; plugins are the extension mechanism.
+- v7's `vertical` option no longer exists in `WaveSurferOptions` — there is no v8
+  replacement; rotate the container via CSS if a vertical waveform is needed.
 
 ---
 

--- a/src/__tests__/decoder.test.ts
+++ b/src/__tests__/decoder.test.ts
@@ -38,4 +38,98 @@ describe('Decoder', () => {
     await expect(Decoder.decode(new ArrayBuffer(0), 8_000)).resolves.toBe(audioBuffer)
     expect(close).not.toHaveBeenCalled()
   })
+
+  describe('createBuffer normalization', () => {
+    test('normalizes all channels by the global max across channels, not channel 0 alone', () => {
+      const buffer = Decoder.createBuffer(
+        [
+          [1, 2],
+          [4, -1],
+        ],
+        2,
+      )
+
+      // Global max is 4 (in channel 1); scaling by channel 0's max (2) would
+      // leave channel 1 outside -1..1.
+      expect(Array.from(buffer.getChannelData(0))).toEqual([0.25, 0.5])
+      expect(Array.from(buffer.getChannelData(1))).toEqual([1, -0.25])
+    })
+
+    test('normalizes when only a non-first channel exceeds -1..1', () => {
+      const buffer = Decoder.createBuffer(
+        [
+          [0.5, -0.5],
+          [2, 1],
+        ],
+        2,
+      )
+
+      // Channel 0 is within range; deciding from channel 0 alone would skip
+      // normalization entirely and leave channel 1 out of range.
+      expect(Array.from(buffer.getChannelData(0))).toEqual([0.25, -0.25])
+      expect(Array.from(buffer.getChannelData(1))).toEqual([1, 0.5])
+    })
+
+    test('does not mutate the caller-owned peaks arrays', () => {
+      const channel0 = [1, 2]
+      const channel1 = Float32Array.from([4, -1])
+
+      Decoder.createBuffer([channel0, channel1], 2)
+
+      expect(channel0).toEqual([1, 2])
+      expect(Array.from(channel1)).toEqual([4, -1])
+    })
+
+    test('leaves data already within -1..1 unscaled', () => {
+      const buffer = Decoder.createBuffer([[0.5, -1, 0.25]], 3)
+      expect(Array.from(buffer.getChannelData(0))).toEqual([0.5, -1, 0.25])
+    })
+  })
+
+  describe('createBuffer copyFromChannel/copyToChannel', () => {
+    test('copyFromChannel copies channel data into the destination', () => {
+      const buffer = Decoder.createBuffer([[0, 0.25, 0.5, 0.75]], 1)
+      const destination = new Float32Array(4)
+
+      buffer.copyFromChannel(destination, 0)
+
+      expect(Array.from(destination)).toEqual([0, 0.25, 0.5, 0.75])
+    })
+
+    test('copyFromChannel respects bufferOffset and the shorter of the two lengths', () => {
+      const buffer = Decoder.createBuffer([[0, 0.25, 0.5, 0.75]], 1)
+
+      const short = new Float32Array(2)
+      buffer.copyFromChannel(short, 0, 1)
+      expect(Array.from(short)).toEqual([0.25, 0.5])
+
+      const long = new Float32Array(4)
+      buffer.copyFromChannel(long, 0, 2)
+      // Only the two remaining frames are copied; the rest stays untouched
+      expect(Array.from(long)).toEqual([0.5, 0.75, 0, 0])
+    })
+
+    test('copyToChannel writes the source into the channel at bufferOffset', () => {
+      const buffer = Decoder.createBuffer([[0, 0, 0, 0]], 1)
+
+      buffer.copyToChannel(Float32Array.from([0.25, 0.5]), 0, 1)
+
+      expect(Array.from(buffer.getChannelData(0))).toEqual([0, 0.25, 0.5, 0])
+    })
+
+    test('copyToChannel truncates a source longer than the remaining channel space', () => {
+      const buffer = Decoder.createBuffer([[0, 0, 0]], 1)
+
+      buffer.copyToChannel(Float32Array.from([0.25, 0.5, 0.75]), 0, 2)
+
+      expect(Array.from(buffer.getChannelData(0))).toEqual([0, 0, 0.25])
+    })
+
+    test('copyFromChannel and copyToChannel throw for a missing channel', () => {
+      const buffer = Decoder.createBuffer([[0, 0]], 1)
+
+      expect(() => buffer.copyFromChannel(new Float32Array(2), 1)).toThrow(/Channel 1/)
+      expect(() => buffer.copyToChannel(new Float32Array(2), 1)).toThrow(/Channel 1/)
+    })
+  })
 })

--- a/src/__tests__/dom.test.ts
+++ b/src/__tests__/dom.test.ts
@@ -6,7 +6,15 @@ describe('isHTMLElement', () => {
   })
 
   test('accepts element-like objects from another realm (e.g. an iframe)', () => {
-    const foreign = { nodeType: 1, style: {} }
+    // A realistic cross-realm HTML element: `instanceof HTMLElement` fails,
+    // but the core element traits are all present.
+    const foreign = {
+      nodeType: 1,
+      nodeName: 'DIV',
+      namespaceURI: 'http://www.w3.org/1999/xhtml',
+      style: {},
+      appendChild: () => undefined,
+    }
     expect(isHTMLElement(foreign)).toBe(true)
   })
 
@@ -16,6 +24,24 @@ describe('isHTMLElement', () => {
     expect(isHTMLElement('#container')).toBe(false)
     expect(isHTMLElement({})).toBe(false)
     expect(isHTMLElement(document.createTextNode('text'))).toBe(false)
+  })
+
+  test('rejects SVG elements (not HTML, even though they have nodeType 1 and style)', () => {
+    expect(isHTMLElement(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))).toBe(false)
+  })
+
+  test('rejects element-shaped objects missing core element traits', () => {
+    // The old check accepted any {nodeType: 1, style: object} bag.
+    expect(isHTMLElement({ nodeType: 1, style: {} })).toBe(false)
+    expect(
+      isHTMLElement({
+        nodeType: 1,
+        nodeName: 'DIV',
+        namespaceURI: 'http://www.w3.org/1999/xhtml',
+        style: null, // typeof null === 'object' slipped through the old check
+        appendChild: () => undefined,
+      }),
+    ).toBe(false)
   })
 })
 

--- a/src/__tests__/envelope-leaks.test.ts
+++ b/src/__tests__/envelope-leaks.test.ts
@@ -2,50 +2,7 @@ import EnvelopePlugin from '../plugins/envelope.js'
 import { Scope } from '../scope.js'
 import { createEmitter } from './helpers/create-emitter.js'
 import { installMatchMediaStub } from './helpers/match-media.js'
-
-// jsdom implements almost none of the SVG geometry APIs envelope.ts relies on
-// (SVGSVGElement.viewBox, SVGSVGElement.createSVGPoint, SVGPointList). Stub
-// just enough of them, on the specific svg/polyline instances Polyline
-// creates, for addPolyPoint/removePolyPoint to run through their real logic.
-class FakeSvgPointList {
-  private items: { x: number; y: number }[]
-  constructor(initial: { x: number; y: number }[]) {
-    this.items = initial
-  }
-  get numberOfItems() {
-    return this.items.length
-  }
-  getItem(i: number) {
-    return this.items[i]
-  }
-  insertItemBefore(item: { x: number; y: number }, index: number) {
-    this.items.splice(index, 0, item)
-    return item
-  }
-  removeItem(index: number) {
-    return this.items.splice(index, 1)[0]
-  }
-  [Symbol.iterator]() {
-    return this.items[Symbol.iterator]()
-  }
-}
-
-const mockSvgGeometry = (svg: SVGSVGElement, width = 100, height = 100) => {
-  Object.defineProperty(svg, 'viewBox', {
-    configurable: true,
-    value: { baseVal: { width, height } },
-  })
-  ;(svg as any).createSVGPoint = () => ({ x: 0, y: 0 })
-
-  const polylineEl = svg.querySelector('polyline') as SVGPolylineElement
-  Object.defineProperty(polylineEl, 'points', {
-    configurable: true,
-    value: new FakeSvgPointList([
-      { x: 0, y: height },
-      { x: width, y: height },
-    ]),
-  })
-}
+import { mockSvgGeometry } from './helpers/svg-geometry.js'
 
 // EnvelopePlugin now only reaches its 'decode'/'redraw'/'timeupdate' wiring
 // through ctx.wavesurfer.on(...) registered inside setup() — which only runs

--- a/src/__tests__/envelope.test.ts
+++ b/src/__tests__/envelope.test.ts
@@ -1,6 +1,7 @@
 import EnvelopePlugin from '../plugins/envelope.js'
 import { createEmitter } from './helpers/create-emitter.js'
 import { installMatchMediaStub } from './helpers/match-media.js'
+import { mockSvgGeometry } from './helpers/svg-geometry.js'
 
 // Only the slice of WaveSurfer that EnvelopePlugin's volume path reads. The polyline is never
 // built here (that needs 'decode' plus the SVG geometry jsdom lacks — see envelope-leaks.test.ts);
@@ -95,5 +96,87 @@ describe('EnvelopePlugin volume interpolation', () => {
     ws.emit('timeupdate', 0)
 
     expect(ws.setVolume).not.toHaveBeenCalledWith(NaN)
+  })
+})
+
+describe('EnvelopePlugin initialization and options', () => {
+  beforeAll(() => {
+    installMatchMediaStub()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // A plugin registered AFTER the audio has already been decoded never gets a
+  // 'decode' event, so without an "already decoded" init path (like the one
+  // minimap/timeline have) its UI never rendered.
+  it('renders its UI on init when the audio is already decoded', () => {
+    const ws = {
+      ...createWaveSurfer(10),
+      getDecodedData: () => ({ duration: 10 }),
+    }
+    const plugin = EnvelopePlugin.create({ points: [] })
+    plugin._init(ws as any)
+
+    expect(ws.getWrapper().querySelector('[part="envelope"]')).not.toBeNull()
+  })
+
+  it('does not render the polyline UI before the audio is decoded', () => {
+    const ws = createWaveSurfer(0)
+    const plugin = EnvelopePlugin.create({ points: [] })
+    plugin._init(ws as any)
+
+    expect(ws.getWrapper().querySelector('[part="envelope"]')).toBeNull()
+  })
+
+  // `||` option fallbacks made falsy option values unusable: dragPointSize: 0
+  // (hidden drag points) silently fell back to the default of 10.
+  it('respects dragPointSize: 0 instead of falling back to the default', () => {
+    const ws = createWaveSurfer(10)
+    const plugin = EnvelopePlugin.create({ points: [], dragPointSize: 0 })
+    plugin._init(ws as any)
+    ws.emit('decode', 10)
+
+    const svg = ws.getWrapper().querySelector('svg') as SVGSVGElement
+    mockSvgGeometry(svg)
+
+    plugin.addPoint({ time: 5, volume: 0.5 })
+
+    const circle = svg.querySelector('ellipse') as SVGEllipseElement
+    expect(circle).toBeTruthy()
+    expect(circle.getAttribute('rx')).toBe('0')
+  })
+
+  // Post-destroy contract (matches core WaveSurfer): public mutators silently
+  // no-op after destroy instead of still mutating closure state.
+  it('makes public mutators silent no-ops after destroy', () => {
+    const ws = createWaveSurfer(10)
+    const plugin = EnvelopePlugin.create({ points: [] })
+    plugin._init(ws as any)
+    ws.emit('decode', 10)
+
+    const svg = ws.getWrapper().querySelector('svg') as SVGSVGElement
+    mockSvgGeometry(svg)
+
+    const point = { time: 2, volume: 0.4 }
+    plugin.addPoint(point)
+    expect(plugin.getPoints()).toHaveLength(1)
+    expect(plugin.getCurrentVolume()).toBe(1)
+
+    plugin.destroy()
+
+    plugin.addPoint({ time: 5, volume: 0.5 })
+    expect(plugin.getPoints()).toHaveLength(1)
+
+    plugin.removePoint(point)
+    expect(plugin.getPoints()).toHaveLength(1)
+
+    plugin.setPoints([{ time: 1, volume: 0.1 }])
+    expect(plugin.getPoints()).toHaveLength(1)
+    expect(plugin.getPoints()[0]).toBe(point)
+
+    plugin.setVolume(0.3)
+    expect(plugin.getCurrentVolume()).toBe(1)
   })
 })

--- a/src/__tests__/fft.test.ts
+++ b/src/__tests__/fft.test.ts
@@ -89,3 +89,40 @@ describe('FFT window construction', () => {
     expect(explicitZero.windowValues[10]).not.toBe(defaulted.windowValues[10])
   })
 })
+
+describe('lanczoz window', () => {
+  const SAMPLE_RATE = 16000
+
+  it('produces finite values (sinc(0) = 1) for odd window lengths', () => {
+    // Odd lengths are reachable via the fftSize decoupling (fftSamples may be any integer from
+    // 2 to fftSize). At the center sample of an odd window the raw sin(pi*x)/(pi*x) formula
+    // hits x = 0, i.e. 0/0 = NaN, which propagates through every frame into a blank spectrogram.
+    const windowLength = 65
+    const fft = new (FFT as any)(512, SAMPLE_RATE, 'lanczoz', undefined, windowLength)
+
+    const live = Array.from(fft.windowValues.slice(0, windowLength)) as number[]
+    expect(live.every(Number.isFinite)).toBe(true)
+    // The center sample is sinc(0) = 1, times the bufferSize / windowLength zero-pad
+    // calibration (Float32 storage, hence the reduced precision)
+    expect(fft.windowValues[(windowLength - 1) / 2]).toBeCloseTo(512 / windowLength, 6)
+  })
+
+  it('yields a finite spectrum (not NaN-blank) for an odd-length lanczoz window', () => {
+    const fft = new (FFT as any)(64, SAMPLE_RATE, 'lanczoz', undefined, 63)
+    const frame = new Float32Array(64)
+    frame.set(makeSine(63, 1000, SAMPLE_RATE))
+
+    const spectrum = fft.calculateSpectrum(frame)
+
+    expect(Array.from(spectrum).every(Number.isFinite)).toBe(true)
+  })
+
+  it('keeps even-length lanczoz windows on the raw sinc formula (Float32 precision)', () => {
+    const windowLength = 64
+    const fft = new (FFT as any)(windowLength, SAMPLE_RATE, 'lanczoz', undefined)
+    for (let i = 0; i < windowLength; i++) {
+      const x = (2 * i) / (windowLength - 1) - 1
+      expect(fft.windowValues[i]).toBeCloseTo(Math.sin(Math.PI * x) / (Math.PI * x), 6)
+    }
+  })
+})

--- a/src/__tests__/frame-scheduler.test.ts
+++ b/src/__tests__/frame-scheduler.test.ts
@@ -77,6 +77,43 @@ describe('FrameScheduler', () => {
     expect(() => scheduler.stop()).not.toThrow()
   })
 
+  it('a throwing callback does not kill the loop: the next frame is scheduled before the callback runs', () => {
+    const scope = new Scope()
+    const scheduler = new FrameScheduler(scope)
+    let calls = 0
+    const tick = jest.fn(() => {
+      calls++
+      if (calls === 2) throw new Error('subscriber boom')
+    })
+
+    scheduler.start(tick) // synchronous first tick: calls = 1
+
+    // The second tick throws. The error must still surface (not be swallowed)...
+    expect(() => (global as any).__flushFrames(1)).toThrow('subscriber boom')
+    expect(calls).toBe(2)
+
+    // ...but the loop must survive: the next frame was scheduled before the
+    // callback ran, so ticking continues and the scheduler is still running.
+    ;(global as any).__flushFrames(2)
+    expect(calls).toBe(4)
+    expect(scheduler.running).toBe(true)
+
+    scheduler.stop()
+    ;(global as any).__flushFrames(1)
+    expect(calls).toBe(4)
+  })
+
+  it('stop() called from inside the callback cancels the frame scheduled for that tick', () => {
+    const scope = new Scope()
+    const scheduler = new FrameScheduler(scope)
+    const tick = jest.fn(() => scheduler.stop())
+
+    scheduler.start(tick) // synchronous first tick calls stop()
+    expect(scheduler.running).toBe(false)
+    ;(global as any).__flushFrames(2)
+    expect(tick).toHaveBeenCalledTimes(1)
+  })
+
   it('restarts cleanly after stop: a fresh synchronous first tick, then RAF ticks resume', () => {
     const scope = new Scope()
     const scheduler = new FrameScheduler(scope)

--- a/src/__tests__/helpers/svg-geometry.ts
+++ b/src/__tests__/helpers/svg-geometry.ts
@@ -1,0 +1,45 @@
+/**
+ * jsdom implements almost none of the SVG geometry APIs envelope.ts relies on
+ * (SVGSVGElement.viewBox, SVGSVGElement.createSVGPoint, SVGPointList). Stub
+ * just enough of them, on the specific svg/polyline instances Polyline
+ * creates, for addPolyPoint/removePolyPoint to run through their real logic.
+ */
+export class FakeSvgPointList {
+  private items: { x: number; y: number }[]
+  constructor(initial: { x: number; y: number }[]) {
+    this.items = initial
+  }
+  get numberOfItems() {
+    return this.items.length
+  }
+  getItem(i: number) {
+    return this.items[i]
+  }
+  insertItemBefore(item: { x: number; y: number }, index: number) {
+    this.items.splice(index, 0, item)
+    return item
+  }
+  removeItem(index: number) {
+    return this.items.splice(index, 1)[0]
+  }
+  [Symbol.iterator]() {
+    return this.items[Symbol.iterator]()
+  }
+}
+
+export const mockSvgGeometry = (svg: SVGSVGElement, width = 100, height = 100) => {
+  Object.defineProperty(svg, 'viewBox', {
+    configurable: true,
+    value: { baseVal: { width, height } },
+  })
+  ;(svg as unknown as { createSVGPoint: () => { x: number; y: number } }).createSVGPoint = () => ({ x: 0, y: 0 })
+
+  const polylineEl = svg.querySelector('polyline') as SVGPolylineElement
+  Object.defineProperty(polylineEl, 'points', {
+    configurable: true,
+    value: new FakeSvgPointList([
+      { x: 0, y: height },
+      { x: width, y: height },
+    ]),
+  })
+}

--- a/src/__tests__/hover.test.ts
+++ b/src/__tests__/hover.test.ts
@@ -75,6 +75,24 @@ describe('HoverPlugin', () => {
     expect(formatTimeCallback).toHaveBeenCalledTimes(1)
   })
 
+  test('positions the hover line with a string lineWidth instead of producing NaN math', () => {
+    const container = document.createElement('div')
+    const { wavesurfer } = createWaveSurfer(container, 10)
+
+    const plugin = HoverPlugin.create({ lineWidth: '2px' })
+    plugin._init(wavesurfer as any)
+
+    // width is 100 (see createWaveSurfer); posX = min(100 - 2 - 1, 99) = 97.
+    // With the documented string form, `100 - '2px' - 1` is NaN and the line
+    // was positioned at translateX(NaNpx).
+    container.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 99 }))
+
+    const hover = container.querySelector<HTMLElement>('[part="hover"]')
+    expect(hover?.style.transform).toBe('translateX(97px)')
+    // The CSS border still uses the string verbatim
+    expect(hover?.style.borderLeft).toContain('2px')
+  })
+
   test('does not accumulate transitionend listeners across pointerleave events', () => {
     const container = document.createElement('div')
     const { wavesurfer } = createWaveSurfer(container, 10)

--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -279,6 +279,26 @@ describe('Player', () => {
     expect(player.getCurrentTime()).toBe(0)
   })
 
+  test("the playbackRate 'canplay' listener does not survive destroy with external media", () => {
+    const media = createMedia()
+    let playbackRate = 1
+    Object.defineProperty(media, 'playbackRate', {
+      configurable: true,
+      get: () => playbackRate,
+      set: (value: number) => {
+        playbackRate = value
+      },
+    })
+
+    const player = new Player({ media, playbackRate: 2 })
+    player.destroy()
+
+    // The external media element outlives the player; the one-shot 'canplay'
+    // playbackRate listener must have been torn down with mediaScope.
+    media.dispatchEvent(new Event('canplay'))
+    expect(playbackRate).toBe(1)
+  })
+
   test('setSinkId uses media method', async () => {
     const media = createMedia()
     const player = new Player({ media })

--- a/src/__tests__/regions.test.ts
+++ b/src/__tests__/regions.test.ts
@@ -196,6 +196,146 @@ describe('RegionsPlugin', () => {
   })
 })
 
+describe('Region length constraints during drag-creation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    installMatchMediaStub()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    document.body.innerHTML = ''
+    jest.clearAllMocks()
+  })
+
+  test('enforces maxLength while a region is being drag-created', () => {
+    const wavesurfer = createWaveSurfer(10)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const regionsContainer = wavesurfer.getWrapper().querySelector<HTMLElement>('[part="regions-container"]')!
+    mockRect(regionsContainer, { left: 0, top: 0, width: 100, height: 100 })
+
+    const region = plugin.addRegion({ start: 1, end: 1.2, maxLength: 2 })
+    jest.runOnlyPendingTimers()
+    expect(region.element?.parentElement).toBe(regionsContainer)
+
+    // Simulate a creation-drag update (+40px = +4s at width 100 / duration 10).
+    // The creation flow passes a startTime, which used to bypass min/maxLength
+    // entirely and let the region grow to 4.2s despite maxLength: 2.
+    region._onUpdate(40, 'end', 1)
+
+    expect(region.end - region.start).toBeLessThanOrEqual(2)
+  })
+
+  test('enforces minLength when a drag-created region is finalized', () => {
+    const wavesurfer = createWaveSurfer(10)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const wrapper = wavesurfer.getWrapper()
+    mockRect(wrapper, { left: 0, top: 0, width: 100, height: 100 })
+    const regionsContainer = wrapper.querySelector<HTMLElement>('[part="regions-container"]')!
+    mockRect(regionsContainer, { left: 0, top: 0, width: 100, height: 100 })
+
+    const created: Array<{ start: number; end: number }> = []
+    plugin.on('region-created', (region) => created.push(region))
+
+    plugin.enableDragSelection({ minLength: 2 })
+
+    // Drag from x=10 to x=14 (0.4s worth of drag at width 100 / duration 10):
+    // far below minLength: 2.
+    wrapper.dispatchEvent(new MouseEvent('pointerdown', { clientX: 10, clientY: 10, bubbles: true }))
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 14, clientY: 10 }))
+    document.dispatchEvent(new MouseEvent('pointerup', { clientX: 14, clientY: 10 }))
+
+    expect(created).toHaveLength(1)
+    const region = created[0]
+    expect(region.end - region.start).toBeGreaterThanOrEqual(2 - 1e-9)
+  })
+})
+
+describe('Region setOptions shape changes', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    installMatchMediaStub()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    document.body.innerHTML = ''
+    jest.clearAllMocks()
+  })
+
+  test('re-renders marker/region styling when setOptions changes the shape', () => {
+    const wavesurfer = createWaveSurfer(10)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const color = 'rgba(0, 128, 0, 0.5)'
+    const region = plugin.addRegion({ start: 2, end: 2, color }) // marker
+    const element = region.element!
+
+    expect(element.style.borderLeft).toContain('2px solid')
+    expect(element.querySelectorAll('[part*="region-handle"]').length).toBe(0)
+
+    // Marker -> range: must pick up the region background, drop the marker
+    // border, and gain resize handles.
+    region.setOptions({ start: 2, end: 4 })
+    expect(element.style.backgroundColor).toBe(color)
+    expect(element.style.borderLeft === 'none' || element.style.borderLeft === '').toBe(true)
+    expect(element.querySelectorAll('[part*="region-handle"]').length).toBe(2)
+
+    // Range -> marker: back to marker styling, resize handles removed.
+    region.setOptions({ start: 3, end: 3 })
+    expect(element.style.borderLeft).toContain('2px solid')
+    expect(element.style.backgroundColor).toBe('')
+    expect(element.querySelectorAll('[part*="region-handle"]').length).toBe(0)
+  })
+})
+
+describe('RegionsPlugin post-destroy API', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    installMatchMediaStub()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    document.body.innerHTML = ''
+    jest.clearAllMocks()
+  })
+
+  // Post-destroy contract (matches core WaveSurfer): public mutators silently
+  // no-op after destroy — addRegion used to throw.
+  test('addRegion after destroy is a silent no-op instead of throwing', () => {
+    const wavesurfer = createWaveSurfer(10)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+    plugin.destroy()
+
+    let region: ReturnType<typeof plugin.addRegion> | undefined
+    expect(() => {
+      region = plugin.addRegion({ start: 1, end: 2 })
+    }).not.toThrow()
+
+    expect(region?.element).toBeNull()
+    expect(plugin.getRegions()).toHaveLength(0)
+    expect(document.querySelector('[part~="region"]')).toBeNull()
+
+    // The rest of the public api already conformed — pin it.
+    expect(() => {
+      const disable = plugin.enableDragSelection({})
+      disable()
+      plugin.clearRegions()
+    }).not.toThrow()
+    expect(plugin.getRegions()).toHaveLength(0)
+  })
+})
+
 describe('Region drag against the waveform edges', () => {
   beforeEach(() => {
     jest.useFakeTimers()

--- a/src/__tests__/renderer-utils.test.ts
+++ b/src/__tests__/renderer-utils.test.ts
@@ -18,6 +18,7 @@ import {
   resolveBarYPosition,
   resolveChannelHeight,
   resolveColorValue,
+  roundToHalfAwayFromZero,
   shouldClearCanvases,
   shouldRenderBars,
   sliceChannelData,
@@ -31,6 +32,12 @@ describe('renderer-utils', () => {
       expect(clampToUnit(-0.5)).toBe(0)
       expect(clampToUnit(0.3)).toBe(0.3)
       expect(clampToUnit(1.8)).toBe(1)
+    })
+
+    it('maps NaN to 0 instead of passing it through', () => {
+      // NaN reaches clampToUnit when pointer math divides by a zero-size
+      // rect (hidden container) -- it must not propagate into seeks.
+      expect(clampToUnit(NaN)).toBe(0)
     })
   })
 
@@ -220,6 +227,16 @@ describe('renderer-utils', () => {
       } as DOMRect
       expect(getRelativePointerPosition(rect, 110, 70)).toEqual([0.5, 0.5])
     })
+
+    it('returns finite coordinates for a zero-size rect (hidden container)', () => {
+      const rect = {
+        left: 10,
+        top: 20,
+        width: 0,
+        height: 0,
+      } as DOMRect
+      expect(getRelativePointerPosition(rect, 110, 70)).toEqual([0, 0])
+    })
   })
 
   describe('resolveChannelHeight', () => {
@@ -280,18 +297,18 @@ describe('renderer-utils', () => {
   })
 
   describe('resolveColorValue', () => {
-    const canvas = document.createElement('canvas')
-
     let createLinearGradient: jest.Mock
     let addColorStop: jest.Mock
 
+    // Mock getContext at the prototype level (not on one specific canvas):
+    // resolveColorValue reuses a single module-level scratch canvas across
+    // calls, so a per-instance spy on a freshly created element would never
+    // be hit again after the first call cached the scratch canvas.
     beforeEach(() => {
-      createLinearGradient = jest.fn(() => ({ addColorStop }))
       addColorStop = jest.fn()
-
-      jest.spyOn(document, 'createElement').mockImplementation(() => canvas)
+      createLinearGradient = jest.fn(() => ({ addColorStop }))
       jest
-        .spyOn(canvas, 'getContext')
+        .spyOn(window.HTMLCanvasElement.prototype, 'getContext')
         .mockImplementation(() => ({ createLinearGradient }) as unknown as CanvasRenderingContext2D)
     })
 
@@ -318,6 +335,24 @@ describe('renderer-utils', () => {
       expect(addColorStop).toHaveBeenNthCalledWith(1, 0, '#000')
       expect(addColorStop).toHaveBeenNthCalledWith(2, 1, '#fff')
       expect(gradient.addColorStop).toBe(addColorStop)
+    })
+
+    it('reuses a single scratch canvas instead of creating one per call', () => {
+      // Gradient resolution runs on every draw, including scroll-time lazy
+      // draws -- a throwaway <canvas> per call caused GC churn.
+      const realCreateElement = document.createElement.bind(document)
+      const createElementSpy = jest
+        .spyOn(document, 'createElement')
+        .mockImplementation((tagName: string) => realCreateElement(tagName))
+
+      resolveColorValue(['#000', '#fff'], 1)
+      resolveColorValue(['#111', '#eee'], 1)
+      resolveColorValue(['#222', '#ddd'], 1)
+
+      const canvasCreations = createElementSpy.mock.calls.filter(([tag]) => tag === 'canvas').length
+      // At most one creation across all calls (zero if an earlier test in
+      // this file already warmed the module-level scratch canvas).
+      expect(canvasCreations).toBeLessThanOrEqual(1)
     })
   })
 
@@ -356,6 +391,38 @@ describe('renderer-utils', () => {
 
     it('clamps width down to align with bar grid spacing', () => {
       expect(clampWidthToBarGrid(10, options)).toBe(9)
+    })
+
+    it('uses the same barWidth/barGap defaults as the bar-drawing site', () => {
+      // Bars enabled via barGap only: the draw site defaults barWidth to 1
+      // (device px at dpr=1), not 0.5 -- grid = 1 + 2 = 3.
+      const container = document.createElement('div')
+      expect(clampWidthToBarGrid(10, { container, barGap: 2 })).toBe(9)
+      // Bars enabled via barAlign only: draw defaults are barWidth 1, gap 0
+      // (no gap when barWidth is unset) -- grid = 1.
+      expect(clampWidthToBarGrid(10.5, { container, barAlign: 'top' })).toBe(10)
+    })
+
+    it('agrees with calculateBarRenderConfig barSpacing at pixelRatio 1', () => {
+      const container = document.createElement('div')
+      const cases: Partial<WaveSurferOptions>[] = [
+        { barWidth: 2, barGap: 1 },
+        { barWidth: 3 },
+        { barGap: 2 },
+        { barAlign: 'top' },
+      ]
+      for (const partial of cases) {
+        const opts = { container, ...partial } as WaveSurferOptions
+        const { barSpacing } = calculateBarRenderConfig({
+          width: 100,
+          height: 50,
+          length: 10,
+          options: opts,
+          pixelRatio: 1,
+        })
+        // A width already aligned to the drawn spacing must survive the clamp
+        expect(clampWidthToBarGrid(barSpacing * 7, opts)).toBe(barSpacing * 7)
+      }
     })
   })
 
@@ -396,18 +463,37 @@ describe('renderer-utils', () => {
   })
 
   describe('getLazyRenderRange', () => {
-    it('returns surrounding canvas indices', () => {
-      expect(
-        getLazyRenderRange({
-          scrollLeft: 50,
-          totalWidth: 200,
-          numCanvases: 5,
-        }),
-      ).toEqual([0, 1, 2])
+    // Args are built as variables (with the legacy `totalWidth` key kept as a
+    // harmless excess property) so the same tests compile against both the
+    // old average-width signature and the fixed exact-width one.
+    it('returns the viewport-covering canvas indices plus one prefetch on each side', () => {
+      // Viewport [50, 90) with 40px canvases covers indices 1-2; prefetch 0 and 3.
+      const args = { scrollLeft: 50, clientWidth: 40, singleCanvasWidth: 40, numCanvases: 5, totalWidth: 200 }
+      expect(getLazyRenderRange(args)).toEqual([0, 1, 2, 3])
     })
 
-    it('defaults to the first canvas when width is zero', () => {
-      expect(getLazyRenderRange({ scrollLeft: 0, totalWidth: 0, numCanvases: 3 })).toEqual([0])
+    it('covers the viewport edges exactly instead of using the average canvas width', () => {
+      // 10 canvases of 400px over totalWidth 4000; a bar-grid-clamped canvas
+      // is slightly narrower than the 402px viewport. At scrollLeft 799 the
+      // viewport spans [799, 1201) -- canvases 1, 2 AND 3. The old
+      // average-width math (floor(scrollLeft / totalWidth * numCanvases) ± 1)
+      // returned [0, 1, 2], leaving an undrawn strip at the right edge.
+      const args = { scrollLeft: 799, clientWidth: 402, singleCanvasWidth: 400, numCanvases: 10, totalWidth: 4000 }
+      expect(getLazyRenderRange(args)).toEqual(expect.arrayContaining([1, 2, 3]))
+    })
+
+    it('clamps the range to existing canvases at the far end', () => {
+      const args = { scrollLeft: 10_000, clientWidth: 400, singleCanvasWidth: 400, numCanvases: 5, totalWidth: 2000 }
+      const range = getLazyRenderRange(args)
+      expect(range).toContain(4) // the last canvas
+      expect(Math.max(...range)).toBe(5) // at most one prefetch past the end
+    })
+
+    it('defaults to the first canvas when there is nothing to window', () => {
+      const zeroWidth = { scrollLeft: 0, clientWidth: 0, singleCanvasWidth: 0, numCanvases: 3, totalWidth: 0 }
+      expect(getLazyRenderRange(zeroWidth)).toEqual([0])
+      const zeroCanvases = { scrollLeft: 0, clientWidth: 100, singleCanvasWidth: 100, numCanvases: 0, totalWidth: 300 }
+      expect(getLazyRenderRange(zeroCanvases)).toEqual([0])
     })
   })
 
@@ -460,6 +546,31 @@ describe('renderer-utils', () => {
         { x: 4, y: 7 },
         { x: 6, y: 4 },
       ])
+    })
+  })
+
+  describe('roundToHalfAwayFromZero', () => {
+    it('rounds to the nearest integer, not outward (the old version ceiled)', () => {
+      // The old implementation ceiled the magnitude to the next half, biasing
+      // every reRender scroll compensation outward -- cursor drift on
+      // repeated wheel-zoom.
+      expect(roundToHalfAwayFromZero(1.2)).toBe(1)
+      expect(roundToHalfAwayFromZero(-1.2)).toBe(-1)
+      expect(roundToHalfAwayFromZero(2.4)).toBe(2)
+      expect(roundToHalfAwayFromZero(1.6)).toBe(2)
+    })
+
+    it('rounds exact halves away from zero', () => {
+      expect(roundToHalfAwayFromZero(0.5)).toBe(1)
+      expect(roundToHalfAwayFromZero(-0.5)).toBe(-1)
+      expect(roundToHalfAwayFromZero(1.5)).toBe(2)
+      expect(roundToHalfAwayFromZero(-1.5)).toBe(-2)
+    })
+
+    it('leaves integers and zero unchanged', () => {
+      expect(roundToHalfAwayFromZero(3)).toBe(3)
+      expect(roundToHalfAwayFromZero(-3)).toBe(-3)
+      expect(roundToHalfAwayFromZero(0)).toBe(0)
     })
   })
 

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -67,7 +67,13 @@ describe('Renderer', () => {
   })
 
   test('parentFromOptionsContainer accepts an element from another realm (e.g. an iframe)', () => {
-    const foreign = { nodeType: 1, style: {} } as unknown as HTMLElement
+    const foreign = {
+      nodeType: 1,
+      nodeName: 'DIV',
+      namespaceURI: 'http://www.w3.org/1999/xhtml',
+      style: {},
+      appendChild: () => undefined,
+    } as unknown as HTMLElement
     expect((renderer as any).parentFromOptionsContainer(foreign)).toBe(foreign)
   })
 
@@ -253,6 +259,20 @@ describe('Renderer', () => {
   test('zoom updates option', () => {
     renderer.zoom(20)
     expect((renderer as any).options.minPxPerSec).toBe(20)
+  })
+
+  test('setOptions with an explicit undefined width reverts to fill behavior', async () => {
+    const buffer = createAudioBuffer([[0, 0.5, -0.5]])
+    renderer.setOptions({ ...(renderer as any).options, width: 250 })
+    await renderer.render(buffer)
+    const scrollContainer = (renderer as any).scrollContainer as HTMLElement
+    expect(scrollContainer.style.width).toBe('250px')
+
+    // WaveSurfer.setOptions merges, so an absent key keeps the fixed width;
+    // an explicit `width: undefined` reaches the renderer as undefined and
+    // must clear the fixed width again.
+    renderer.setOptions({ ...(renderer as any).options, width: undefined })
+    expect(scrollContainer.style.width).toBe('')
   })
 
   test('scrollIntoView updates scroll', () => {

--- a/src/__tests__/spectrogram-fft-size.test.ts
+++ b/src/__tests__/spectrogram-fft-size.test.ts
@@ -138,11 +138,23 @@ describe('worker compute with fftSize', () => {
   it('uses integer hops for non-power-of-two windows', () => {
     const fftSamples = 333
     const signal = makeSine(3000)
-    const result = runWorker(signal, { fftSamples, fftSize: 512, noverlap: 400 })
+    const result = runWorker(signal, { fftSamples, fftSize: 512, noverlap: 166 })
 
-    // noverlap capped at floor(333 / 2) = 166 -> hop = max(max(64, ceil(83.25)), 333 - 166) = 167
+    // hop = 333 - 166 = 167, an integer even though fftSamples is not a power of two
     const hop = 167
     const expectedFrames = Math.floor((signal.length - fftSamples - 1) / hop) + 1
+    expect(result[0].length).toBe(expectedFrames)
+    expect(result[0][0].length).toBe(256)
+  })
+
+  it('honors noverlap above 50% of fftSamples, clamped only to fftSamples - 1', () => {
+    const fftSamples = 333
+    const signal = makeSine(1000)
+    const result = runWorker(signal, { fftSamples, fftSize: 512, noverlap: 400 })
+
+    // noverlap >= fftSamples is clamped to fftSamples - 1 = 332 -> hop = 1 (the old code
+    // silently capped noverlap at 50% and floored the hop, yielding hop 167 here instead)
+    const expectedFrames = Math.floor((signal.length - fftSamples - 1) / 1) + 1
     expect(result[0].length).toBe(expectedFrames)
     expect(result[0][0].length).toBe(256)
   })

--- a/src/__tests__/spectrogram-frequencies.test.ts
+++ b/src/__tests__/spectrogram-frequencies.test.ts
@@ -550,3 +550,48 @@ describe('computeFrequencies golden values', () => {
     expect(__getFFTCacheStatsForTests().constructions).toBe(6)
   })
 })
+
+describe('noverlap contract (hop size)', () => {
+  const base = { scale: 'linear' as const, gainDB: 20, rangeDB: 80, sampleRate: SAMPLE_RATE }
+
+  it('honors an explicit noverlap above 50% of fftSamples instead of silently capping it', () => {
+    const signal = makeSine(1280, 1000)
+
+    // hop = 128 - 96 = 32; frames start at 0, 32, ... while sample + 128 < 1280.
+    // The old silent 50% cap forced noverlap down to 64 (hop 64), halving the frame count.
+    const result = computeFrequencies([signal], { ...base, fftSamples: 128, noverlap: 96 })
+
+    const expectedFrames = Math.floor((1280 - 128 - 1) / 32) + 1
+    expect(result[0].length).toBe(expectedFrames)
+  })
+
+  it('clamps noverlap to fftSamples - 1 so the hop stays >= 1 sample (no infinite loop)', () => {
+    const signal = makeSine(64, 1000)
+
+    // noverlap >= fftSamples is mathematically impossible; the only clamp is to
+    // fftSamples - 1, i.e. hop = 1: frames at every sample while sample + 32 < 64.
+    const result = computeFrequencies([signal], { ...base, fftSamples: 32, noverlap: 64 })
+
+    expect(result[0].length).toBe(32)
+  })
+
+  it('keeps the 50% default hop when noverlap is unset', () => {
+    const signal = makeSine(1280, 1000)
+
+    const result = computeFrequencies([signal], { ...base, fftSamples: 128, noverlap: null })
+
+    const expectedFrames = Math.floor((1280 - 128 - 1) / 64) + 1
+    expect(result[0].length).toBe(expectedFrames)
+  })
+
+  it('uses the true fftSamples/2 default hop for small windows (no 64-sample hop floor)', () => {
+    const signal = makeSine(640, 1000)
+
+    // fftSamples 64 -> default noverlap 32 -> hop 32. The old minHopSize floor of 64 samples
+    // silently doubled the hop (zero overlap) for any window of 64 samples or fewer.
+    const result = computeFrequencies([signal], { ...base, fftSamples: 64, noverlap: null })
+
+    const expectedFrames = Math.floor((640 - 64 - 1) / 32) + 1
+    expect(result[0].length).toBe(expectedFrames)
+  })
+})

--- a/src/__tests__/spectrogram-render-utils.test.ts
+++ b/src/__tests__/spectrogram-render-utils.test.ts
@@ -8,6 +8,11 @@ import {
   createPreEmphasisTilt,
   getBinFrequencies,
   SILENCE_FLOOR_DB,
+  hzToBark,
+  barkToHz,
+  hzToScale,
+  scaleToHz,
+  paintColumnPixels,
 } from '../spectrogram-render-utils.js'
 
 const SCALES = ['mel', 'logarithmic', 'bark', 'erb'] as const
@@ -297,3 +302,59 @@ describe('sparse filter bank golden values (frozen baseline)', () => {
 function closeTo(value: number, precision = 6) {
   return expect.closeTo(value, precision)
 }
+
+describe('bark scale zero normalization', () => {
+  // The vertical-mapping code (renderChannelToCanvas / drawSpectrogramSegment) assumes
+  // hzToScale(0, scale) === 0 when computing rMin/rMax ratios; the raw Traunmüller-corrected
+  // bark formula maps 0 Hz to about -0.1505 instead, producing a slightly negative rMin and
+  // out-of-range bitmap source rows (~0.6% offset). The mapping must be offset-corrected so
+  // 0 Hz lands on exactly 0, consistently in both directions so the pair stays inverse.
+  it('maps 0 Hz to exactly 0', () => {
+    expect(hzToBark(0)).toBe(0)
+    expect(hzToScale(0, 'bark')).toBe(0)
+  })
+
+  it('keeps every other scale mapping 0 Hz to 0 too (the shared zero assumption)', () => {
+    for (const scale of ['linear', 'logarithmic', 'mel', 'erb'] as const) {
+      expect(hzToScale(0, scale)).toBe(0)
+    }
+  })
+
+  it('keeps barkToHz the exact inverse of hzToBark across the audible range', () => {
+    // Values straddle both piecewise corrections (bark < 2 and bark > 20.1)
+    for (const hz of [0, 50, 100, 250, 500, 1000, 2000, 4000, 8000, 12000, 16000, 22050]) {
+      expect(barkToHz(hzToBark(hz))).toBeCloseTo(hz, 6)
+      expect(scaleToHz(hzToScale(hz, 'bark'), 'bark')).toBeCloseTo(hz, 6)
+    }
+  })
+
+  it('stays monotonically increasing after the offset correction', () => {
+    let previous = -Infinity
+    for (let hz = 0; hz <= 22050; hz += 50) {
+      const bark = hzToBark(hz)
+      expect(bark).toBeGreaterThan(previous)
+      previous = bark
+    }
+  })
+})
+
+describe('paintColumnPixels floors fractional bin values', () => {
+  // Internally computed columns are Uint8Array entries (integers 0-255), but
+  // loadFrequenciesData's externally-supplied frequenciesDataUrl JSON can carry fractional
+  // numbers; a fractional index like colorMap[12.7] is undefined and throws mid-draw on
+  // `color[0]`. Values must be floored after clamping.
+  it('does not throw indexing colorMap for fractional values, flooring after the clamp', () => {
+    const colorMap: number[][] = Array.from({ length: 256 }, (_, i) => [i / 255, 0, 0, 1])
+    const data = new Uint8ClampedArray(4 * 3) // 1 column, 3 rows, RGBA
+    const column = [12.7, 254.5, 300.9]
+
+    expect(() => paintColumnPixels(data, column, colorMap, 0, 1, 3)).not.toThrow()
+
+    // row 0 (12.7 -> floor 12) lands at the BOTTOM pixel row: ((3 - 0 - 1) * 1 + 0) * 4 = 8
+    expect(data[8]).toBe(12)
+    // row 1 (254.5 -> floor 254) at pixelIndex (3 - 1 - 1) * 4 = 4
+    expect(data[4]).toBe(254)
+    // row 2 (300.9 -> clamps to 255 first, floor is a no-op) at pixelIndex 0
+    expect(data[0]).toBe(255)
+  })
+})

--- a/src/__tests__/spectrogram-rendering-mode.test.ts
+++ b/src/__tests__/spectrogram-rendering-mode.test.ts
@@ -493,3 +493,105 @@ describe('windowed mode splitChannels fallback', () => {
     expect(frequencies.length).toBe(2)
   })
 })
+
+describe('full mode canvas rendering cosmetics', () => {
+  // jsdom has no real 2D context, ImageData, or createImageBitmap; stub just enough for
+  // drawSpectrogram to create its canvases and reach the label/background fill calls.
+  const originalImageData = (globalThis as any).ImageData
+  const originalCreateImageBitmap = (globalThis as any).createImageBitmap
+  const originalDpr = Object.getOwnPropertyDescriptor(window, 'devicePixelRatio')
+  let getContextSpy: jest.SpyInstance
+  let fillRects: number[][]
+  let fakeCtx: Record<string, unknown>
+
+  beforeEach(() => {
+    fillRects = []
+    fakeCtx = {
+      fillStyle: '',
+      font: '',
+      textAlign: '',
+      textBaseline: '',
+      fillRect: jest.fn((...args: number[]) => fillRects.push(args)),
+      fillText: jest.fn(),
+      fill: jest.fn(),
+      drawImage: jest.fn(),
+      scale: jest.fn(),
+    }
+    getContextSpy = jest
+      .spyOn(window.HTMLCanvasElement.prototype, 'getContext')
+      .mockReturnValue(fakeCtx as unknown as ReturnType<HTMLCanvasElement['getContext']>)
+    ;(globalThis as any).ImageData = class {
+      data: Uint8ClampedArray
+      constructor(
+        public width: number,
+        public height: number,
+      ) {
+        this.data = new Uint8ClampedArray(width * height * 4)
+      }
+    }
+    ;(globalThis as any).createImageBitmap = jest.fn(() => Promise.resolve({ close: jest.fn() }))
+  })
+
+  afterEach(() => {
+    getContextSpy.mockRestore()
+    ;(globalThis as any).ImageData = originalImageData
+    ;(globalThis as any).createImageBitmap = originalCreateImageBitmap
+    if (originalDpr) {
+      Object.defineProperty(window, 'devicePixelRatio', originalDpr)
+    } else {
+      delete (window as any).devicePixelRatio
+    }
+  })
+
+  /** [channel][frame][bin] plain-array frequency data, duck-typed like frequenciesDataUrl JSON. */
+  function makeFrames(channels: number): number[][][] {
+    return Array.from({ length: channels }, () =>
+      Array.from({ length: 4 }, (_, frame) => Array.from({ length: 8 }, (_, bin) => (frame * 8 + bin) % 256)),
+    )
+  }
+
+  it('scales the spectrogram canvas backing store by devicePixelRatio while keeping its CSS size', () => {
+    Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true })
+
+    const plugin: any = SpectrogramPlugin.create({ scale: 'linear' })
+    plugin._init(createFakeWaveSurfer())
+    const internals = plugin.__spectrogramInternalsForTests()
+    internals.buffer = createFakeAudioBuffer(new Float32Array(8000))
+
+    internals.drawSpectrogram(makeFrames(1) as unknown as Uint8Array[][])
+
+    const canvas = internals.canvases[0]
+    // Pre-fix the backing store matched the CSS size (600x200): blurry on HiDPI displays,
+    // in contrast with the axis labels canvas, which already scaled by devicePixelRatio.
+    expect(canvas.width).toBe(1200)
+    expect(canvas.height).toBe(400)
+    expect(canvas.style.width).toBe('600px')
+    expect(canvas.style.height).toBe('200px')
+    // Drawing stays in CSS coordinates via the context transform.
+    expect(fakeCtx.scale).toHaveBeenCalledWith(2, 2)
+  })
+
+  it('fills each frequency-labels channel row with a row-height rect instead of overdrawing rows below', () => {
+    const plugin: any = SpectrogramPlugin.create({
+      labels: true,
+      labelsBackground: 'rgba(0, 0, 0, 0.1)',
+      scale: 'linear',
+      frequencyMax: 4000,
+      splitChannels: true,
+    })
+    plugin._init(createFakeWaveSurfer())
+    const internals = plugin.__spectrogramInternalsForTests()
+    internals.buffer = createFakeAudioBuffer(new Float32Array(8000))
+
+    internals.drawSpectrogram(makeFrames(2) as unknown as Uint8Array[][])
+
+    // The 55px-wide fills are the labels background (one per channel row of height 200).
+    // Pre-fix the height argument was the row's END y ((1 + c) * height), so channel 1's fill
+    // was 400px tall - overdrawing past its own row (double-painting a translucent background).
+    const bgRects = fillRects.filter((args) => args[2] === 55)
+    expect(bgRects).toEqual([
+      [0, 0, 55, 200],
+      [0, 200, 55, 200],
+    ])
+  })
+})

--- a/src/__tests__/spectrogram-windowed-destroy.test.ts
+++ b/src/__tests__/spectrogram-windowed-destroy.test.ts
@@ -9,7 +9,7 @@ import { createFakeWaveSurfer } from './helpers/fake-wavesurfer.js'
 //
 // __windowedInternals() below is the private-poke adaptation for this file: every direct
 // instance-field poke the pre-unification version of this test used
-// ((plugin as any).segments, .maxRetainedSegments, .buffer, .evictDistantSegments(), etc.) is
+// ((plugin as any).segments, .maxRetainedBytes, .buffer, .evictDistantSegments(), etc.) is
 // replaced with the equivalent read through __spectrogramInternalsForTests().windowed, whose
 // segmentManager is a real SegmentManager class instance - its own methods call each other via
 // `this.foo()`, so jest.spyOn(internals.segmentManager, 'foo') still correctly intercepts
@@ -40,37 +40,48 @@ describe('WindowedSpectrogramPlugin destroy', () => {
   })
 
   describe('segment eviction', () => {
-    it('caps retained segments', () => {
+    // Each 100x100 canvas backing store costs 100 * 100 * 4 bytes against the manager's
+    // byte budget (maxRetainedBytes) - the cap counts canvas memory, not segments.
+    const CANVAS_BYTES = 100 * 100 * 4
+    function makeSizedCanvas(): HTMLCanvasElement {
+      const canvas = document.createElement('canvas')
+      canvas.width = 100
+      canvas.height = 100
+      return canvas
+    }
+
+    it('caps retained segment canvas memory', () => {
       const plugin: any = WindowedSpectrogramPlugin.create({})
       const internals = initPlugin(plugin)
       const manager = internals.segmentManager
-      const cap = manager.maxRetainedSegments
-      expect(typeof cap).toBe('number')
-      for (let i = 0; i < cap + 10; i++) {
+      expect(typeof manager.maxRetainedBytes).toBe('number')
+      manager.maxRetainedBytes = 3 * CANVAS_BYTES
+      for (let i = 0; i < 13; i++) {
         manager.segments.set(i, {
           startTime: i * 30,
           endTime: (i + 1) * 30,
           startPixel: i * 30,
           endPixel: (i + 1) * 30,
-          canvas: document.createElement('canvas'),
+          canvas: makeSizedCanvas(),
           frequencies: [],
         })
       }
       manager.evictDistantSegments(0) // current view at t=0
-      expect(manager.segments.size).toBeLessThanOrEqual(cap)
+      expect(manager.segments.size).toBeLessThanOrEqual(3)
     })
 
     it('evicts segments farthest from the current time and removes their canvases from the DOM', () => {
       const plugin: any = WindowedSpectrogramPlugin.create({})
       const internals = initPlugin(plugin)
       const manager = internals.segmentManager
-      const cap = manager.maxRetainedSegments
+      const retained = 4
+      manager.maxRetainedBytes = retained * CANVAS_BYTES
       const container = document.createElement('div')
       document.body.appendChild(container)
 
-      const total = cap + 10
+      const total = retained + 10
       for (let i = 0; i < total; i++) {
-        const canvas = document.createElement('canvas')
+        const canvas = makeSizedCanvas()
         container.appendChild(canvas)
         manager.segments.set(i, {
           startTime: i * 30,
@@ -86,27 +97,27 @@ describe('WindowedSpectrogramPlugin destroy', () => {
       // indices (farthest midpoints) should be the ones evicted.
       manager.evictDistantSegments(0)
 
-      expect(manager.segments.size).toBe(cap)
+      expect(manager.segments.size).toBe(retained)
       // Every remaining segment's canvas should still be attached to the DOM.
       for (const segment of manager.segments.values()) {
         expect(segment.canvas.isConnected).toBe(true)
       }
       // The DOM should have exactly as many canvases left as retained segments -
       // the evicted ones were actually removed, not just dropped from the map.
-      expect(container.children.length).toBe(cap)
+      expect(container.children.length).toBe(retained)
       // The segments closest to t=0 (lowest indices) must have survived.
       expect(manager.segments.has(0)).toBe(true)
       expect(manager.segments.has(total - 1)).toBe(false)
     })
 
-    it('enforces the segment cap during progressive loading even with no renderVisibleWindow calls', async () => {
+    it('enforces the byte budget during progressive loading even with no renderVisibleWindow calls', async () => {
       jest.useFakeTimers()
       try {
         const plugin: any = WindowedSpectrogramPlugin.create({ progressiveLoading: true })
         const internals = initPlugin(plugin)
         const manager = internals.segmentManager
-        manager.maxRetainedSegments = 3
-        // Long enough for far more than maxRetainedSegments 30s segments.
+        manager.maxRetainedBytes = 3 * CANVAS_BYTES
+        // Long enough for far more 30s segments than the budget retains.
         plugin.__spectrogramInternalsForTests().buffer = { duration: 30 * 20 }
         manager.isProgressiveLoading = true
 
@@ -120,7 +131,7 @@ describe('WindowedSpectrogramPlugin destroy', () => {
             endTime: end,
             startPixel: 0,
             endPixel: 0,
-            canvas: document.createElement('canvas'),
+            canvas: makeSizedCanvas(),
             frequencies: [],
           })
         })

--- a/src/__tests__/spectrogram-windowing.test.ts
+++ b/src/__tests__/spectrogram-windowing.test.ts
@@ -6,6 +6,7 @@ import {
   deriveNoverlap,
   getScrollLeft,
   getViewportWidth,
+  renderFrequencySegment,
 } from '../spectrogram-windowing.js'
 
 /** A minimal, fully-controllable SegmentManagerDeps for unit tests: no DOM/wavesurfer/Scope involved. */
@@ -54,17 +55,27 @@ function makeSegment(start: number, end: number, canvas?: HTMLCanvasElement): Fr
   return { startTime: start, endTime: end, startPixel: start * 100, endPixel: end * 100, frequencies: [], canvas }
 }
 
-describe('SegmentManager eviction', () => {
-  it('does nothing when at or under the cap', () => {
-    const manager = new SegmentManager(makeDeps(), { maxRetainedSegments: 5 })
-    for (let i = 0; i < 5; i++) manager.segments.set(String(i), makeSegment(i * 30, (i + 1) * 30))
+/** A canvas whose backing store costs width * height * 4 bytes (default 100x100 = 40 000 B). */
+function makeCanvas(width = 100, height = 100): HTMLCanvasElement {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  return canvas
+}
+
+const CANVAS_BYTES = 100 * 100 * 4 // one makeCanvas() backing store
+
+describe('SegmentManager eviction (byte budget)', () => {
+  it('does nothing when at or under the byte budget', () => {
+    const manager = new SegmentManager(makeDeps(), { maxRetainedBytes: 5 * CANVAS_BYTES })
+    for (let i = 0; i < 5; i++) manager.segments.set(String(i), makeSegment(i * 30, (i + 1) * 30, makeCanvas()))
     manager.evictDistantSegments(0)
     expect(manager.segments.size).toBe(5)
   })
 
-  it('evicts the farthest-from-currentTime segments down to the cap', () => {
-    const manager = new SegmentManager(makeDeps(), { maxRetainedSegments: 3 })
-    for (let i = 0; i < 10; i++) manager.segments.set(String(i), makeSegment(i * 30, (i + 1) * 30))
+  it('evicts the farthest-from-currentTime segments down to the byte budget', () => {
+    const manager = new SegmentManager(makeDeps(), { maxRetainedBytes: 3 * CANVAS_BYTES })
+    for (let i = 0; i < 10; i++) manager.segments.set(String(i), makeSegment(i * 30, (i + 1) * 30, makeCanvas()))
 
     manager.evictDistantSegments(0)
 
@@ -75,12 +86,25 @@ describe('SegmentManager eviction', () => {
     expect(manager.segments.has('9')).toBe(false)
   })
 
+  it('counts bytes, not segments: fewer large canvases fit in the same budget', () => {
+    const manager = new SegmentManager(makeDeps(), { maxRetainedBytes: 4 * CANVAS_BYTES })
+    // Each canvas is 4x the base size (200x200), so the 4-canvas-equivalent budget only fits one.
+    for (let i = 0; i < 6; i++) {
+      manager.segments.set(String(i), makeSegment(i * 30, (i + 1) * 30, makeCanvas(200, 200)))
+    }
+
+    manager.evictDistantSegments(0)
+
+    expect(manager.segments.size).toBe(1)
+    expect(manager.segments.has('0')).toBe(true)
+  })
+
   it('removes evicted segments canvases from the DOM', () => {
-    const manager = new SegmentManager(makeDeps(), { maxRetainedSegments: 2 })
+    const manager = new SegmentManager(makeDeps(), { maxRetainedBytes: 2 * CANVAS_BYTES })
     const container = document.createElement('div')
     document.body.appendChild(container)
     for (let i = 0; i < 5; i++) {
-      const canvas = document.createElement('canvas')
+      const canvas = makeCanvas()
       container.appendChild(canvas)
       manager.segments.set(String(i), makeSegment(i * 30, (i + 1) * 30, canvas))
     }
@@ -94,8 +118,8 @@ describe('SegmentManager eviction', () => {
   })
 
   it('anchors eviction on the given currentTime, not always segment index 0', () => {
-    const manager = new SegmentManager(makeDeps(), { maxRetainedSegments: 3 })
-    for (let i = 0; i < 10; i++) manager.segments.set(String(i), makeSegment(i * 30, (i + 1) * 30))
+    const manager = new SegmentManager(makeDeps(), { maxRetainedBytes: 3 * CANVAS_BYTES })
+    for (let i = 0; i < 10; i++) manager.segments.set(String(i), makeSegment(i * 30, (i + 1) * 30, makeCanvas()))
 
     // Anchor near segment 9 (t=285): the lowest-index segments should be evicted instead.
     manager.evictDistantSegments(285)
@@ -103,6 +127,24 @@ describe('SegmentManager eviction', () => {
     expect(manager.segments.has('9')).toBe(true)
     expect(manager.segments.has('8')).toBe(true)
     expect(manager.segments.has('0')).toBe(false)
+  })
+
+  it('never evicts the segment nearest to the current view, even when it alone exceeds the budget', () => {
+    const manager = new SegmentManager(makeDeps(), { maxRetainedBytes: CANVAS_BYTES })
+    manager.segments.set('near', makeSegment(0, 30, makeCanvas(400, 400)))
+    manager.segments.set('far', makeSegment(300, 330, makeCanvas(400, 400)))
+
+    manager.evictDistantSegments(0)
+
+    // Evicting the visible segment would just force an immediate recompute (thrash);
+    // the budget therefore only ever removes all-but-the-nearest.
+    expect(manager.segments.has('near')).toBe(true)
+    expect(manager.segments.has('far')).toBe(false)
+  })
+
+  it('defaults to a ~256MB budget', () => {
+    const manager = new SegmentManager(makeDeps())
+    expect(manager.maxRetainedBytes).toBe(256 * 1024 * 1024)
   })
 })
 
@@ -406,9 +448,15 @@ describe('SegmentManager progressive loading', () => {
     expect(manager.isProgressiveLoading).toBe(false)
   })
 
-  it('enforces maxRetainedSegments purely through the progressive path, with no viewport render involved', async () => {
-    const deps = makeDeps({ getBufferDuration: () => 30 * 20, getWidth: () => 100000 })
-    const manager = new SegmentManager(deps, { progressiveLoading: true, maxRetainedSegments: 3 })
+  it('enforces the byte budget purely through the progressive path, with no viewport render involved', async () => {
+    const deps = makeDeps({
+      getBufferDuration: () => 30 * 20,
+      getWidth: () => 100000,
+      renderSegment: async (segment) => {
+        segment.canvas = makeCanvas()
+      },
+    })
+    const manager = new SegmentManager(deps, { progressiveLoading: true, maxRetainedBytes: 3 * CANVAS_BYTES })
     manager.isProgressiveLoading = true
 
     for (let i = 0; i < 10; i++) {
@@ -573,5 +621,203 @@ describe('getScrollLeft / getViewportWidth', () => {
   it('getViewportWidth falls back to a default when nothing is measurable', () => {
     const wrapper = document.createElement('div')
     expect(getViewportWidth(wrapper)).toBeGreaterThan(0)
+  })
+})
+
+describe('SegmentManager.generateSegments await races', () => {
+  // The progressive loader calls generateSegments() directly, bypassing renderVisibleWindow's
+  // re-entrancy guard - so two generateSegments() calls for overlapping ranges genuinely race.
+  // Every await point must re-check the segment map before/after attaching a canvas, or the
+  // loser's canvas is left attached-but-unreachable (never evicted: no map key points at it).
+  it('does not orphan a canvas when a concurrent call creates the same segment mid-compute', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const resolvers: Array<(value: Uint8Array[][]) => void> = []
+    const deps = makeDeps({
+      // Short audio + small container -> fill-container mode -> both calls race the SAME key.
+      getBufferDuration: () => 5,
+      getWidth: () => 100,
+      getPixelsPerSecond: () => 10,
+      computeSegmentFrequencies: () =>
+        new Promise<Uint8Array[][]>((resolve) => {
+          resolvers.push(resolve)
+        }),
+      renderSegment: async (segment) => {
+        const canvas = document.createElement('canvas')
+        segment.canvas = canvas
+        container.appendChild(canvas)
+      },
+    })
+    const manager = new SegmentManager(deps)
+
+    const first = manager.generateSegments(0, 5)
+    const second = manager.generateSegments(0, 5)
+    expect(resolvers).toHaveLength(2)
+
+    resolvers[0]([[new Uint8Array([1])]])
+    await first
+    resolvers[1]([[new Uint8Array([2])]])
+    await second
+
+    // Pre-fix the second call's Map.set() overwrote the first's entry and attached a second
+    // canvas that nothing could ever evict (the map no longer pointed at it).
+    expect(manager.segments.size).toBe(1)
+    expect(container.children.length).toBe(1)
+    const [segment] = manager.segments.values()
+    expect(segment.canvas?.isConnected).toBe(true)
+  })
+
+  it('removes the canvas it attached when the segment was deleted during the renderSegment await', async () => {
+    const container = document.createElement('div')
+    let resolveRender: (() => void) | null = null
+    const deps = makeDeps({
+      getBufferDuration: () => 5,
+      getWidth: () => 100,
+      getPixelsPerSecond: () => 10,
+      renderSegment: (segment) => {
+        const canvas = document.createElement('canvas')
+        segment.canvas = canvas
+        container.appendChild(canvas)
+        return new Promise<void>((resolve) => {
+          resolveRender = resolve
+        })
+      },
+    })
+    const manager = new SegmentManager(deps)
+
+    const generating = manager.generateSegments(0, 5)
+    for (let i = 0; i < 10 && !resolveRender; i++) {
+      await Promise.resolve()
+    }
+    expect(resolveRender).not.toBeNull()
+
+    // Eviction (or a reset for a new buffer) deletes the segment while its render is in flight.
+    const [key] = manager.segments.keys()
+    manager.segments.delete(key)
+
+    resolveRender!()
+    await generating
+
+    // The canvas the in-flight render attached must not be left orphaned in the DOM.
+    expect(container.children.length).toBe(0)
+  })
+})
+
+describe('SegmentManager progress reporting', () => {
+  it('emits per-segment fractions ending at exactly 1 for a viewport-driven generate (non-progressive)', async () => {
+    const progressValues: number[] = []
+    const deps = makeDeps({
+      getBufferDuration: () => 600,
+      getWidth: () => 1000,
+      getPixelsPerSecond: () => 1000, // segmentDuration = 15000px / 1000px/s = 15s
+      emitProgress: (progress) => progressValues.push(progress),
+    })
+    const manager = new SegmentManager(deps) // progressiveLoading off (the default)
+
+    await manager.generateSegments(0, 45) // 3 segments of 15s
+
+    // Pre-fix every emitted value was 0: getLoadingProgress() only tracks the progressive
+    // loader's cursor, which never moves in default (non-progressive) loading.
+    expect(progressValues).toEqual([1 / 3, 2 / 3, 1])
+  })
+
+  it('emits 1 when a default-loading renderVisibleWindow pass completes', async () => {
+    const progressValues: number[] = []
+    const deps = makeDeps({
+      getBufferDuration: () => 600,
+      emitProgress: (progress) => progressValues.push(progress),
+    })
+    const manager = new SegmentManager(deps)
+
+    await manager.renderVisibleWindow()
+
+    expect(progressValues.length).toBeGreaterThan(0)
+    expect(progressValues[progressValues.length - 1]).toBe(1)
+  })
+
+  it('keeps loader-cursor progress for progressive-load calls, and emits 1 on completion', async () => {
+    const progressValues: number[] = []
+    const deps = makeDeps({
+      getBufferDuration: () => 60,
+      getWidth: () => 100000,
+      emitProgress: (progress) => progressValues.push(progress),
+    })
+    const manager = new SegmentManager(deps, { progressiveLoading: true })
+    manager.isProgressiveLoading = true
+
+    await manager.progressiveLoadNextSegment() // [0, 30): cursor still at 0 when it emits
+    await manager.progressiveLoadNextSegment() // [30, 60): cursor at 30 -> 0.5
+    await manager.progressiveLoadNextSegment() // cursor at 60 -> done: emits 1 and stops
+
+    expect(progressValues).toEqual([0, 0.5, 1])
+    expect(manager.isProgressiveLoading).toBe(false)
+  })
+})
+
+describe('renderFrequencySegment devicePixelRatio scaling', () => {
+  const originalDpr = Object.getOwnPropertyDescriptor(window, 'devicePixelRatio')
+  const originalCreateImageBitmap = (globalThis as any).createImageBitmap
+  const originalImageData = (globalThis as any).ImageData
+  let getContextSpy: jest.SpyInstance
+  let fakeCtx: { scale: jest.Mock; drawImage: jest.Mock }
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true })
+    fakeCtx = { scale: jest.fn(), drawImage: jest.fn() }
+    getContextSpy = jest
+      .spyOn(window.HTMLCanvasElement.prototype, 'getContext')
+      .mockReturnValue(fakeCtx as unknown as ReturnType<HTMLCanvasElement['getContext']>)
+    ;(globalThis as any).ImageData = class {
+      data: Uint8ClampedArray
+      constructor(
+        public width: number,
+        public height: number,
+      ) {
+        this.data = new Uint8ClampedArray(width * height * 4)
+      }
+    }
+    ;(globalThis as any).createImageBitmap = jest.fn(() => Promise.resolve({ close: jest.fn() }))
+  })
+
+  afterEach(() => {
+    getContextSpy.mockRestore()
+    ;(globalThis as any).createImageBitmap = originalCreateImageBitmap
+    ;(globalThis as any).ImageData = originalImageData
+    if (originalDpr) {
+      Object.defineProperty(window, 'devicePixelRatio', originalDpr)
+    } else {
+      delete (window as any).devicePixelRatio
+    }
+  })
+
+  it('scales the canvas backing store by devicePixelRatio while keeping its CSS size', async () => {
+    const colorMap = Array.from({ length: 256 }, (_, i) => [i / 255, i / 255, i / 255, 1])
+    const segment: FrequencySegment = {
+      startTime: 0,
+      endTime: 1,
+      startPixel: 0,
+      endPixel: 300,
+      frequencies: [[new Uint8Array([1, 2, 3])]],
+    }
+    const container = document.createElement('div')
+
+    await renderFrequencySegment(segment, {
+      height: 200,
+      colorMap,
+      scale: 'linear',
+      freqFrom: 4000,
+      freqMin: 0,
+      freqMax: 4000,
+      canvasContainer: container,
+    })
+
+    const canvas = segment.canvas!
+    // Pre-fix the backing store matched the CSS size (300x200), rendering blurry on HiDPI.
+    expect(canvas.width).toBe(600)
+    expect(canvas.height).toBe(400)
+    expect(canvas.style.width).toBe('300px')
+    expect(canvas.style.height).toBe('200px')
+    // Drawing happens in CSS coordinates via the context transform.
+    expect(fakeCtx.scale).toHaveBeenCalledWith(2, 2)
   })
 })

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -169,6 +169,46 @@ describe('TimelinePlugin', () => {
     expect(notchAt160?.isConnected).toBe(false)
   })
 
+  // Notch widths must be measured AFTER the notch is inserted into the
+  // document: a detached element's clientWidth is always 0, which made the
+  // label-culling condition (`start + width < scrollRight`) degenerate — a
+  // notch whose label sticks out past the visible window was never culled.
+  // jsdom also reports 0 for connected elements, so simulate real browser
+  // behavior with a prototype getter keyed on connectedness.
+  test('culls a notch whose measured width overflows the visible window (width measured after insertion)', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.isConnected ? 20 : 0
+      },
+    })
+
+    try {
+      const wavesurfer = createWaveSurfer(1, 100)
+      // Visible window: [0, 60). pxPerSec = 100, so notches land at 0 and 50.
+      wavesurfer.getWidth = jest.fn(() => 60)
+
+      const plugin = TimelinePlugin.create({ duration: 1, timeInterval: 0.5 })
+      plugin._init(wavesurfer as any)
+
+      const wrapper = wavesurfer.getWrapper()
+      const notchAt0 = wrapper.querySelector<HTMLElement>('[part^="timeline-notch"][style*="left: 0px"]')
+      const notchAt50 = wrapper.querySelector<HTMLElement>('[part^="timeline-notch"][style*="left: 50px"]')
+
+      // 0 + 20 < 60: stays. 50 + 20 < 60 is false: must be culled — with the
+      // detached (0-width) measurement it incorrectly stayed visible.
+      expect(notchAt0).not.toBeNull()
+      expect(notchAt50).toBeNull()
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalDescriptor)
+      } else {
+        delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth
+      }
+    }
+  })
+
   // ADAPTED (private-internal poke): the original read the private
   // `notchElements`/`currentTimeline` fields directly. Neither exists
   // post-port (they're setup()-local closure state, discarded with the

--- a/src/__tests__/wavesurfer.test.ts
+++ b/src/__tests__/wavesurfer.test.ts
@@ -414,6 +414,44 @@ describe('WaveSurfer public methods', () => {
     ws.destroy()
   })
 
+  test("normalizes a MediaError into a real Error on the 'error' event", () => {
+    const ws = createWs()
+    const media = ws.getMediaElement()!
+    // HTMLMediaElement.error is a MediaError ({ code, message }), NOT an Error
+    Object.defineProperty(media, 'error', {
+      configurable: true,
+      value: { code: 4, message: 'MEDIA_ELEMENT_ERROR: Format error' },
+    })
+    const onError = jest.fn()
+    ws.on('error', onError)
+
+    media.dispatchEvent(new Event('error'))
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    const err = onError.mock.calls[0][0]
+    expect(err).toBeInstanceOf(Error)
+    expect(err.message).toBe('MEDIA_ELEMENT_ERROR: Format error')
+    ws.destroy()
+  })
+
+  test('preserves the MediaError code in the normalized Error when the message is empty', () => {
+    const ws = createWs()
+    const media = ws.getMediaElement()!
+    Object.defineProperty(media, 'error', {
+      configurable: true,
+      value: { code: 3, message: '' },
+    })
+    const onError = jest.fn()
+    ws.on('error', onError)
+
+    media.dispatchEvent(new Event('error'))
+
+    const err = onError.mock.calls[0][0]
+    expect(err).toBeInstanceOf(Error)
+    expect(err.message).toBe('Media error 3')
+    ws.destroy()
+  })
+
   test('reflects zoom and decoded audio in reactive state', async () => {
     const ws = createWs({
       peaks: [[0, 0.5, 1]],
@@ -621,15 +659,15 @@ describe('WaveSurfer public methods', () => {
       // Regression probe for the destroy-vs-supersede fix above: load(A),
       // then load(B) (superseding A), then destroy() -- all synchronously,
       // no await between them. A was genuinely superseded *before* destroy()
-      // ever ran, so it must still resolve (swallowed) even though, by the
-      // time its rejection handler finally runs (a later microtask),
-      // destroy() has *also* torn the instance down. Only B (the load that
-      // was still live at destroy time) should reject and emit 'error' --
-      // exactly once. A design that re-derives "was this superseded?" from
-      // scope.disposed state at catch time (rather than marking it at the
-      // moment supersession actually happens) gets this wrong: both A and B
-      // would look indistinguishable from "destroyed" by the time their
-      // catches run, so both reject and 'error' fires twice.
+      // ever ran, so it rejects with the supersession AbortError and emits
+      // NO 'error' event, even though, by the time its rejection handler
+      // finally runs (a later microtask), destroy() has *also* torn the
+      // instance down. Only B (the load that was still live at destroy time)
+      // should emit 'error' -- exactly once. A design that re-derives "was
+      // this superseded?" from scope.disposed state at catch time (rather
+      // than marking it at the moment supersession actually happens) gets
+      // this wrong: both A and B would look indistinguishable from
+      // "destroyed" by the time their catches run, so 'error' fires twice.
       global.fetch = jest.fn().mockImplementation((_url, init: RequestInit) => {
         const signal = init.signal as AbortSignal
         return new Promise((_resolve, reject) => {
@@ -653,7 +691,7 @@ describe('WaveSurfer public methods', () => {
       const onError = jest.fn()
       ws.on('error', onError)
 
-      await expect(pA).resolves.toBeUndefined()
+      await expect(pA).rejects.toMatchObject({ name: 'AbortError' })
       await expect(pB).rejects.toMatchObject({ name: 'AbortError' })
       expect(onError).toHaveBeenCalledTimes(1)
       expect(onError.mock.calls[0][0].name).toBe('AbortError')
@@ -779,6 +817,97 @@ describe('WaveSurfer public methods', () => {
         global.fetch = originalFetch
         ws.destroy()
       }
+    })
+
+    it('rejects a superseded load with a canonical AbortError without emitting error', async () => {
+      const ws = WaveSurfer.create({ container: document.createElement('div') })
+      const onError = jest.fn()
+      ws.on('error', onError)
+      global.fetch = jest.fn().mockImplementation((_url, init: RequestInit) => {
+        const signal = init.signal as AbortSignal
+        return new Promise((_resolve, reject) => {
+          const onAbort = () => reject(new DOMException('The user aborted a request.', 'AbortError'))
+          if (signal.aborted) {
+            onAbort()
+          } else {
+            signal.addEventListener('abort', onAbort, { once: true })
+          }
+        })
+      })
+
+      const pA = ws.load('http://x/a.mp3')
+      await Promise.resolve()
+      ws.load('http://x/b.mp3').catch(() => undefined) // supersedes A
+
+      // v8: the superseded (old) load's promise rejects with an AbortError
+      // DOMException for awaiting callers...
+      await expect(pA).rejects.toBeInstanceOf(DOMException)
+      await expect(pA).rejects.toMatchObject({ name: 'AbortError' })
+      // ...but supersession is normal control flow, not a failure: no public
+      // 'error' event.
+      expect(onError).not.toHaveBeenCalled()
+      ws.destroy()
+    })
+
+    it('rejects a superseded load with AbortError even when the pipeline bails without any rejection', async () => {
+      // Load A gets past its fetch (resolved blob) and parks on the unknown-
+      // duration await; superseding it disposes its scope, so it bails at a
+      // checkpoint rather than via a rejected promise -- it must still reject
+      // with the same canonical AbortError as the fetch-abort path.
+      const ws = WaveSurfer.create({ container: document.createElement('div') })
+      const onError = jest.fn()
+      ws.on('error', onError)
+      const blob = new Blob([new ArrayBuffer(8)], { type: 'audio/wav' })
+      const response = {
+        status: 200,
+        blob: () => Promise.resolve(blob),
+        body: null,
+        headers: new Headers(),
+        clone: () => ({ body: null, headers: new Headers() }),
+      } as unknown as Response
+      global.fetch = jest.fn().mockResolvedValue(response)
+
+      const pA = ws.load('http://x/a.mp3')
+      await new Promise((r) => setTimeout(r, 0)) // let A reach the duration await
+      ws.load('http://x/b.mp3').catch(() => undefined) // supersedes A
+
+      await expect(pA).rejects.toMatchObject({ name: 'AbortError' })
+      expect(onError).not.toHaveBeenCalled()
+      ws.destroy()
+    })
+
+    it('setMediaElement() during an in-flight load with unknown duration settles that load instead of hanging it', async () => {
+      // The duration resolver's 'loadedmetadata' listener lives on the media-
+      // event bridge that setMediaElement() disposes -- without a settle hook
+      // on that same bridge, the load() promise pends forever.
+      const media = createMedia()
+      Object.defineProperty(media, 'duration', { configurable: true, value: NaN })
+      const ws = WaveSurfer.create({ container: document.createElement('div'), media })
+      const blob = new Blob([new ArrayBuffer(8)], { type: 'audio/wav' })
+      const response = {
+        status: 200,
+        blob: () => Promise.resolve(blob),
+        body: null,
+        headers: new Headers(),
+        clone: () => ({ body: null, headers: new Headers() }),
+      } as unknown as Response
+      global.fetch = jest.fn().mockResolvedValue(response)
+
+      const pA = ws.load('http://x/a.mp3')
+      await new Promise((r) => setTimeout(r, 0)) // let the load reach the duration await
+
+      ws.setMediaElement(createMedia())
+
+      await expect(
+        Promise.race([
+          pA.then(
+            () => 'settled',
+            () => 'settled',
+          ),
+          new Promise((r) => setTimeout(() => r('pending'), 50)),
+        ]),
+      ).resolves.toBe('settled')
+      ws.destroy()
     })
 
     it('sets loadPhase=error when a load listener throws synchronously', async () => {

--- a/src/__tests__/webaudio.test.ts
+++ b/src/__tests__/webaudio.test.ts
@@ -340,6 +340,88 @@ describe('WebAudioPlayer', () => {
       expect(player.error).toBeNull()
     })
 
+    test('changing src aborts the previous in-flight fetch', () => {
+      const { audioContext } = createMockAudioContext()
+      const player = new WebAudioPlayer(audioContext)
+      const signals: AbortSignal[] = []
+      global.fetch = jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
+        signals.push(init?.signal as AbortSignal)
+        return new Promise(() => undefined) // never settles
+      })
+
+      player.src = 'http://x/a.mp3'
+      player.src = 'http://x/b.mp3'
+
+      expect(signals).toHaveLength(2)
+      expect(signals[0].aborted).toBe(true)
+      expect(signals[1].aborted).toBe(false)
+    })
+
+    test('destroy aborts the in-flight src fetch', () => {
+      const { audioContext } = createMockAudioContext()
+      const player = new WebAudioPlayer(audioContext)
+      const signals: AbortSignal[] = []
+      global.fetch = jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
+        signals.push(init?.signal as AbortSignal)
+        return new Promise(() => undefined) // never settles
+      })
+
+      player.src = 'http://x/a.mp3'
+      player.destroy()
+
+      expect(signals[0].aborted).toBe(true)
+    })
+
+    test('a stale fetch does not apply its decoded buffer when the same URL was set again (A -> B -> A)', async () => {
+      const { audioContext } = createMockAudioContext()
+      ;(audioContext.decodeAudioData as jest.Mock).mockResolvedValue(createMockBuffer(1))
+      const player = new WebAudioPlayer(audioContext)
+      const onCanplay = jest.fn()
+      player.on('canplay', onCanplay)
+
+      const resolvers: Array<(response: Response) => void> = []
+      global.fetch = jest.fn().mockImplementation(() => new Promise<Response>((res) => resolvers.push(res)))
+
+      player.src = 'http://x/a.mp3'
+      player.src = 'http://x/b.mp3'
+      player.src = 'http://x/a.mp3' // back to A: fetch #3 owns the src now
+
+      // Fetch #1 (the stale request for A) resolves first. A URL-equality guard
+      // alone would let it through, since currentSrc is A again -- only a
+      // per-assignment generation check rejects it.
+      resolvers[0]({
+        status: 200,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      } as unknown as Response)
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(onCanplay).not.toHaveBeenCalled()
+      expect((player as any).buffer).toBeNull()
+    })
+
+    test('a stale decode does not apply after destroy', async () => {
+      const { audioContext } = createMockAudioContext()
+      ;(audioContext.decodeAudioData as jest.Mock).mockResolvedValue(createMockBuffer(1))
+      const player = new WebAudioPlayer(audioContext)
+      const onCanplay = jest.fn()
+      player.on('canplay', onCanplay)
+
+      let resolveFetch: (response: Response) => void = () => undefined
+      global.fetch = jest.fn().mockImplementation(() => new Promise<Response>((res) => (resolveFetch = res)))
+
+      player.src = 'http://x/a.mp3'
+      player.destroy()
+
+      resolveFetch({
+        status: 200,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      } as unknown as Response)
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(onCanplay).not.toHaveBeenCalled()
+      expect((player as any).buffer).toBeNull()
+    })
+
     test('does not emit error for a fetch that lost the race to a newer src', async () => {
       const { audioContext } = createMockAudioContext()
       const player = new WebAudioPlayer(audioContext)
@@ -356,6 +438,55 @@ describe('WebAudioPlayer', () => {
       await new Promise((r) => setTimeout(r, 0))
       expect(onError).not.toHaveBeenCalled() // stale failure must be silent
     })
+  })
+})
+
+describe('suspended AudioContext', () => {
+  test('play() resumes a suspended AudioContext (autoplay policy would otherwise play silently)', async () => {
+    const { audioContext } = createMockAudioContext()
+    const resume = jest.fn().mockResolvedValue(undefined)
+    Object.assign(audioContext, { state: 'suspended', resume })
+    const player = new WebAudioPlayer(audioContext)
+    ;(player as any).buffer = createMockBuffer(10)
+
+    await player.play()
+
+    expect(resume).toHaveBeenCalled()
+  })
+
+  test('play() does not call resume() on a running AudioContext', async () => {
+    const { audioContext } = createMockAudioContext()
+    const resume = jest.fn().mockResolvedValue(undefined)
+    Object.assign(audioContext, { state: 'running', resume })
+    const player = new WebAudioPlayer(audioContext)
+    ;(player as any).buffer = createMockBuffer(10)
+
+    await player.play()
+
+    expect(resume).not.toHaveBeenCalled()
+  })
+})
+
+describe('stopAt clamping', () => {
+  test('stopAt with a time already in the past clamps the scheduled stop to now (no RangeError)', () => {
+    const { audioContext, bufferSource } = createMockAudioContext()
+    const player = new WebAudioPlayer(audioContext)
+    ;(player as any).buffer = createMockBuffer(20)
+
+    audioContext.currentTime = 100
+    player.play()
+    audioContext.currentTime = 110 // playback position is now 10
+
+    // AudioScheduledSourceNode.stop() throws a RangeError for a negative
+    // `when`; a real node also rejects times in the past relative to now.
+    bufferSource.stop.mockImplementation((when?: number) => {
+      if (when != null && when < audioContext.currentTime) {
+        throw new RangeError('stop time must not be in the past')
+      }
+    })
+
+    expect(() => player.stopAt(5)).not.toThrow()
+    expect(bufferSource.stop).toHaveBeenCalledWith(110)
   })
 })
 

--- a/src/__tests__/zoom.test.ts
+++ b/src/__tests__/zoom.test.ts
@@ -7,6 +7,7 @@ const createWaveSurfer = (container: HTMLElement, wrapper: HTMLElement, duration
   const zoom = signal(0)
 
   return {
+    duration,
     wavesurfer: {
       ...createEmitter(),
       options: { minPxPerSec: 50 },
@@ -17,6 +18,30 @@ const createWaveSurfer = (container: HTMLElement, wrapper: HTMLElement, duration
       zoom: jest.fn(),
     },
   }
+}
+
+const createDom = (containerWidth = 100) => {
+  const container = document.createElement('div')
+  const wrapper = document.createElement('div')
+  container.appendChild(wrapper)
+  document.body.appendChild(container)
+
+  Object.defineProperty(container, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({ left: 0 }),
+  })
+  Object.defineProperty(container, 'clientWidth', { configurable: true, value: containerWidth })
+
+  let scrollLeftValue = 0
+  Object.defineProperty(container, 'scrollLeft', {
+    configurable: true,
+    get: () => scrollLeftValue,
+    set: (value: number) => {
+      scrollLeftValue = value
+    },
+  })
+
+  return { container, wrapper }
 }
 
 describe('ZoomPlugin', () => {
@@ -71,5 +96,83 @@ describe('ZoomPlugin', () => {
     // If maxZoom had been cached from the first init (the pre-port
     // behavior), this would still be clamped at 100.
     expect(wavesurfer.zoom).toHaveBeenLastCalledWith(300)
+  })
+
+  test('lets the page scroll (no preventDefault, no zoom) before the audio is decoded', () => {
+    const { container, wrapper } = createDom()
+    const { wavesurfer } = createWaveSurfer(container, wrapper, 0)
+
+    const plugin = ZoomPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const event = new WheelEvent('wheel', { deltaY: -100, deltaX: 0, cancelable: true })
+    container.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(wavesurfer.zoom).not.toHaveBeenCalled()
+  })
+
+  test('re-derives the pointer anchor from the current scroll after an external scroll at the same x', () => {
+    const { container, wrapper } = createDom()
+    const { wavesurfer } = createWaveSurfer(container, wrapper, 10)
+
+    const plugin = ZoomPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    // First wheel step at x=50: anchor time = (scroll 0 + 50) / 50 px/s = 1s.
+    container.dispatchEvent(new WheelEvent('wheel', { deltaY: -10, deltaX: 0, clientX: 50 }))
+
+    // newMinPxPerSec = min(50 + 10 * 0.5, maxZoom 100) = 55
+    expect(wavesurfer.zoom).toHaveBeenLastCalledWith(55)
+    expect(container.scrollLeft).toBeCloseTo((1 - (100 / 55) * (50 / 100)) * 55)
+
+    // The container is scrolled externally (not by the plugin).
+    wavesurfer.getScroll.mockReturnValue(200)
+
+    // A wheel event at the SAME x must anchor at the newly visible time
+    // (scroll 200 + x 50) / 50 px/s = 5s — not reuse the stale cached anchor.
+    container.dispatchEvent(new WheelEvent('wheel', { deltaY: -10, deltaX: 0, clientX: 50 }))
+
+    expect(container.scrollLeft).toBeCloseTo((5 - (100 / 55) * (50 / 100)) * 55)
+  })
+
+  test('iterations: 1 zooms in a single step instead of dividing by zero', () => {
+    const { container, wrapper } = createDom()
+    Object.defineProperty(wrapper, 'clientWidth', { configurable: true, value: 800 })
+    const { wavesurfer } = createWaveSurfer(container, wrapper, 4)
+    wavesurfer.options.minPxPerSec = 300
+
+    const plugin = ZoomPlugin.create({ exponentialZooming: true, iterations: 1, maxZoom: 400 })
+    plugin._init(wavesurfer as any)
+
+    // startZoom = wrapper width 800 / duration 4 = 200; a zoom-out step with a
+    // single iteration applies the full ratio startZoom/endZoom = 0.5 once:
+    // 300 * 0.5 = 150. The divide-by-zero exponent (1 / (1 - 1)) collapsed the
+    // zoom to 0 instead, snapping straight to fit-to-width.
+    container.dispatchEvent(new WheelEvent('wheel', { deltaY: 1000, deltaX: 0 }))
+
+    expect(wavesurfer.zoom).toHaveBeenLastCalledWith(150)
+  })
+
+  test('resets the exponential zoom baseline when new audio loads', () => {
+    const { container, wrapper } = createDom()
+    Object.defineProperty(wrapper, 'clientWidth', { configurable: true, value: 100 })
+    const { duration, wavesurfer } = createWaveSurfer(container, wrapper, 10)
+
+    const plugin = ZoomPlugin.create({ exponentialZooming: true, iterations: 3, maxZoom: 6400 })
+    plugin._init(wavesurfer as any)
+
+    // First track: startZoom = 100 / 10 = 10.
+    container.dispatchEvent(new WheelEvent('wheel', { deltaY: -10, deltaX: 0 }))
+    expect(wavesurfer.zoom).toHaveBeenLastCalledWith(Math.min(50 * Math.pow(6400 / 10, 1 / 2), 6400))
+
+    // Load a new, longer audio file.
+    duration.set(40)
+    wavesurfer.emit('ready', 40)
+
+    // The baseline must be re-derived from the NEW duration (100 / 40 = 2.5),
+    // not kept from the previous track.
+    container.dispatchEvent(new WheelEvent('wheel', { deltaY: -10, deltaX: 0 }))
+    expect(wavesurfer.zoom).toHaveBeenLastCalledWith(Math.min(50 * Math.pow(6400 / 2.5, 1 / 2), 6400))
   })
 })

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -11,23 +11,30 @@ async function decode(audioData: ArrayBuffer, sampleRate: number): Promise<Audio
   }
 }
 
-/** Normalize peaks to -1..1 */
-function normalize<T extends Array<Float32Array | number[]>>(channelData: T): T {
-  const firstChannel = channelData[0]
-  if (firstChannel.some((n) => n > 1 || n < -1)) {
-    const length = firstChannel.length
-    let max = 0
-    for (let i = 0; i < length; i++) {
-      const absN = Math.abs(firstChannel[i])
+/**
+ * Normalize peaks to -1..1.
+ * Decides from and scales by the GLOBAL max across all channels (scaling by
+ * channel 0's max alone could leave other channels outside -1..1), and never
+ * mutates the caller-owned input arrays: when scaling is needed, scaled copies
+ * are returned instead.
+ */
+function normalize(channelData: Array<Float32Array | number[]>): Array<Float32Array | number[]> {
+  let max = 0
+  for (const channel of channelData) {
+    for (let i = 0; i < channel.length; i++) {
+      const absN = Math.abs(channel[i])
       if (absN > max) max = absN
     }
-    for (const channel of channelData) {
-      for (let i = 0; i < length; i++) {
-        channel[i] /= max
-      }
-    }
   }
-  return channelData
+  if (max <= 1) return channelData
+
+  return channelData.map((channel) => {
+    const scaled = new Float32Array(channel.length)
+    for (let i = 0; i < channel.length; i++) {
+      scaled[i] = channel[i] / max
+    }
+    return scaled
+  })
 }
 
 /** Create an audio buffer from pre-decoded audio data */
@@ -48,28 +55,44 @@ function createBuffer(channelData: Array<Float32Array | number[]>, duration: num
     throw new Error('channelData must contain non-empty channel arrays')
   }
 
-  // Normalize to -1..1
-  normalize(channelData)
+  // Normalize to -1..1 (returns scaled copies when scaling is needed --
+  // the caller-owned arrays are never mutated)
+  const normalizedChannels = normalize(channelData)
 
   // Convert to Float32Array for consistency
-  const float32Channels = channelData.map((channel) =>
+  const float32Channels = normalizedChannels.map((channel) =>
     channel instanceof Float32Array ? channel : Float32Array.from(channel),
   )
+
+  const getChannelData = (i: number) => {
+    const channel = float32Channels[i]
+    if (!channel) {
+      throw new Error(`Channel ${i} not found`)
+    }
+    return channel
+  }
 
   return {
     duration,
     length: float32Channels[0].length,
     sampleRate: float32Channels[0].length / duration,
     numberOfChannels: float32Channels.length,
-    getChannelData: (i: number) => {
-      const channel = float32Channels[i]
-      if (!channel) {
-        throw new Error(`Channel ${i} not found`)
-      }
-      return channel
+    getChannelData,
+    // Real implementations per AudioBuffer semantics (the previous borrowed
+    // AudioBuffer.prototype methods threw "Illegal invocation" on this plain
+    // object): copy min(available, requested) frames, honoring the offset.
+    copyFromChannel: (destination: Float32Array, channelNumber: number, bufferOffset = 0) => {
+      const channel = getChannelData(channelNumber)
+      const start = Math.max(0, bufferOffset)
+      const frameCount = Math.max(0, Math.min(destination.length, channel.length - start))
+      destination.set(channel.subarray(start, start + frameCount))
     },
-    copyFromChannel: AudioBuffer.prototype.copyFromChannel,
-    copyToChannel: AudioBuffer.prototype.copyToChannel,
+    copyToChannel: (source: Float32Array, channelNumber: number, bufferOffset = 0) => {
+      const channel = getChannelData(channelNumber)
+      const start = Math.max(0, bufferOffset)
+      const frameCount = Math.max(0, Math.min(source.length, channel.length - start))
+      channel.set(source.subarray(0, frameCount), start)
+    },
   } as AudioBuffer
 }
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -43,15 +43,24 @@ export function createElement(tagName: string, content?: TreeNode, container?: N
 
 /**
  * Check if a value is an HTML element, including elements from other realms
- * (e.g. an iframe), for which `instanceof HTMLElement` returns false
+ * (e.g. an iframe), for which `instanceof HTMLElement` returns false.
+ *
+ * The cross-realm fallback duck-types against the core element traits
+ * instead of accepting any `{nodeType: 1, style: object}` bag: it also
+ * requires a string nodeName, the HTML namespace (rejecting SVG elements),
+ * a non-null style object, and a callable appendChild.
  */
 export function isHTMLElement(value: unknown): value is HTMLElement {
   if (value instanceof HTMLElement) return true
+  if (typeof value !== 'object' || value === null) return false
+  const element = value as HTMLElement
   return (
-    typeof value === 'object' &&
-    value !== null &&
-    (value as Node).nodeType === Node.ELEMENT_NODE &&
-    typeof (value as HTMLElement).style === 'object'
+    element.nodeType === Node.ELEMENT_NODE &&
+    typeof element.nodeName === 'string' &&
+    element.namespaceURI === 'http://www.w3.org/1999/xhtml' &&
+    typeof element.style === 'object' &&
+    element.style !== null &&
+    typeof element.appendChild === 'function'
   )
 }
 

--- a/src/fft.ts
+++ b/src/fft.ts
@@ -84,8 +84,11 @@ function FFT(bufferSize: number, sampleRate: number, windowFunc: string, alpha: 
       break
     case 'lanczoz':
       for (let i = 0; i < windowLength; i++) {
-        this.windowValues[i] =
-          Math.sin(Math.PI * ((2 * i) / (windowLength - 1) - 1)) / (Math.PI * ((2 * i) / (windowLength - 1) - 1))
+        // sinc(x) with sinc(0) = 1: the raw division is 0/0 = NaN at the center sample of odd
+        // window lengths (reachable via the fftSize decoupling, where windowLength may be any
+        // integer >= 2), which would propagate NaN through every frame into a blank spectrogram
+        const x = (2 * i) / (windowLength - 1) - 1
+        this.windowValues[i] = x === 0 ? 1 : Math.sin(Math.PI * x) / (Math.PI * x)
       }
       break
     case 'rectangular':

--- a/src/frame-scheduler.ts
+++ b/src/frame-scheduler.ts
@@ -26,8 +26,13 @@ export class FrameScheduler {
     this.isRunning = true
     const tick = () => {
       if (!this.isRunning) return
-      this.callback?.()
+      // Schedule the next frame BEFORE running the callback: a throwing
+      // subscriber must not kill the loop (isRunning would stay true, blocking
+      // any restart). The exception still propagates to the caller/RAF task so
+      // it stays visible for debugging; a stop() from inside the callback
+      // cancels the frame just scheduled here via cancelAnimationFrame.
       this.frameId = requestAnimationFrame(tick)
+      this.callback?.()
     }
     // Replicate Timer's synchronous first tick so event timing stays identical.
     tick()

--- a/src/player.ts
+++ b/src/player.ts
@@ -91,14 +91,19 @@ class Player {
     }
     // Speed
     if (options.playbackRate != null) {
-      this.onMediaEvent(
-        'canplay',
-        () => {
-          if (options.playbackRate != null) {
-            this.media.playbackRate = options.playbackRate
-          }
-        },
-        { once: true },
+      // Registered on mediaScope like every other media listener: with an
+      // external media element that never fires 'canplay', an unregistered
+      // one-shot listener would survive destroy().
+      this.mediaScope.add(
+        this.onMediaEvent(
+          'canplay',
+          () => {
+            if (options.playbackRate != null) {
+              this.media.playbackRate = options.playbackRate
+            }
+          },
+          { once: true },
+        ),
       )
     }
   }

--- a/src/plugins/envelope.ts
+++ b/src/plugins/envelope.ts
@@ -352,10 +352,14 @@ const EnvelopePlugin = definePlugin<EnvelopePluginOptions, EnvelopePluginEvents,
   'EnvelopePlugin',
   (ctx, options) => {
     const opts: Options = Object.assign({}, defaultOptions, options)
-    opts.lineColor = opts.lineColor || defaultOptions.lineColor
-    opts.dragPointFill = opts.dragPointFill || defaultOptions.dragPointFill
-    opts.dragPointStroke = opts.dragPointStroke || defaultOptions.dragPointStroke
-    opts.dragPointSize = opts.dragPointSize || defaultOptions.dragPointSize
+    // `??`, not `||`: falsy option values are legitimate here (e.g.
+    // `dragPointSize: 0` to hide the drag points) and must not silently fall
+    // back to the defaults. These re-assignments only guard explicitly-passed
+    // `undefined` values, which Object.assign copies over the defaults.
+    opts.lineColor = opts.lineColor ?? defaultOptions.lineColor
+    opts.dragPointFill = opts.dragPointFill ?? defaultOptions.dragPointFill
+    opts.dragPointStroke = opts.dragPointStroke ?? defaultOptions.dragPointStroke
+    opts.dragPointSize = opts.dragPointSize ?? defaultOptions.dragPointSize
 
     const points: EnvelopePoint[] = options?.points || []
     let polyline: Polyline | null = null
@@ -454,6 +458,8 @@ const EnvelopePlugin = definePlugin<EnvelopePluginOptions, EnvelopePluginEvents,
     }
 
     function addPoint(point: EnvelopePoint) {
+      // Post-destroy: public mutators are silent no-ops (matches core WaveSurfer)
+      if (ctx.scope.disposed) return
       if (!point.id) point.id = randomId()
 
       // Insert the point in the correct position to keep the array sorted
@@ -470,6 +476,8 @@ const EnvelopePlugin = definePlugin<EnvelopePluginOptions, EnvelopePluginEvents,
     }
 
     function removePoint(point: EnvelopePoint) {
+      // Post-destroy: public mutators are silent no-ops (matches core WaveSurfer)
+      if (ctx.scope.disposed) return
       const index = points.indexOf(point)
       if (index > -1) {
         points.splice(index, 1)
@@ -492,6 +500,8 @@ const EnvelopePlugin = definePlugin<EnvelopePluginOptions, EnvelopePluginEvents,
     }
 
     function setVolume(floatValue: number) {
+      // Post-destroy: public mutators are silent no-ops (matches core WaveSurfer)
+      if (ctx.scope.disposed) return
       volume = floatValue
       ctx.wavesurfer?.setVolume(floatValue)
     }
@@ -532,6 +542,19 @@ const EnvelopePlugin = definePlugin<EnvelopePluginOptions, EnvelopePluginEvents,
       polyline?.destroy()
       polyline = null
     })
+
+    // "Already decoded" init path (same pattern as minimap/timeline): a plugin
+    // registered AFTER the audio has been decoded gets no 'decode' event, so
+    // build the polyline UI right away.
+    if (ctx.wavesurfer.getDecodedData()) {
+      initPolyline()
+      const duration = ctx.wavesurfer.getDuration()
+      if (duration) {
+        points.forEach((point) => {
+          addPolyPoint(point, duration)
+        })
+      }
+    }
 
     return {
       addPoint,

--- a/src/plugins/hover.ts
+++ b/src/plugins/hover.ts
@@ -59,6 +59,10 @@ function addUnits(value: string | number): string {
 const HoverPlugin = definePlugin<HoverPluginOptions, HoverPluginEvents, object>('HoverPlugin', (ctx, options) => {
   const opts: HoverPluginOptions & typeof defaultOptions = Object.assign({}, defaultOptions, options)
 
+  // The documented string form of lineWidth ('2', '2px') is fine for CSS but
+  // NaN in the positioning math below — normalize to a pixel number once.
+  const lineWidthPx = typeof opts.lineWidth === 'number' ? opts.lineWidth : parseFloat(opts.lineWidth) || 0
+
   // Create the plugin elements
   const wrapper = createElement('div', { part: 'hover' })
   const label = createElement('span', { part: 'hover-label' }, wrapper)
@@ -130,7 +134,7 @@ const HoverPlugin = definePlugin<HoverPluginOptions, HoverPluginEvents, object>(
       const { width } = bbox
       const offsetX = e.clientX - bbox.left
       const relX = Math.min(1, Math.max(0, offsetX / width))
-      const posX = Math.min(width - opts.lineWidth - 1, offsetX)
+      const posX = Math.min(width - lineWidthPx - 1, offsetX)
       wrapper.style.transform = `translateX(${posX}px)`
       wrapper.style.opacity = '1'
 
@@ -139,7 +143,7 @@ const HoverPlugin = definePlugin<HoverPluginOptions, HoverPluginEvents, object>(
       label.textContent = opts.formatTimeCallback(dur * relX)
       const labelWidth = label.offsetWidth
       const transformCondition = opts.labelPreferLeft ? posX - labelWidth > 0 : posX + labelWidth > width
-      label.style.transform = transformCondition ? `translateX(-${labelWidth + opts.lineWidth}px)` : ''
+      label.style.transform = transformCondition ? `translateX(-${labelWidth + lineWidthPx}px)` : ''
 
       // Emit a hover event with the relative X position
       ctx.emit('hover', relX)
@@ -191,7 +195,7 @@ const HoverPlugin = definePlugin<HoverPluginOptions, HoverPluginEvents, object>(
       const { width } = bbox
       const offsetX = lastPointerPosition.clientX - bbox.left
       const relX = Math.min(1, Math.max(0, offsetX / width))
-      const posX = Math.min(width - opts.lineWidth - 1, offsetX)
+      const posX = Math.min(width - lineWidthPx - 1, offsetX)
       wrapper.style.transform = `translateX(${posX}px)`
 
       // Timestamp
@@ -199,7 +203,7 @@ const HoverPlugin = definePlugin<HoverPluginOptions, HoverPluginEvents, object>(
       label.textContent = opts.formatTimeCallback(dur * relX)
       const labelWidth = label.offsetWidth
       const transformCondition = opts.labelPreferLeft ? posX - labelWidth > 0 : posX + labelWidth > width
-      label.style.transform = transformCondition ? `translateX(-${labelWidth + opts.lineWidth}px)` : ''
+      label.style.transform = transformCondition ? `translateX(-${labelWidth + lineWidthPx}px)` : ''
     }
   }
 

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -229,6 +229,9 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
             }
           })
           .catch((err) => {
+            // Rapid re-renders supersede each other; a superseded load()
+            // rejects with AbortError by design -- not an error here.
+            if (err instanceof DOMException && err.name === 'AbortError') return
             console.error('Error rendering real-time recording data:', err)
           })
       }

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -434,7 +434,11 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
 
     this.updatingSide = side
     const resizeValid = length >= this.minLength && length <= this.maxLength
-    if (newStart <= newEnd && (resizeValid || isRegionCreating)) {
+    // During drag-creation the region necessarily grows through sub-minLength
+    // sizes, so only maxLength can be enforced mid-drag; minLength is enforced
+    // when the creation drag ends (see enableDragSelection).
+    const creationValid = isRegionCreating && length <= this.maxLength
+    if (newStart <= newEnd && (resizeValid || creationValid)) {
       this.start = newStart
       this.end = newEnd
 
@@ -549,11 +553,28 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     }
 
     if (options.start !== undefined || options.end !== undefined) {
-      const isMarker = this.start === this.end
+      const wasMarker = this.start === this.end
       this.start = this.clampPosition(options.start ?? this.start)
-      this.end = this.clampPosition(options.end ?? (isMarker ? this.start : this.end))
+      this.end = this.clampPosition(options.end ?? (wasMarker ? this.start : this.end))
       this.renderPosition()
       this.setPart()
+
+      // A marker turned into a range (or vice versa) must not keep its stale
+      // styling: swap the background/border and add/remove the resize handles
+      // to match what initElement() would have produced for the new shape.
+      const isMarker = this.start === this.end
+      if (isMarker !== wasMarker) {
+        this.element.style.backgroundColor = isMarker ? '' : this.color
+        this.element.style.borderLeft = isMarker ? '2px solid ' + this.color : 'none'
+        if (this.resize) {
+          if (isMarker) {
+            this.removeResizeHandles(this.element)
+          } else {
+            this.addResizeHandles(this.element)
+          }
+        }
+      }
+
       this.emit('render')
     }
 
@@ -873,7 +894,13 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
     /** Create a region with given parameters */
     function addRegion(options: RegionParams): Region {
       if (!ctx.wavesurfer) {
-        throw Error('WaveSurfer is not initialized')
+        // The api only exists after init, so a missing wavesurfer means
+        // destroy() has run. Post-destroy contract (matches core WaveSurfer):
+        // public mutators silently no-op — return an inert, already-removed
+        // region instead of throwing.
+        const region = new SingleRegion(options, 0, new Scope())
+        region.remove()
+        return region
       }
 
       const duration = ctx.wavesurfer.getDuration()
@@ -970,6 +997,15 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
         } else if (drag.type === 'end') {
           // On drag end
           if (region && regionScope) {
+            // Enforce minLength on the just-created region: mid-drag it
+            // necessarily passes through sub-minLength sizes (see _onUpdate),
+            // so the length contract is applied when the creation finishes.
+            if (region.end - region.start < region.minLength) {
+              const duration = ctx.wavesurfer?.getDuration() ?? 0
+              const end = Math.min(duration, region.start + region.minLength)
+              const start = Math.max(0, end - region.minLength)
+              region.setOptions({ start, end })
+            }
             saveRegion(region, regionScope)
             region.updatingSide = undefined
             region = null

--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -106,23 +106,27 @@ const TimelinePlugin = definePlugin<TimelinePluginOptions, TimelinePluginEvents,
     }
 
     function virtualAppend(start: number, container: HTMLElement, element: HTMLElement) {
-      // Store notch metadata for batch updates
-      notchElements.set(element, {
-        start,
-        width: element.clientWidth,
-        wasVisible: false,
-      })
+      // Append BEFORE measuring: a detached element's clientWidth is always 0,
+      // which would make the culling condition below degenerate (no label was
+      // ever culled for overflowing the visible window). The timeline element
+      // is already attached to the document at this point (see initTimeline).
+      container.appendChild(element)
+      const width = element.clientWidth
 
       // Initial render check
       const scrollLeft = ctx.wavesurfer.getScroll()
       const scrollRight = scrollLeft + ctx.wavesurfer.getWidth()
+      const isVisible = start >= scrollLeft && start + width < scrollRight
 
-      const notchData = notchElements.get(element)!
-      const isVisible = start >= scrollLeft && start + notchData.width < scrollRight
-      notchData.wasVisible = isVisible
+      // Store notch metadata for batch updates
+      notchElements.set(element, {
+        start,
+        width,
+        wasVisible: isVisible,
+      })
 
-      if (isVisible) {
-        container.appendChild(element)
+      if (!isVisible) {
+        element.remove()
       }
     }
 
@@ -185,6 +189,12 @@ const TimelinePlugin = definePlugin<TimelinePluginOptions, TimelinePluginEvents,
         Object.assign(timeline.style, opts.style)
       }
 
+      // Attach the (empty) timeline to the document BEFORE building notches so
+      // virtualAppend can measure each notch's real width after insertion.
+      timelineWrapper.innerHTML = ''
+      timelineWrapper.appendChild(timeline)
+      currentTimeline = timeline
+
       const notchEl = createElement('div', {
         style: {
           width: '0',
@@ -225,10 +235,6 @@ const TimelinePlugin = definePlugin<TimelinePluginOptions, TimelinePluginEvents,
         notch.style.left = `${offset}px`
         virtualAppend(offset, timeline, notch)
       }
-
-      timelineWrapper.innerHTML = ''
-      timelineWrapper.appendChild(timeline)
-      currentTimeline = timeline
 
       ctx.emit('ready')
     }

--- a/src/plugins/zoom.ts
+++ b/src/plugins/zoom.ts
@@ -99,6 +99,7 @@ const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('Zo
   let accumulatedDelta = 0
   let pointerTime = 0
   let oldX = 0
+  let lastScrollX = 0
   let startZoom = 0
 
   // State for proportional pinch-to-zoom
@@ -109,10 +110,11 @@ const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('Zo
   const calculateNewZoom = (oldZoom: number, delta: number) => {
     let newZoom
     if (opts.exponentialZooming) {
-      const zoomFactor =
-        delta > 0
-          ? Math.pow(endZoom / startZoom, 1 / (opts.iterations - 1))
-          : Math.pow(startZoom / endZoom, 1 / (opts.iterations - 1))
+      // `iterations: 1` means "reach the target in a single step" — clamp the
+      // divisor to 1 instead of dividing by zero (which collapsed the factor
+      // to 0/Infinity/NaN).
+      const exponent = 1 / Math.max(1, opts.iterations - 1)
+      const zoomFactor = delta > 0 ? Math.pow(endZoom / startZoom, exponent) : Math.pow(startZoom / endZoom, exponent)
       newZoom = Math.max(0, oldZoom * zoomFactor)
     } else {
       // Default linear zooming
@@ -125,6 +127,14 @@ const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('Zo
     if (Math.abs(e.deltaX) >= Math.abs(e.deltaY)) {
       return
     }
+
+    const duration = ctx.wavesurfer.getDuration()
+    // Nothing to zoom before the audio is decoded — bail out WITHOUT
+    // preventDefault so the page can still scroll.
+    if (!duration) {
+      return
+    }
+
     // prevent scrolling the sidebar while zooming
     e.preventDefault()
 
@@ -132,12 +142,11 @@ const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('Zo
     accumulatedDelta += -e.deltaY
 
     if (startZoom === 0 && opts.exponentialZooming) {
-      startZoom = ctx.wavesurfer.getWrapper().clientWidth / ctx.wavesurfer.getDuration()
+      startZoom = ctx.wavesurfer.getWrapper().clientWidth / duration
     }
 
     // ...and only scroll once we've hit our threshold
     if (opts.deltaThreshold === 0 || Math.abs(accumulatedDelta) >= opts.deltaThreshold) {
-      const duration = ctx.wavesurfer.getDuration()
       const oldMinPxPerSec =
         ctx.wavesurfer.options.minPxPerSec === 0
           ? ctx.wavesurfer.getWrapper().scrollWidth / duration
@@ -146,8 +155,11 @@ const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('Zo
       const width = container.clientWidth
       const scrollX = ctx.wavesurfer.getScroll()
 
-      // Update pointerTime only if the pointer position has changed. This prevents the waveform from drifting during fixed zooming.
-      if (x !== oldX || oldX === 0) {
+      // Update pointerTime only if the pointer position has changed (this prevents
+      // the waveform from drifting during fixed zooming) or if the container was
+      // scrolled since the last wheel step (e.g. by the user) — reusing the cached
+      // anchor with a different scroll would zoom around a stale time.
+      if (x !== oldX || oldX === 0 || scrollX !== lastScrollX) {
         pointerTime = (scrollX + x) / oldMinPxPerSec
       }
       oldX = x
@@ -162,6 +174,10 @@ const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('Zo
         ctx.wavesurfer.zoom(newMinPxPerSec)
         container.scrollLeft = (pointerTime - newLeftSec) * newMinPxPerSec
       }
+
+      // Remember the scroll position this step produced so the next wheel step
+      // can detect an external scroll and re-derive the anchor.
+      lastScrollX = container.scrollLeft
 
       // Reset the accumulated delta
       accumulatedDelta = 0
@@ -232,6 +248,14 @@ const ZoomPlugin = definePlugin<ZoomPluginOptions, ZoomPluginEvents, object>('Zo
       initialZoom = 0
     }
   }
+
+  // A new audio file invalidates the cached exponential-zoom baseline — reset
+  // it so the next zoom step re-derives it from the new duration.
+  const resetStartZoom = () => {
+    startZoom = 0
+  }
+  ctx.scope.add(ctx.wavesurfer.on('load', resetStartZoom))
+  ctx.scope.add(ctx.wavesurfer.on('ready', resetStartZoom))
 
   // Get reactive state
   const { zoom, duration } = ctx.state

--- a/src/renderer-utils.ts
+++ b/src/renderer-utils.ts
@@ -24,9 +24,29 @@ export const MAX_CANVAS_WIDTH = 8000
 export const MAX_NODES = 10
 
 export function clampToUnit(value: number): number {
+  // NaN (e.g. from pointer math over a zero-size, hidden container) must not
+  // escape into seek positions -- treat it as 0.
+  if (Number.isNaN(value)) return 0
   if (value < 0) return 0
   if (value > 1) return 1
   return value
+}
+
+/**
+ * The effective bar width and gap, with defaults applied. This is THE single
+ * definition of the bar grid: the draw site (calculateBarRenderConfig) and
+ * the layout clamp (clampWidthToBarGrid) both resolve through it, so canvas
+ * widths always align with the drawn bar spacing. `pixelRatio` scales the
+ * configured CSS-pixel values into device pixels for drawing; layout code
+ * (which works in CSS pixels) passes 1.
+ */
+export function resolveBarDimensions(
+  options: WaveSurferOptions,
+  pixelRatio: number,
+): { barWidth: number; barGap: number } {
+  const barWidth = options.barWidth ? options.barWidth * pixelRatio : 1
+  const barGap = options.barGap ? options.barGap * pixelRatio : options.barWidth ? barWidth / 2 : 0
+  return { barWidth, barGap }
 }
 
 export function calculateBarRenderConfig({
@@ -43,8 +63,7 @@ export function calculateBarRenderConfig({
   pixelRatio: number
 }) {
   const halfHeight = height / 2
-  const barWidth = options.barWidth ? options.barWidth * pixelRatio : 1
-  const barGap = options.barGap ? options.barGap * pixelRatio : options.barWidth ? barWidth / 2 : 0
+  const { barWidth, barGap } = resolveBarDimensions(options, pixelRatio)
   const barRadius = options.barRadius || 0
   const barMinHeight = options.barMinHeight ? options.barMinHeight * pixelRatio : 0
   const spacing = barWidth + barGap || 1
@@ -182,10 +201,10 @@ export function calculateBarSegments({
 }
 
 export function getRelativePointerPosition(rect: DOMRect, clientX: number, clientY: number): [number, number] {
-  const x = clientX - rect.left
-  const y = clientY - rect.top
-  const relativeX = x / rect.width
-  const relativeY = y / rect.height
+  // A hidden or not-yet-laid-out container has a zero-size rect; dividing by
+  // it would yield NaN relative coordinates (and NaN seeks downstream).
+  const relativeX = rect.width > 0 ? (clientX - rect.left) / rect.width : 0
+  const relativeY = rect.height > 0 ? (clientY - rect.top) / rect.height : 0
   return [relativeX, relativeY]
 }
 
@@ -223,6 +242,12 @@ export function shouldRenderBars(options: WaveSurferOptions): boolean {
   return Boolean(options.barWidth || options.barGap || options.barAlign)
 }
 
+// A single reusable scratch canvas for gradient creation: resolveColorValue
+// runs on every draw (including scroll-time lazy draws), and allocating a
+// throwaway <canvas> per call caused needless GC churn. Lazily created so
+// importing this module never touches the DOM.
+let gradientScratchCanvas: HTMLCanvasElement | null = null
+
 export function resolveColorValue(
   color: WaveSurferOptions['waveColor'],
   devicePixelRatio: number,
@@ -232,10 +257,10 @@ export function resolveColorValue(
   if (color.length === 0) return '#999'
   if (color.length < 2) return color[0] || ''
 
-  const canvasElement = document.createElement('canvas')
-  const ctx = canvasElement.getContext('2d')
+  gradientScratchCanvas ??= document.createElement('canvas')
+  const ctx = gradientScratchCanvas.getContext('2d')
   if (!ctx) return color[0] || ''
-  const gradientHeight = canvasHeight || canvasElement.height * devicePixelRatio
+  const gradientHeight = canvasHeight || gradientScratchCanvas.height * devicePixelRatio
   const gradient = ctx.createLinearGradient(0, 0, 0, gradientHeight)
 
   const colorStopPercentage = 1 / (color.length - 1)
@@ -274,8 +299,10 @@ export function calculateWaveformLayout({
 
 export function clampWidthToBarGrid(width: number, options: WaveSurferOptions): number {
   if (!shouldRenderBars(options)) return width
-  const barWidth = options.barWidth || 0.5
-  const barGap = options.barGap || barWidth / 2
+  // Resolve through the same defaults the bar-drawing site uses (at
+  // pixelRatio 1, since layout works in CSS pixels) -- divergent defaults
+  // here produced a clipped bar / irregular gap at canvas seams at dpr=1.
+  const { barWidth, barGap } = resolveBarDimensions(options, 1)
   const totalBarWidth = barWidth + barGap
   if (totalBarWidth === 0) return width
   return Math.floor(width / totalBarWidth) * totalBarWidth
@@ -349,17 +376,30 @@ export function shouldClearCanvases(currentNodeCount: number): boolean {
 
 export function getLazyRenderRange({
   scrollLeft,
-  totalWidth,
+  clientWidth,
+  singleCanvasWidth,
   numCanvases,
 }: {
   scrollLeft: number
-  totalWidth: number
+  clientWidth: number
+  singleCanvasWidth: number
   numCanvases: number
 }): number[] {
-  if (totalWidth === 0) return [0]
-  const viewPosition = scrollLeft / totalWidth
-  const startCanvas = Math.floor(viewPosition * numCanvases)
-  return [startCanvas - 1, startCanvas, startCanvas + 1]
+  if (singleCanvasWidth <= 0 || numCanvases <= 0) return [0]
+  // Canvas i occupies [i * singleCanvasWidth, (i + 1) * singleCanvasWidth)
+  // (only the tail one may be narrower), so index both viewport edges against
+  // the ACTUAL canvas width. The previous average-width math
+  // (scrollLeft / totalWidth * numCanvases, +/- 1) could miss the canvas at a
+  // viewport edge by up to a bar spacing when singleCanvasWidth was bar-grid
+  // clamped below clientWidth -- an undrawn strip. One extra canvas on each
+  // side is prefetch; draw() ignores out-of-range indexes.
+  const startCanvas = Math.min(numCanvases - 1, Math.floor(scrollLeft / singleCanvasWidth))
+  const endCanvas = Math.min(numCanvases - 1, Math.floor((scrollLeft + clientWidth) / singleCanvasWidth))
+  const range: number[] = []
+  for (let i = startCanvas - 1; i <= endCanvas + 1; i++) {
+    range.push(i)
+  }
+  return range
 }
 
 /**
@@ -458,8 +498,7 @@ export function calculateLinePaths({
   })
 }
 
+/** Round to the nearest integer, with exact halves rounded away from zero. */
 export function roundToHalfAwayFromZero(value: number): number {
-  const scaled = value * 2
-  const rounded = scaled < 0 ? Math.floor(scaled) : Math.ceil(scaled)
-  return rounded / 2
+  return Math.sign(value) * Math.round(Math.abs(value))
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -704,7 +704,8 @@ class Renderer {
     // Lazy rendering
     const initialRange = utils.getLazyRenderRange({
       scrollLeft: this.scrollContainer.scrollLeft,
-      totalWidth,
+      clientWidth,
+      singleCanvasWidth: plan.singleCanvasWidth,
       numCanvases: plan.numCanvases,
     })
     initialRange.forEach((index) => draw(index))
@@ -714,10 +715,17 @@ class Renderer {
     // stays the source of truth for the pixel math, unchanged from before.
     if (plan.numCanvases > 1) {
       const unsubscribe = effect(() => {
-        const { scrollLeft } = this.scrollContainer
+        // Re-read both scroll position and viewport width from the DOM per
+        // pass -- the viewport can resize between scrolls.
+        const { scrollLeft, clientWidth: viewportWidth } = this.scrollContainer
         clearCanvases()
         utils
-          .getLazyRenderRange({ scrollLeft, totalWidth, numCanvases: plan.numCanvases })
+          .getLazyRenderRange({
+            scrollLeft,
+            clientWidth: viewportWidth,
+            singleCanvasWidth: plan.singleCanvasWidth,
+            numCanvases: plan.numCanvases,
+          })
           .forEach((index) => draw(index))
       }, [this.visibleRange])
 
@@ -772,10 +780,15 @@ class Renderer {
     this.canvasWrapper.innerHTML = ''
     this.progressWrapper.innerHTML = ''
 
-    // Width
+    // Width. Always write the style: setOptions merges options, so a width
+    // that was once set persists until the user passes an explicit
+    // `width: undefined`/null -- which must clear the fixed width again and
+    // revert to the default fill behavior.
     if (this.options.width != null) {
       this.scrollContainer.style.width =
         typeof this.options.width === 'number' ? `${this.options.width}px` : this.options.width
+    } else {
+      this.scrollContainer.style.width = ''
     }
 
     // Determine the width of the waveform

--- a/src/spectrogram-frequencies.ts
+++ b/src/spectrogram-frequencies.ts
@@ -126,9 +126,10 @@ export type FrequencyParams = {
   /** Shape parameter used only by the 'blackman' and 'gauss' window functions. */
   alpha?: number
   /**
-   * Frame overlap in samples. A falsy value (0, null, or undefined) falls back to
-   * round(fftSamples * 0.5) - this mirrors the worker's original behavior, where an
-   * explicit 0 is indistinguishable from "not set".
+   * Frame overlap in samples, honored up to fftSamples - 1 (the hop size always stays >= 1
+   * sample, so values >= fftSamples are clamped to fftSamples - 1). A falsy value (0, null, or
+   * undefined) falls back to round(fftSamples * 0.5) - this mirrors the worker's original
+   * behavior, where an explicit 0 is indistinguishable from "not set".
    */
   noverlap?: number | null
   /** Frequency axis scale used to build the filter bank. */
@@ -186,12 +187,13 @@ export function computeFrequencies(channels: Float32Array[], params: FrequencyPa
   const filterBank = createSparseFilterBankForScale(scale, numFilters, fftLength, sampleRate)
 
   // Calculate hop size; integer arithmetic so non-power-of-two windows cannot produce
-  // fractional frame starts
+  // fractional frame starts. noverlap is honored as documented ("must be < fftSamples"):
+  // the only clamp is to fftSamples - 1, keeping the hop at >= 1 sample so the frame loop
+  // always advances. (The historical silent 50% cap and 64-sample hop floor contradicted
+  // that contract, quietly halving the requested overlap.)
   let actualNoverlap = noverlap || Math.max(0, Math.round(fftSamples * 0.5))
-  const maxOverlap = Math.floor(fftSamples / 2)
-  actualNoverlap = Math.min(actualNoverlap, maxOverlap)
-  const minHopSize = Math.max(64, Math.ceil(fftSamples * 0.25))
-  const hopSize = Math.max(minHopSize, fftSamples - actualNoverlap)
+  actualNoverlap = Math.min(actualNoverlap, fftSamples - 1)
+  const hopSize = Math.max(1, fftSamples - actualNoverlap)
 
   const frequencies: Uint8Array[][] = []
 

--- a/src/spectrogram-render-utils.ts
+++ b/src/spectrogram-render-utils.ts
@@ -30,6 +30,17 @@ export function logToHz(log: number): number {
   return Math.pow(10, log)
 }
 
+/**
+ * The raw Traunmüller-corrected bark value at 0 Hz (~-0.1505): raw bark(0) = -0.53, then the
+ * bark < 2 correction adds 0.15 * (2 + 0.53). Subtracted in hzToBark (and added back in
+ * barkToHz, keeping the pair exact inverses) so hzToBark(0) === 0 - the vertical-mapping code
+ * (renderChannelToCanvas / drawSpectrogramSegment) divides hzToScale values assuming every
+ * scale maps 0 Hz to 0, and the raw bark offset produced a slightly negative rMin and
+ * out-of-range bitmap source rows (~0.6% offset). Written with the exact operations hzToBark
+ * itself performs at 0 Hz so the subtraction cancels to exactly 0 in floating point.
+ */
+const BARK_ZERO_OFFSET = 0.15 * (2 + 0.53) - 0.53
+
 export function hzToBark(hz: number): number {
   // https://www.mathworks.com/help/audio/ref/hz2bark.html#function_hz2bark_sep_mw_06bea6f7-353b-4479-a58d-ccadb90e44de
   let bark = (26.81 * hz) / (1960 + hz) - 0.53
@@ -39,11 +50,14 @@ export function hzToBark(hz: number): number {
   if (bark > 20.1) {
     bark += 0.22 * (bark - 20.1)
   }
-  return bark
+  // Normalize so 0 Hz maps to exactly 0 (see BARK_ZERO_OFFSET above)
+  return bark - BARK_ZERO_OFFSET
 }
 
 export function barkToHz(bark: number): number {
   // https://www.mathworks.com/help/audio/ref/bark2hz.html#function_bark2hz_sep_mw_bee310ea-48ac-4d95-ae3d-80f3e4149555
+  // Undo hzToBark's zero-normalization shift first, so the pair stays exact inverses
+  bark += BARK_ZERO_OFFSET
   if (bark < 2) {
     bark = (bark - 0.3) / 0.85
   }
@@ -617,7 +631,9 @@ export function setupColorMap(colorMap: number[][] | 'gray' | 'igray' | 'roseus'
  * loadFrequenciesData's externally supplied JSON (see SpectrogramPluginOptions.frequenciesDataUrl
  * in spectrogram-setup.ts) is only assumed, never runtime-validated, to already be in range - an
  * out-of-range index would otherwise read `colorMap[colorIndex]` out of bounds and throw on
- * `color[0]` off `undefined` instead of just rendering the nearest valid color.
+ * `color[0]` off `undefined` instead of just rendering the nearest valid color. The clamped value
+ * is also floored, since the same external JSON can carry fractional values, and a fractional
+ * index (`colorMap[12.7]`) is just as much an out-of-bounds read as a negative one.
  *
  * Lives here (not in spectrogram-setup.ts, despite being consumed there too) so
  * spectrogram-windowing.ts - which spectrogram-setup.ts already imports SegmentManager etc. from
@@ -635,7 +651,9 @@ export function paintColumnPixels(
   rowCount: number,
 ): void {
   for (let row = 0; row < rowCount; row++) {
-    const colorIndex = Math.min(255, Math.max(0, column[row]))
+    // Floor AFTER clamping: externally-supplied frequenciesDataUrl JSON can carry fractional
+    // values, and a fractional index (colorMap[12.7] === undefined) would throw mid-draw
+    const colorIndex = Math.floor(Math.min(255, Math.max(0, column[row])))
     const color = colorMap[colorIndex]
     const pixelIndex = ((rowCount - row - 1) * columnCount + columnIndex) * 4
     data[pixelIndex] = color[0] * 255
@@ -643,6 +661,33 @@ export function paintColumnPixels(
     data[pixelIndex + 2] = color[2] * 255
     data[pixelIndex + 3] = color[3] * 255
   }
+}
+
+// Conservative cross-browser per-side canvas limit (Chrome/Firefox cap a side at 32767px).
+const MAX_CANVAS_DIMENSION = 32767
+// Most conservative common backing-store area cap (4096 x 4096, older iOS Safari).
+const MAX_CANVAS_AREA = 16777216
+
+/**
+ * Device pixel ratio to use for a spectrogram canvas backing store of the given CSS size, so
+ * HiDPI displays get a crisp spectrogram (matching the axis-labels canvas, which has always
+ * scaled by devicePixelRatio) while the CSS size stays unchanged. Clamped down (never below 1)
+ * so neither backing dimension exceeds MAX_CANVAS_DIMENSION and the backing area stays within
+ * MAX_CANVAS_AREA - very wide full-mode/windowed canvases would otherwise silently fail to
+ * draw in browsers with per-side or per-area canvas limits, which is worse than a blurry one.
+ */
+export function getCanvasPixelRatio(cssWidth: number, cssHeight: number): number {
+  const dpr = (typeof window !== 'undefined' && window.devicePixelRatio) || 1
+  if (dpr <= 1 || cssWidth <= 0 || cssHeight <= 0) return 1
+  return Math.max(
+    1,
+    Math.min(
+      dpr,
+      MAX_CANVAS_DIMENSION / cssWidth,
+      MAX_CANVAS_DIMENSION / cssHeight,
+      Math.sqrt(MAX_CANVAS_AREA / (cssWidth * cssHeight)),
+    ),
+  )
 }
 
 /**

--- a/src/spectrogram-setup.ts
+++ b/src/spectrogram-setup.ts
@@ -24,6 +24,7 @@ import {
   createWrapperClickHandler,
   AUTO_GAIN_BUFFER_BUDGET_BYTES,
   paintColumnPixels,
+  getCanvasPixelRatio,
 } from './spectrogram-render-utils.js'
 import { computeFrequencies, type FrequencyParams } from './spectrogram-frequencies.js'
 // Windowed rendering strategy: segment map, eviction, uncovered-range
@@ -101,7 +102,11 @@ export type SpectrogramPluginOptions = {
   labelsBackground?: string
   labelsColor?: string
   labelsHzColor?: string
-  /** Size of the overlapping window. Must be < fftSamples. Auto deduced from canvas size by default. */
+  /**
+   * Size of the overlapping window, in samples. Must be < fftSamples; larger values are
+   * clamped to fftSamples - 1 (the hop size always stays >= 1 sample). Auto deduced from
+   * canvas size by default.
+   */
   noverlap?: number
   /** The window function to be used. */
   windowFunc?:
@@ -512,8 +517,15 @@ export function spectrogramSetup(
       },
     }) as HTMLCanvasElement
 
-    canvas.width = Math.round(width)
-    canvas.height = Math.round(height)
+    // HiDPI: scale the backing store by devicePixelRatio (clamped for browser canvas limits)
+    // while the CSS size above stays width x height, so the spectrogram renders as crisp as
+    // its own axis labels (which have always scaled by devicePixelRatio). Drawing code keeps
+    // using CSS coordinates: the context scale below persists for every later getContext('2d')
+    // call on this canvas, since that returns the same context instance.
+    const pixelRatio = getCanvasPixelRatio(width, height)
+    canvas.width = Math.round(width * pixelRatio)
+    canvas.height = Math.round(height * pixelRatio)
+    if (pixelRatio !== 1) canvas.getContext('2d')?.scale(pixelRatio, pixelRatio)
 
     canvasContainer.appendChild(canvas)
     return canvas
@@ -1502,10 +1514,11 @@ export function spectrogramSetup(
 
     for (let c = 0; c < channels; c++) {
       // for each channel
-      // fill background
+      // fill background: one row-height rect per channel. (fillRect's 4th argument is a
+      // HEIGHT, not an end coordinate - the historical `(1 + c) * getMaxY` overdrew every
+      // row below channel c, double-painting a translucent background per extra channel.)
       canvasCtx.fillStyle = bgFill
-      canvasCtx.fillRect(0, c * getMaxY, bgWidth, (1 + c) * getMaxY)
-      canvasCtx.fill()
+      canvasCtx.fillRect(0, c * getMaxY, bgWidth, getMaxY)
 
       // render labels
       for (let i = 0; i <= labelIndex; i++) {

--- a/src/spectrogram-windowing.ts
+++ b/src/spectrogram-windowing.ts
@@ -17,7 +17,7 @@
  * progressive scheduling unit-testable in isolation (see spectrogram-windowing.test.ts).
  */
 
-import { hzToScale, paintColumnPixels } from './spectrogram-render-utils.js'
+import { hzToScale, paintColumnPixels, getCanvasPixelRatio } from './spectrogram-render-utils.js'
 
 /** One lazily-computed slice of the sliding window's frequency data. */
 export interface FrequencySegment {
@@ -61,9 +61,17 @@ export interface SegmentManagerDeps {
 export interface SegmentManagerOptions {
   /** Enable progressive background loading of the whole buffer (default: false). */
   progressiveLoading?: boolean
-  /** Cap on retained segments before farthest-from-view ones are evicted (default: 48). */
-  maxRetainedSegments?: number
+  /**
+   * Byte budget for retained segment canvas backing stores (width * height * 4 per canvas)
+   * before farthest-from-view segments are evicted (default: 256MB). A byte budget, not a
+   * segment count: segment canvas sizes vary hugely with zoom/height/devicePixelRatio, and a
+   * fixed segment count could retain far more canvas memory than mobile Safari's budget allows.
+   */
+  maxRetainedBytes?: number
 }
+
+/** Default eviction budget for retained segment canvases: 256MB, safely under Safari's canvas memory budget. */
+export const DEFAULT_MAX_RETAINED_BYTES = 256 * 1024 * 1024
 
 // Fixed-size progressive-loading segments (seconds); independent of viewport zoom, unlike
 // the pixel-width-driven segments generateSegments creates for on-demand viewport rendering.
@@ -88,7 +96,7 @@ export class SegmentManager {
   readonly segments = new Map<string, FrequencySegment>()
   isProgressiveLoading = false
   nextProgressiveSegmentTime = 0
-  maxRetainedSegments: number
+  maxRetainedBytes: number
   progressiveLoading: boolean
 
   private readonly deps: SegmentManagerDeps
@@ -113,7 +121,7 @@ export class SegmentManager {
 
   constructor(deps: SegmentManagerDeps, options: SegmentManagerOptions = {}) {
     this.deps = deps
-    this.maxRetainedSegments = options.maxRetainedSegments ?? 48
+    this.maxRetainedBytes = options.maxRetainedBytes ?? DEFAULT_MAX_RETAINED_BYTES
     this.progressiveLoading = options.progressiveLoading ?? false
   }
 
@@ -124,12 +132,24 @@ export class SegmentManager {
     this.segments.clear()
   }
 
+  /** Canvas backing-store bytes retained by one segment (width * height * 4; 0 before its canvas exists). */
+  private static segmentCanvasBytes(segment: FrequencySegment): number {
+    return segment.canvas ? segment.canvas.width * segment.canvas.height * 4 : 0
+  }
+
   /**
-   * Evict segments whose midpoint is farthest from currentTime once the retained count
-   * exceeds maxRetainedSegments, so memory usage stays bounded regardless of audio length.
+   * Evict segments whose midpoint is farthest from currentTime once the retained canvas
+   * memory (width * height * 4 per canvas) exceeds maxRetainedBytes, so memory usage stays
+   * bounded regardless of audio length. The nearest segment is never evicted, even when it
+   * alone exceeds the budget - removing what the user is looking at would only force an
+   * immediate recompute of the same segment (thrash), not save memory for long.
    */
   evictDistantSegments(currentTime: number): void {
-    if (this.segments.size <= this.maxRetainedSegments) return
+    let totalBytes = 0
+    for (const segment of this.segments.values()) {
+      totalBytes += SegmentManager.segmentCanvasBytes(segment)
+    }
+    if (totalBytes <= this.maxRetainedBytes) return
 
     const entries = Array.from(this.segments.entries())
     // Farthest-from-currentTime first
@@ -139,9 +159,10 @@ export class SegmentManager {
       return distB - distA
     })
 
-    const numToEvict = this.segments.size - this.maxRetainedSegments
-    for (let i = 0; i < numToEvict; i++) {
+    // Evict farthest-first until back under budget; entries.length - 1 spares the nearest
+    for (let i = 0; i < entries.length - 1 && totalBytes > this.maxRetainedBytes; i++) {
       const [key, segment] = entries[i]
+      totalBytes -= SegmentManager.segmentCanvasBytes(segment)
       segment.canvas?.remove()
       this.segments.delete(key)
     }
@@ -226,6 +247,24 @@ export class SegmentManager {
     const uncoveredRanges = this.findUncoveredTimeRanges(startTime, endTime)
     if (uncoveredRanges.length === 0) return
 
+    // Count the segments this call will walk, with the same loop shape as below so the float
+    // stepping matches exactly. Progressive-load calls keep reporting the loader's whole-buffer
+    // cursor via getLoadingProgress(); viewport-driven calls (the default, non-progressive
+    // loading path, where that cursor never moves and progress used to sit at 0 forever)
+    // report this call's own fraction of segments processed instead, reaching exactly 1 when
+    // the call has covered everything it set out to render.
+    let totalSegments = 0
+    for (const range of uncoveredRanges) {
+      for (let time = range.start; time < range.end; time += segmentDuration) totalSegments++
+    }
+    let processedSegments = 0
+    const emitSegmentProgress = () => {
+      processedSegments++
+      this.deps.emitProgress(
+        isProgressiveLoadCall ? this.getLoadingProgress() / 100 : processedSegments / totalSegments,
+      )
+    }
+
     for (const range of uncoveredRanges) {
       for (let time = range.start; time < range.end; time += segmentDuration) {
         const segmentStart = time
@@ -233,10 +272,23 @@ export class SegmentManager {
         const segmentKey = `${Math.floor(segmentStart * 10)}_${Math.floor(segmentEnd * 10)}`
 
         // Double-check if segment already exists (shouldn't happen but be safe)
-        if (this.segments.has(segmentKey)) continue
+        if (this.segments.has(segmentKey)) {
+          emitSegmentProgress()
+          continue
+        }
 
         const frequencies = await this.deps.computeSegmentFrequencies(segmentStart, segmentEnd)
         if (this.deps.isDisposed()) return
+
+        // Re-check after the await: a concurrent generateSegments() (the progressive loader
+        // races the viewport-driven calls - only renderVisibleWindow has a re-entrancy guard)
+        // may have created and rendered this same segment while we were computing. Overwriting
+        // its map entry here would orphan its canvas: still attached to the DOM, but no longer
+        // reachable through the map, so eviction could never remove it.
+        if (this.segments.has(segmentKey)) {
+          emitSegmentProgress()
+          continue
+        }
 
         if (frequencies && frequencies.length > 0) {
           const segment: FrequencySegment = {
@@ -252,8 +304,15 @@ export class SegmentManager {
           await this.deps.renderSegment(segment)
           if (this.deps.isDisposed()) return
 
-          this.deps.emitProgress(this.getLoadingProgress() / 100)
+          // Re-check identity after the await: the segment may have been evicted (or replaced,
+          // or cleared by a reset for a new buffer) while renderSegment was in flight - the
+          // canvas that render just attached would be orphaned in the DOM, so remove it.
+          if (this.segments.get(segmentKey) !== segment) {
+            segment.canvas?.remove()
+          }
         }
+
+        emitSegmentProgress()
       }
     }
 
@@ -371,6 +430,10 @@ export class SegmentManager {
 
     if (this.nextProgressiveSegmentTime >= totalDuration) {
       this.stopProgressiveLoading()
+      // The whole buffer is covered: report completion. Each tick's own emit (via
+      // generateSegments) reports the cursor position BEFORE that tick's segment loaded, so
+      // without this the last emitted value would forever sit one segment short of 1.
+      this.deps.emitProgress(1)
       return
     }
 
@@ -576,8 +639,12 @@ export async function renderFrequencySegment(segment: FrequencySegment, opts: Se
   const totalHeight = opts.height * segment.frequencies.length
 
   const canvas = document.createElement('canvas')
-  canvas.width = Math.round(segmentWidth)
-  canvas.height = Math.round(totalHeight)
+  // HiDPI: scale the backing store by devicePixelRatio (clamped for browser canvas limits)
+  // while the CSS size stays segmentWidth x totalHeight, so windowed segments render as crisp
+  // as the axis labels; drawing below stays in CSS coordinates via the context scale.
+  const pixelRatio = getCanvasPixelRatio(segmentWidth, totalHeight)
+  canvas.width = Math.round(segmentWidth * pixelRatio)
+  canvas.height = Math.round(totalHeight * pixelRatio)
   canvas.style.position = 'absolute'
   canvas.style.left = `${segment.startPixel}px`
   canvas.style.top = '0'
@@ -586,6 +653,7 @@ export async function renderFrequencySegment(segment: FrequencySegment, opts: Se
 
   const canvasCtx = canvas.getContext('2d')
   if (!canvasCtx) return
+  if (pixelRatio !== 1) canvasCtx.scale(pixelRatio, pixelRatio)
 
   for (let c = 0; c < segment.frequencies.length; c++) {
     await renderChannelToCanvas(segment.frequencies[c], canvasCtx, segmentWidth, opts.height, c * opts.height, opts)

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -375,8 +375,21 @@ class WaveSurfer extends EventEmitter<WaveSurferEvents> {
     this.mediaEventScope.add(
       this.player.onMediaEvent('error', () => {
         // Deliberately the raw media (never null): under the WebAudio backend
-        // the error lives on the WebAudioPlayer's media surface.
-        this.emit('error', (this.player.getMediaElement().error ?? new Error('Media error')) as Error)
+        // the error lives on the WebAudioPlayer's media surface (and is
+        // already a real Error there). An HTMLMediaElement reports a
+        // MediaError, which is NOT an Error -- normalize it so the public
+        // 'error' event typing is honest, preserving the MediaError's
+        // message and code.
+        const mediaError = this.player.getMediaElement().error
+        let error: Error
+        if (mediaError instanceof Error) {
+          error = mediaError
+        } else if (mediaError) {
+          error = new Error(mediaError.message || `Media error ${mediaError.code}`)
+        } else {
+          error = new Error('Media error')
+        }
+        this.emit('error', error)
         this.stopAtPosition = null
       }),
     )
@@ -594,7 +607,22 @@ class WaveSurfer extends EventEmitter<WaveSurferEvents> {
     return this.plugins
   }
 
-  private async loadAudio(url: string, blob?: Blob, channelData?: WaveSurferOptions['peaks'], duration?: number) {
+  /**
+   * Classify a bailed-out (disposed-scope) load: 'superseded' when a newer
+   * load()/loadBlob() took over -- the old call's promise must then reject
+   * with a canonical AbortError (see load()) -- and undefined for a
+   * destroy-triggered disposal, which keeps its existing settle contract.
+   */
+  private bailedLoadOutcome(loadScope: Scope): 'superseded' | undefined {
+    return this.supersededLoadScopes.has(loadScope) ? 'superseded' : undefined
+  }
+
+  private async loadAudio(
+    url: string,
+    blob?: Blob,
+    channelData?: WaveSurferOptions['peaks'],
+    duration?: number,
+  ): Promise<'superseded' | undefined> {
     // destroy() is terminal: a post-destroy load must reject (catchably --
     // this async throw becomes a rejection that load()/loadBlob() classify
     // and re-emit as 'error') rather than resurrect torn-down bridges.
@@ -673,7 +701,7 @@ class WaveSurfer extends EventEmitter<WaveSurferEvents> {
         const onProgress = (percentage: number) => this.emit('loading', percentage)
         blob = await Fetcher.fetchBlob(url, onProgress, fetchParams)
         // Guard: bail if a newer load started or the instance was destroyed
-        if (loadScope.disposed) return
+        if (loadScope.disposed) return this.bailedLoadOutcome(loadScope)
         const overriddenMimeType = this.options.blobMimeType
         if (overriddenMimeType) {
           blob = new Blob([blob], { type: overriddenMimeType })
@@ -681,7 +709,7 @@ class WaveSurfer extends EventEmitter<WaveSurferEvents> {
       }
 
       // Guard: bail if a newer load started or the instance was destroyed
-      if (loadScope.disposed) return
+      if (loadScope.disposed) return this.bailedLoadOutcome(loadScope)
 
       // Set the mediaelement source
       this.player.setSrc(url, blob)
@@ -695,24 +723,31 @@ class WaveSurfer extends EventEmitter<WaveSurferEvents> {
           this.mediaEventScope.add(
             this.player.onMediaEvent('loadedmetadata', () => resolve(this.getDuration()), { once: true }),
           )
-          // Settle if this load is superseded or the instance is destroyed
-          // before 'loadedmetadata' ever fires (e.g. never emitted by the
-          // test/media environment) -- otherwise this promise, and thus
-          // loadAudio()/load(), would hang forever. Registered on loadScope
-          // (not mediaEventScope, which the 'loadedmetadata' listener above
-          // must stay on -- moving it there would remove it, and thus resolve
-          // this promise, on every load's disposal, not just this one's).
-          // Late registration on an already-disposed scope runs immediately
-          // (see Scope.add), so this is safe even if loadScope somehow
-          // disposes synchronously before this line runs. The resolved value
-          // is discarded either way: the very next `if (loadScope.disposed)
-          // return` bails before audioDuration is used.
-          loadScope.add(() => resolve(0))
+          // Settle if the media-event bridge is torn down before
+          // 'loadedmetadata' ever fires: setMediaElement() disposes
+          // mediaEventScope (killing the listener above) WITHOUT disposing
+          // loadScope, so without this hook the promise -- and thus
+          // loadAudio()/load() -- would hang forever; the load then continues
+          // against the new media with an unknown (0) duration, and the
+          // decode step recovers the real duration where possible.
+          const settleOnBridgeTeardown = this.mediaEventScope.add(() => resolve(0))
+          // Also settle if this load is superseded or the instance is
+          // destroyed before 'loadedmetadata' ever fires (e.g. never emitted
+          // by the test/media environment). Running settleOnBridgeTeardown
+          // here both resolves the promise and deregisters the bridge hook
+          // above, so completed loads don't accumulate stale disposers on
+          // mediaEventScope. Late registration on an already-disposed scope
+          // runs immediately (see Scope.add), so this is safe even if
+          // loadScope somehow disposes synchronously before this line runs.
+          // The resolved value is discarded either way: the very next
+          // `if (loadScope.disposed) return` bails before audioDuration is
+          // used.
+          loadScope.add(settleOnBridgeTeardown)
         }
       })
 
       // Guard: bail if a newer load started or the instance was destroyed
-      if (loadScope.disposed) return
+      if (loadScope.disposed) return this.bailedLoadOutcome(loadScope)
 
       // Set the duration if the player is a WebAudioPlayer without a URL
       if (!url && !blob && this.webAudioPlayer) {
@@ -729,18 +764,18 @@ class WaveSurfer extends EventEmitter<WaveSurferEvents> {
       } else if (blob) {
         const arrayBuffer = await blob.arrayBuffer()
         // Guard: bail if a newer load started or the instance was destroyed
-        if (loadScope.disposed) return
+        if (loadScope.disposed) return this.bailedLoadOutcome(loadScope)
         // Decode into a local first: assigning `this.decodedData = await ...`
         // directly would repopulate the field AFTER destroy()'s cleanup ran
         // (the continuation resumes past it), retaining the large buffer on a
         // destroyed instance.
         const decoded = await Decoder.decode(arrayBuffer, this.options.sampleRate)
-        if (loadScope.disposed) return
+        if (loadScope.disposed) return this.bailedLoadOutcome(loadScope)
         this.decodedData = decoded
       }
 
       // Guard: bail if a newer load started or the instance was destroyed
-      if (loadScope.disposed) return
+      if (loadScope.disposed) return this.bailedLoadOutcome(loadScope)
 
       if (this.decodedData) {
         this.wavesurferActions.setAudioBuffer(this.decodedData)
@@ -761,11 +796,13 @@ class WaveSurfer extends EventEmitter<WaveSurferEvents> {
       this.emit('ready', this.getDuration())
     } catch (err) {
       // Superseded loads were marked in supersededLoadScopes at the moment
-      // supersession happened (see the top of this method): swallow those,
-      // the new load owns the state now. Everything else -- destroy
-      // mid-load, or a genuine failure -- must propagate so load()/loadBlob()
-      // rejects and emits 'error' (issue #3637 / cypress/e2e/abort.cy.js
-      // contract).
+      // supersession happened (see the top of this method): swallow the raw
+      // pipeline error (e.g. the aborted fetch's AbortError) -- the new load
+      // owns the state now -- and report the supersession outcome so load()
+      // rejects with the canonical AbortError instead. Everything else --
+      // destroy mid-load, or a genuine failure -- must propagate so
+      // load()/loadBlob() rejects and emits 'error' (issue #3637 /
+      // cypress/e2e/abort.cy.js contract).
       if (!this.supersededLoadScopes.has(loadScope)) {
         // Write the 'error' phase here, not in load()/loadBlob()'s catches,
         // and only when this load is still the current one (this.loadScope
@@ -777,27 +814,55 @@ class WaveSurfer extends EventEmitter<WaveSurferEvents> {
         }
         throw err
       }
+      return 'superseded'
     }
+    return undefined
   }
 
-  /** Load an audio file by URL, with optional pre-decoded audio data */
-  public async load(url: string, channelData?: WaveSurferOptions['peaks'], duration?: number) {
-    try {
-      return await this.loadAudio(url, undefined, channelData, duration)
-    } catch (err) {
-      this.emit('error', err as Error)
-      throw err
-    }
+  /**
+   * Classify the settled loadAudio() pipeline for the public promise:
+   * a superseded load rejects with a canonical AbortError (v8) but emits NO
+   * public 'error' event -- supersession is normal control flow, not a
+   * failure; every real rejection (destroy mid-load, fetch/decode failure)
+   * keeps emitting 'error' before propagating. A no-op rejection handler is
+   * attached to the SAME promise object that is returned, so fire-and-forget
+   * callers produce no unhandled-rejection noise while awaiting callers
+   * still observe the rejection.
+   */
+  private classifyLoadResult(loadResult: Promise<'superseded' | undefined>): Promise<void> {
+    const promise = loadResult.then(
+      (outcome) => {
+        if (outcome === 'superseded') {
+          throw new DOMException('The load was superseded by a newer load call', 'AbortError')
+        }
+      },
+      (err) => {
+        this.emit('error', err as Error)
+        throw err
+      },
+    )
+    promise.catch(() => undefined)
+    return promise
   }
 
-  /** Load an audio blob */
-  public async loadBlob(blob: Blob, channelData?: WaveSurferOptions['peaks'], duration?: number) {
-    try {
-      return await this.loadAudio('', blob, channelData, duration)
-    } catch (err) {
-      this.emit('error', err as Error)
-      throw err
-    }
+  /**
+   * Load an audio file by URL, with optional pre-decoded audio data.
+   * If a newer load()/loadBlob() supersedes this call before it completes,
+   * the returned promise rejects with an AbortError DOMException (and no
+   * 'error' event is emitted for it).
+   */
+  public load(url: string, channelData?: WaveSurferOptions['peaks'], duration?: number): Promise<void> {
+    return this.classifyLoadResult(this.loadAudio(url, undefined, channelData, duration))
+  }
+
+  /**
+   * Load an audio blob.
+   * If a newer load()/loadBlob() supersedes this call before it completes,
+   * the returned promise rejects with an AbortError DOMException (and no
+   * 'error' event is emitted for it).
+   */
+  public loadBlob(blob: Blob, channelData?: WaveSurferOptions['peaks'], duration?: number): Promise<void> {
+    return this.classifyLoadResult(this.loadAudio('', blob, channelData, duration))
   }
 
   /** Zoom the waveform by a given pixels-per-second factor */

--- a/src/webaudio.ts
+++ b/src/webaudio.ts
@@ -79,6 +79,11 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
   }
 
   private _destroyed = false
+  // Guards the src setter's async fetch/decode chain: each src assignment (and
+  // destroy()) bumps the generation, so a stale chain can never apply its
+  // decoded buffer -- even when the same URL is assigned again later.
+  private srcGeneration = 0
+  private srcFetchAbort: AbortController | null = null
 
   /** Clean up all resources. Idempotent — safe to call multiple times. */
   destroy() {
@@ -88,8 +93,10 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
     // Tear down the stopAt() 'ended' listener, if any is pending
     this.scope.dispose()
 
-    // Clear currentSrc so any in-flight fetch/decode chains bail out
-    // via their existing `this.currentSrc !== value` guards
+    // Invalidate and abort any in-flight fetch/decode chain
+    this.srcGeneration++
+    this.srcFetchAbort?.abort()
+    this.srcFetchAbort = null
     this.currentSrc = ''
 
     // Stop and disconnect buffer node
@@ -130,13 +137,24 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
     // A new load starts with a clean slate, like HTMLMediaElement.error
     this.error = null
 
+    // Invalidate any in-flight fetch/decode chain for a previous assignment.
+    // A generation check (not a URL comparison) so that re-setting the SAME
+    // URL (A -> B -> A) can't let the stale first chain apply its result, and
+    // abort the previous network request outright instead of just ignoring it.
+    const generation = ++this.srcGeneration
+    this.srcFetchAbort?.abort()
+    this.srcFetchAbort = null
+
     if (!value) {
       this.buffer = null
       this.emit('emptied')
       return
     }
 
-    fetch(value)
+    const abortController = new AbortController()
+    this.srcFetchAbort = abortController
+
+    fetch(value, { signal: abortController.signal })
       .then((response) => {
         if (response.status >= 400) {
           throw new Error(`Failed to fetch ${value}: ${response.status} (${response.statusText})`)
@@ -144,11 +162,11 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
         return response.arrayBuffer()
       })
       .then((arrayBuffer) => {
-        if (this.currentSrc !== value) return null
+        if (generation !== this.srcGeneration) return null
         return this.audioContext.decodeAudioData(arrayBuffer)
       })
       .then((audioBuffer) => {
-        if (this.currentSrc !== value) return
+        if (generation !== this.srcGeneration) return
 
         this.buffer = audioBuffer
 
@@ -158,7 +176,7 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
         if (this.autoplay) this.play()
       })
       .catch((err) => {
-        if (this.currentSrc !== value) return // stale request lost the race
+        if (generation !== this.srcGeneration) return // stale request lost the race
         // Emit error for proper error handling
         console.error('WebAudioPlayer load error:', err)
         this.error = err instanceof Error ? err : new Error(String(err))
@@ -216,6 +234,13 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
 
   async play() {
     if (!this.paused) return
+    // An AudioContext created without a user gesture starts suspended
+    // (autoplay policy); starting a buffer node on it "plays" silently.
+    // Not awaited: the context clock doesn't advance while suspended, so the
+    // node start below is queued correctly, and 'play' stays synchronous.
+    if (this.audioContext.state === 'suspended' && typeof this.audioContext.resume === 'function') {
+      this.audioContext.resume().catch(() => undefined)
+    }
     this._play()
     this.emit('play')
   }
@@ -231,7 +256,9 @@ class WebAudioPlayer extends EventEmitter<WebAudioPlayerEvents> {
     // media time to real time via the playback rate
     const delay = (timeSeconds - this.currentTime) / this._playbackRate
     const currentBufferNode = this.bufferNode
-    currentBufferNode?.stop(this.audioContext.currentTime + delay)
+    // A stop time already in the past would make AudioScheduledSourceNode.stop()
+    // throw a RangeError -- clamp to "now" (stop immediately) instead.
+    currentBufferNode?.stop(this.audioContext.currentTime + Math.max(0, delay))
 
     if (currentBufferNode) {
       // Each stopAt() call adds one more disposer to this.scope, even though the `{ once: true }`


### PR DESCRIPTION
## Short description

Follow-up to #4354: fixes all remaining open minor findings from `V8_REFACTORING_SPEC.md` §R6 — ~30 defects across core, renderer/DOM, plugins, and the spectrogram subsystem, delivered as four semantic commits. Every fix carries a regression test that was verified to fail before the fix (+75 new unit tests, 681 total).

## Implementation details

**Core (`fix(core)!`)** — one deliberate breaking change: a `load()` superseded by a newer `load()`/`loadBlob()` now rejects with a canonical `AbortError` instead of silently resolving (no `error` event; fire-and-forget callers get no unhandled-rejection noise via an internal no-op catch on the returned promise; the #3637 destroy/abort contracts are untouched). Also: Player's one-shot `canplay` playbackRate listener no longer survives `destroy()` with external media; `setMediaElement()` during an in-flight unknown-duration load settles that load instead of hanging it forever; a throwing subscriber can no longer kill the `FrameScheduler` loop; decoder normalization uses the global all-channel max and stops mutating caller-owned peaks arrays; `createBuffer`'s `copyFromChannel`/`copyToChannel` are real implementations; `WebAudioPlayer.play()` resumes a suspended AudioContext, stale `src` fetches are aborted/generation-guarded (including A→B→A), and past `stopAt()` times are clamped; the public `error` event always delivers a real `Error` (a `MediaError` is wrapped, code preserved).

**Renderer/DOM** — bar-grid clamping and bar drawing now share one set of spacing defaults (no more clipped bars/irregular gaps at canvas seams at dpr=1); the lazy render window indexes both viewport edges against the actual canvas width instead of the average (no undrawn edge strips); `roundToHalfAwayFromZero` actually rounds (it ceiled — outward cursor drift on wheel-zoom); an explicit `width: undefined` in `setOptions` reverts to fill behavior; pointer math guards zero-size rects and `clampToUnit` maps NaN to 0 (no NaN seeks on hidden containers); gradient resolution reuses one scratch canvas instead of allocating per draw; `isHTMLElement`'s cross-realm fallback is hardened (rejects SVG and element-shaped objects).

**Plugins** — Zoom: pre-decode wheel events let the page scroll, the pointer anchor is re-derived after external scrolls, `iterations: 1` no longer divides by zero, and the exponential baseline resets on new audio. Hover: string `lineWidth` values no longer produce NaN positioning. Timeline: notch widths are measured after DOM insertion so label culling works. Envelope: renders immediately when registered after decode, `??` fallbacks make `dragPointSize: 0` usable, and mutators no-op after destroy. Regions: `maxLength` is enforced during drag-creation and `minLength` on its finalization, `setOptions({start,end})` restyles marker↔range shape flips, and `addRegion` after destroy returns an inert region instead of throwing. Post-destroy behavior is now uniform (silent no-op) across all plugins.

**Spectrogram** — segment compute/render awaits re-check identity, removing orphaned canvases from viewport races; the `lanczoz` window computes `sinc(0) = 1` (odd window lengths no longer render blank); `noverlap` honors its documented contract (clamped only to `fftSamples - 1` instead of a silent 50% cap); `paintColumnPixels` floors fractional external-JSON values instead of throwing mid-draw; the bark scale is offset-corrected so `hzToScale(0)` is exactly 0; the windowed segment cache budget is byte-based (256MB default, farthest-first eviction) instead of a segment count (~576MB worst case before); the windowed `progress` event reports real fractions and reaches 1 under default loading; frequency labels stop overdrawing and main canvases scale by `devicePixelRatio` in both modes (clamped to browser canvas limits).

Deferred, as documented in the spec: windowed-zoom segment FFT recomputation, `dom.ts` API restructuring, and the R5 P1 guardrail items.

## How to test it

```
yarn lint && yarn typecheck   # clean
yarn test:unit                # 681 tests, 40 suites, coverage thresholds enforced
yarn test:leaks               # GC-leak harness green
yarn build                    # export verification passes
```
Cypress e2e: all specs green (92 tests) against the built dist.

## Screenshots

N/A — behavioral fixes; visible effects are corrections (no clipped bars at canvas seams, crisp spectrograms on HiDPI, no blank odd-length lanczoz spectrograms).

## Checklist
* [ ] This PR is covered by e2e tests — existing e2e suite passes; new coverage is unit-level (75 new tests)
* [ ] It introduces no breaking API changes — **one deliberate v8 breaking change**: superseded `load()` rejects with `AbortError` (documented in `V8_REFACTORING_SPEC.md` §R6.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUzhua459swLp3mXLrFuuT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUzhua459swLp3mXLrFuuT)_