### PR TITLE
docs(examples): update examples for the v8 API

### DIFF
--- a/examples/phase-vocoder/index.js
+++ b/examples/phase-vocoder/index.js
@@ -1,19 +1,24 @@
 // WebAudio speed control with pitch preservation
 
 import WaveSurfer from 'wavesurfer.js'
+import WebAudioPlayer from 'wavesurfer.js/dist/webaudio.js'
+
+// Create a WebAudio player explicitly and pass it as `media`
+// so we keep a reference to it -- in v8, `getMediaElement()`
+// returns null when the WebAudio backend is used
+const webAudioPlayer = new WebAudioPlayer()
 
 // Init wavesurfer
 const wavesurfer = WaveSurfer.create({
-  backend: 'WebAudio',
   container: document.body,
   waveColor: 'violet',
   progressColor: 'purple',
+  media: webAudioPlayer,
   url: '/examples/audio/librivox.mp3',
 })
 
 // Wait for the audio to be ready
 wavesurfer.on('ready', async () => {
-  const webAudioPlayer = wavesurfer.getMediaElement()
   const gainNode = webAudioPlayer.getGainNode()
   const audioContext = gainNode.context
 

--- a/examples/pitch.js
+++ b/examples/pitch.js
@@ -45,7 +45,7 @@ pitchWorker.onmessage = (e) => {
   })
 
   // Add the canvas to the waveform container
-  wavesurfer.renderer.getWrapper().appendChild(canvas)
+  wavesurfer.getWrapper().appendChild(canvas)
   // Remove the canvas when a new audio is loaded
   wavesurfer.once('load', () => canvas.remove())
 }


### PR DESCRIPTION
## Short description
Audited all files in `examples/` against the v8 public API and updated the two examples that used APIs changed in v8. All other examples already work as-is (public events, destroy-then-`create()` pattern, and plugin import paths are unchanged in v8).

## Implementation details
- **`examples/phase-vocoder/index.js`**: it used `backend: 'WebAudio'` and then `getMediaElement()` to reach the WebAudio player's gain node. In v8, `getMediaElement()` returns `null` under the WebAudio backend, so the example now creates a `WebAudioPlayer` explicitly and passes it via the `media` option (same pattern as `webaudio-shim.js`), keeping its own reference for `getGainNode()`.
- **`examples/pitch.js`**: the `renderer` field is private in v8, so `wavesurfer.renderer.getWrapper()` was replaced with the public `wavesurfer.getWrapper()`.

## How to test it
1. `yarn build`
2. Serve the repo root and open `/index.html`, then the `pitch.js` and `phase-vocoder` examples.
3. In pitch: the pitch-detection canvas renders on top of the waveform. In phase-vocoder: the audio loads, plays, and the speed slider changes the rate with pitch preserved.

Both examples were also verified in a headless browser against the built dist (replicating `_preview.js`'s import rewriting): `ready` fires, the gain node is reachable and rewired through the worklet, `setPlaybackRate` works, playback time advances, and the pitch canvas is appended to the wrapper — with no page errors.

## Screenshots
N/A (behavioral doc/example changes only).

## Checklist
* [ ] This PR is covered by e2e tests
* [x] It introduces no breaking API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfnKnBzDq9KzMbPhn2XmUo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfnKnBzDq9KzMbPhn2XmUo)_