### PR TITLE
ci: skip already-published versions and tag prereleases correctly on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,16 @@ jobs:
           if [ -z "$PUBLISHED_VERSION" ]; then
             echo "New version $NEW_VERSION detected"
             echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            # Publish prereleases (e.g. 8.0.0-beta.4) under their prerelease
+            # dist-tag (beta) so they don't overwrite "latest" on npm
+            PRERELEASE_ID=$(echo "$NEW_VERSION" | sed -nE 's/^[0-9.]+-([A-Za-z]+).*/\1/p')
+            if [ -n "$PRERELEASE_ID" ]; then
+              echo "tag=$PRERELEASE_ID" >> $GITHUB_OUTPUT
+              echo "prerelease=true" >> $GITHUB_OUTPUT
+            else
+              echo "tag=latest" >> $GITHUB_OUTPUT
+              echo "prerelease=false" >> $GITHUB_OUTPUT
+            fi
             LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
             git log "$LAST_TAG"..HEAD --pretty=format:"* %s by %ae" | sed -E 's/by [0-9]+\+(.+)@users.noreply.github.com/by @\1/g' | sed -E 's/ by @?katspaugh.*//g' > TEMP_CHANGELOG.md
             echo -e "\n\n---\n[![npm](https://img.shields.io/npm/v/wavesurfer.js)](https://www.npmjs.com/package/wavesurfer.js/v/$NEW_VERSION)" >> TEMP_CHANGELOG.md
@@ -48,7 +58,7 @@ jobs:
         if: ${{ steps.version.outputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
-        run: npm publish
+        run: npm publish --tag ${{ steps.version.outputs.tag }}
 
       - name: Create a git tag
         if: ${{ steps.version.outputs.version }}
@@ -62,7 +72,7 @@ jobs:
         id: create_release
         with:
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
           name: ${{ steps.version.outputs.version }}
           tag_name: ${{ steps.version.outputs.version }}
           body_path: TEMP_CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
             echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
             # Publish prereleases (e.g. 8.0.0-beta.4) under their prerelease
             # dist-tag (beta) so they don't overwrite "latest" on npm
-            PRERELEASE_ID=$(echo "$NEW_VERSION" | sed -nE 's/^[0-9.]+-([A-Za-z]+).*/\1/p')
-            if [ -n "$PRERELEASE_ID" ]; then
-              echo "tag=$PRERELEASE_ID" >> $GITHUB_OUTPUT
+            if [[ "$NEW_VERSION" == *-* ]]; then
+              PRERELEASE_ID=$(echo "$NEW_VERSION" | sed -nE 's/^[^-]+-[^A-Za-z]*([A-Za-z]+).*/\1/p' | tr '[:upper:]' '[:lower:]')
+              echo "tag=${PRERELEASE_ID:-next}" >> $GITHUB_OUTPUT
               echo "prerelease=true" >> $GITHUB_OUTPUT
             else
               echo "tag=latest" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,19 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          OLD_VERSION=$(npm show . version)
+          PACKAGE_NAME=$(node -p 'require("./package.json").name')
           NEW_VERSION=$(node -p 'require("./package.json").version')
-          if [ $NEW_VERSION != $OLD_VERSION ]; then
+          # Check if this exact version (stable or prerelease) is already on npm,
+          # not just whether it differs from the "latest" dist-tag
+          PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME@$NEW_VERSION" version 2>/dev/null || true)
+          if [ -z "$PUBLISHED_VERSION" ]; then
             echo "New version $NEW_VERSION detected"
             echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-            git log "$OLD_VERSION"..HEAD --pretty=format:"* %s by %ae" | sed -E 's/by [0-9]+\+(.+)@users.noreply.github.com/by @\1/g' | sed -E 's/ by @?katspaugh.*//g' > TEMP_CHANGELOG.md
+            LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
+            git log "$LAST_TAG"..HEAD --pretty=format:"* %s by %ae" | sed -E 's/by [0-9]+\+(.+)@users.noreply.github.com/by @\1/g' | sed -E 's/ by @?katspaugh.*//g' > TEMP_CHANGELOG.md
             echo -e "\n\n---\n[![npm](https://img.shields.io/npm/v/wavesurfer.js)](https://www.npmjs.com/package/wavesurfer.js/v/$NEW_VERSION)" >> TEMP_CHANGELOG.md
           else
-            echo "Version $OLD_VERSION hasn't changed, skipping the release"
+            echo "Version $NEW_VERSION is already published, skipping the release"
           fi
 
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## Short description
Fixes the release workflow attempting to publish on every push to main, and betas overwriting the `latest` dist-tag on npm.

## Implementation details
- **Skip already-published versions.** The "Extract version" step compared package.json against `npm show . version`, which returns the version behind the `latest` dist-tag (7.12.11). While 8.x betas are published under the `beta` dist-tag, every push looked like a new version, so `npm publish` ran and failed with `E403: cannot publish over previously published versions` (nearly every Release run since July was red). The step now checks whether the exact version from package.json — stable or prerelease — already exists on the registry (`npm view <name>@<version> version`) and skips the release if it does.
- **Publish prereleases under their prerelease dist-tag.** A plain `npm publish` tags everything as `latest`, so betas were overwriting `latest` and a bare `npm install wavesurfer.js` handed users a prerelease (the run for 8.0.0-beta.2 shows "Publishing … with tag latest"). The dist-tag is now derived from the version's prerelease identifier (`8.0.0-beta.4` → `beta`, `7.0.0-alpha.58` → `alpha`, stable → `latest`) and passed to `npm publish --tag`; the GitHub release is marked as a prerelease accordingly.
- The changelog range is now based on the most recent git tag instead of the `latest` version, so beta release notes only cover commits since the previous release rather than everything since 7.12.11.

## How to test it
- Verified against the live registry: `npm view wavesurfer.js@8.0.0-beta.3 version` and `…@7.12.11` return the version (→ skip), an unpublished version returns empty with the `|| true` guard handling npm's E404 exit code (→ release).
- Tag derivation checked for `8.0.0-beta.4` → `beta`, `7.0.0-alpha.58` → `alpha`, `8.0.0-rc.1` → `rc`, `8.0.0`/`7.12.11` → `latest`.
- Workflow YAML validated.

## Screenshots
N/A (CI-only change)

## Checklist
* [ ] This PR is covered by e2e tests — N/A, workflow-only change
* [x] It introduces no breaking API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQPSNNmG2yzMzzfyC4PG3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQPSNNmG2yzMzzfyC4PG3K)_