### PR TITLE
feat(regions): auto-scroll while dragging, resizing, or creating a region (v8 rework of #4181)

### DIFF
--- a/cypress/e2e/regions.cy.js
+++ b/cypress/e2e/regions.cy.js
@@ -92,8 +92,8 @@ describe('WaveSurfer Regions plugin tests', () => {
           clientY: 10,
         })
         region.element.dispatchEvent(pointerDownEvent)
-        win.document.dispatchEvent(pointerMoveEvent)
-        win.document.dispatchEvent(pointerUpEvent)
+        win.dispatchEvent(pointerMoveEvent)
+        win.dispatchEvent(pointerUpEvent)
 
         expect(region.start).to.be.greaterThan(3)
       })
@@ -195,9 +195,9 @@ describe('WaveSurfer Regions plugin tests', () => {
         clientY: 10,
       })
       win.wavesurfer.getWrapper().dispatchEvent(pointerDownEvent)
-      win.document.dispatchEvent(pointerMoveEvent)
+      win.dispatchEvent(pointerMoveEvent)
       expect(regionInitializedEventCalled).to.be.true
-      win.document.dispatchEvent(pointerUpEvent)
+      win.dispatchEvent(pointerUpEvent)
 
       // It shouldn't trigger a click
       expect(win.wavesurfer.getCurrentTime()).to.equal(0)
@@ -211,8 +211,8 @@ describe('WaveSurfer Regions plugin tests', () => {
       disableDragSelection()
 
       win.wavesurfer.getWrapper().querySelector('div').dispatchEvent(pointerDownEvent)
-      win.document.dispatchEvent(pointerMoveEvent)
-      win.document.dispatchEvent(pointerUpEvent)
+      win.dispatchEvent(pointerMoveEvent)
+      win.dispatchEvent(pointerUpEvent)
 
       // It should not create any regions because drag selection is disabled
       expect(regions.getRegions().length).to.equal(0)

--- a/src/__tests__/regions.test.ts
+++ b/src/__tests__/regions.test.ts
@@ -247,8 +247,8 @@ describe('Region length constraints during drag-creation', () => {
     // Drag from x=10 to x=14 (0.4s worth of drag at width 100 / duration 10):
     // far below minLength: 2.
     wrapper.dispatchEvent(new MouseEvent('pointerdown', { clientX: 10, clientY: 10, bubbles: true }))
-    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 14, clientY: 10 }))
-    document.dispatchEvent(new MouseEvent('pointerup', { clientX: 14, clientY: 10 }))
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 14, clientY: 10 }))
+    window.dispatchEvent(new MouseEvent('pointerup', { clientX: 14, clientY: 10 }))
 
     expect(created).toHaveLength(1)
     const region = created[0]

--- a/src/__tests__/regions.test.ts
+++ b/src/__tests__/regions.test.ts
@@ -396,3 +396,184 @@ describe('Region drag against the waveform edges', () => {
     expect(region.start).toBeCloseTo(8) // length preserved
   })
 })
+
+describe('Auto-scroll while dragging, resizing, or creating a region', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    installMatchMediaStub()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    document.body.innerHTML = ''
+    jest.clearAllMocks()
+  })
+
+  // Wrap the wavesurfer wrapper in a scrollable container (clientWidth 100,
+  // scrollWidth 1000) so adjustScroll sees a horizontal scrollbar.
+  const setup = () => {
+    const wavesurfer = createWaveSurfer(10)
+    const wrapper = wavesurfer.getWrapper()
+    const scrollContainer = document.createElement('div')
+    document.body.appendChild(scrollContainer)
+    scrollContainer.appendChild(wrapper)
+    Object.defineProperty(scrollContainer, 'clientWidth', { configurable: true, value: 100 })
+    Object.defineProperty(scrollContainer, 'scrollWidth', { configurable: true, value: 1000 })
+    mockRect(scrollContainer, { left: 0, top: 0, width: 100, height: 100 })
+    mockRect(wrapper, { left: 0, top: 0, width: 100, height: 100 })
+
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const regionsContainer = wrapper.querySelector<HTMLElement>('[part="regions-container"]')!
+    mockRect(regionsContainer, { left: 0, top: 0, width: 100, height: 100 })
+    Object.defineProperty(regionsContainer, 'clientWidth', { configurable: true, value: 1000 })
+
+    return { wavesurfer, plugin, wrapper, scrollContainer, regionsContainer }
+  }
+
+  const startDrag = (target: HTMLElement, fromX = 50, toX = 60) => {
+    target.dispatchEvent(new MouseEvent('pointerdown', { clientX: fromX, clientY: 10, bubbles: true }))
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: toX, clientY: 10 }))
+  }
+
+  const endDrag = (x = 60) => {
+    window.dispatchEvent(new MouseEvent('pointerup', { clientX: x, clientY: 10 }))
+  }
+
+  test('dragging a region past the right edge scrolls the container to keep it in view', () => {
+    const { plugin, scrollContainer, regionsContainer } = setup()
+    const region = plugin.addRegion({ start: 0.3, end: 0.8 })
+    jest.runOnlyPendingTimers()
+    expect(region.element?.parentElement).toBe(regionsContainer)
+
+    // Fully visible at drag start, so auto-scroll is allowed in both directions
+    mockRect(region.element!, { left: 20, top: 0, width: 40, height: 100 })
+    startDrag(region.element!)
+
+    // The drag pushed the region 20px past the right edge of the container
+    mockRect(region.element!, { left: 80, top: 0, width: 40, height: 100 })
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 70, clientY: 10 }))
+
+    expect(scrollContainer.scrollLeft).toBe(20)
+    endDrag(70)
+  })
+
+  test('a region already overflowing a side at drag start does not scroll further toward it', () => {
+    const { plugin, scrollContainer, regionsContainer } = setup()
+    const region = plugin.addRegion({ start: 0.3, end: 0.8 })
+    jest.runOnlyPendingTimers()
+    expect(region.element?.parentElement).toBe(regionsContainer)
+
+    // Already sticking out 20px past the right edge when the drag starts
+    mockRect(region.element!, { left: 80, top: 0, width: 40, height: 100 })
+    startDrag(region.element!)
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 70, clientY: 10 }))
+
+    expect(scrollContainer.scrollLeft).toBe(0)
+    endDrag(70)
+  })
+
+  test('resizing scrolls only toward the dragged handle', () => {
+    const { plugin, scrollContainer, regionsContainer } = setup()
+    const region = plugin.addRegion({ start: 0.3, end: 0.8 })
+    jest.runOnlyPendingTimers()
+    expect(region.element?.parentElement).toBe(regionsContainer)
+
+    scrollContainer.scrollLeft = 50
+
+    // The region overflows the left edge by 10px; dragging the left handle
+    // (side 'start' -> direction 'left') scrolls the container left by that much
+    mockRect(region.element!, { left: -10, top: 0, width: 40, height: 100 })
+    const leftHandle = region.element!.querySelector<HTMLElement>('[part*="region-handle-left"]')!
+    startDrag(leftHandle, 50, 45)
+
+    expect(scrollContainer.scrollLeft).toBe(40)
+    endDrag(45)
+
+    // Dragging the right handle (direction 'right') must NOT scroll left,
+    // even though the region still overflows on the left
+    const rightHandle = region.element!.querySelector<HTMLElement>('[part*="region-handle-right"]')!
+    startDrag(rightHandle, 30, 35)
+
+    expect(scrollContainer.scrollLeft).toBe(40)
+    endDrag(35)
+  })
+
+  test('container scroll during a drag keeps moving the region', () => {
+    const { wavesurfer, plugin, regionsContainer } = setup()
+    const region = plugin.addRegion({ start: 0.3, end: 0.8 })
+    jest.runOnlyPendingTimers()
+    expect(region.element?.parentElement).toBe(regionsContainer)
+
+    mockRect(region.element!, { left: 20, top: 0, width: 20, height: 100 })
+    startDrag(region.element!, 30, 40)
+    const startAfterPointerMove = region.start
+    const length = region.end - region.start
+
+    // The container scrolls 10px to the right mid-drag (e.g. from
+    // auto-scrolling); the region must follow (+10px = +1s at width 100)
+    wavesurfer.emit('scroll', 0, 0, 10, 110)
+    expect(region.start).toBeCloseTo(startAfterPointerMove + 1)
+    expect(region.end).toBeCloseTo(startAfterPointerMove + 1 + length)
+
+    endDrag(40)
+
+    // After the drag ends, scrolling no longer moves the region
+    const startAfterDrag = region.start
+    wavesurfer.emit('scroll', 0, 0, 20, 120)
+    expect(region.start).toBeCloseTo(startAfterDrag)
+  })
+
+  test('virtualization does not detach a region mid-drag', () => {
+    const { wavesurfer, plugin, regionsContainer } = setup()
+    const region = plugin.addRegion({ start: 0.5, end: 1.5 })
+    jest.runOnlyPendingTimers()
+    expect(region.element?.parentElement).toBe(regionsContainer)
+
+    mockRect(region.element!, { left: 50, top: 0, width: 10, height: 100 })
+    startDrag(region.element!)
+    const element = region.element!
+
+    // Scroll the viewport far away from the region: normally it would be
+    // detached by virtualization, but not while it is being dragged
+    wavesurfer.getScroll.mockReturnValue(800)
+    wavesurfer.emit('scroll', 8, 9, 800, 900)
+    expect(element.parentElement).toBe(regionsContainer)
+
+    endDrag()
+
+    // Once the drag is over, virtualization applies again
+    wavesurfer.emit('scroll', 8, 9, 800, 900)
+    expect(element.parentElement).toBeNull()
+  })
+
+  test('container scroll during drag-creation keeps growing the region', () => {
+    const { wavesurfer, plugin, wrapper } = setup()
+    const created: Array<{ start: number; end: number }> = []
+    plugin.on('region-created', (region) => created.push(region))
+
+    plugin.enableDragSelection({})
+
+    // Drag from x=10 to x=20: creates a region from 1s, end dragged to ~2.5s
+    wrapper.dispatchEvent(new MouseEvent('pointerdown', { clientX: 10, clientY: 10, bubbles: true }))
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 20, clientY: 10 }))
+
+    expect(created).toHaveLength(0) // not saved until the drag ends
+    // The container auto-scrolls 10px to the right; the region's end must
+    // keep growing by the equivalent 1s
+    wavesurfer.emit('scroll', 0, 0, 10, 110)
+
+    window.dispatchEvent(new MouseEvent('pointerup', { clientX: 20, clientY: 10 }))
+
+    expect(created).toHaveLength(1)
+    expect(created[0].start).toBeCloseTo(1)
+    expect(created[0].end).toBeCloseTo(3.5)
+
+    // After creation, scrolling no longer updates the region
+    const end = created[0].end
+    wavesurfer.emit('scroll', 0, 0, 30, 130)
+    expect(created[0].end).toBeCloseTo(end)
+  })
+})

--- a/src/__tests__/regions.test.ts
+++ b/src/__tests__/regions.test.ts
@@ -549,6 +549,85 @@ describe('Auto-scroll while dragging, resizing, or creating a region', () => {
     expect(element.parentElement).toBeNull()
   })
 
+  test('holding a region at the edge sustains the auto-scroll feedback loop', () => {
+    const { wavesurfer, plugin, scrollContainer, regionsContainer } = setup()
+    const region = plugin.addRegion({ start: 0.3, end: 0.8 })
+    jest.runOnlyPendingTimers()
+    expect(region.element?.parentElement).toBe(regionsContainer)
+
+    // Fully visible at drag start
+    mockRect(region.element!, { left: 20, top: 0, width: 40, height: 100 })
+    startDrag(region.element!)
+
+    // The pointer parks the region 20px past the right edge and stays there:
+    // the element rect keeps reporting the same overflow (the region tracks
+    // the stationary pointer), so every scroll step must trigger another one
+    mockRect(region.element!, { left: 80, top: 0, width: 40, height: 100 })
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 70, clientY: 10 }))
+    expect(scrollContainer.scrollLeft).toBe(20)
+
+    // The renderer reports each scroll back as a wavesurfer 'scroll' event;
+    // the replay moves the region AND re-triggers adjustScroll — round two
+    const startAfterFirstScroll = region.start
+    wavesurfer.emit('scroll', 0, 0, 20, 120)
+    expect(region.start).toBeCloseTo(startAfterFirstScroll + 2) // +20px = +2s
+    expect(scrollContainer.scrollLeft).toBe(40)
+
+    // ... and round three, without any pointer movement
+    wavesurfer.emit('scroll', 0, 0, 40, 140)
+    expect(region.start).toBeCloseTo(startAfterFirstScroll + 4)
+    expect(scrollContainer.scrollLeft).toBe(60)
+
+    // Once the region no longer overflows, the loop stops
+    mockRect(region.element!, { left: 40, top: 0, width: 40, height: 100 })
+    wavesurfer.emit('scroll', 0, 0, 60, 160)
+    expect(scrollContainer.scrollLeft).toBe(60)
+
+    endDrag(70)
+  })
+
+  test('drag-creation keeps auto-scrolling once the region is wider than the viewport', () => {
+    const { wavesurfer, plugin, wrapper, scrollContainer } = setup()
+    const initialized: Array<{ element: HTMLElement | null }> = []
+    plugin.on('region-initialized', (region) => initialized.push(region))
+
+    plugin.enableDragSelection({})
+
+    wrapper.dispatchEvent(new MouseEvent('pointerdown', { clientX: 10, clientY: 10, bubbles: true }))
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 20, clientY: 10 }))
+    expect(initialized).toHaveLength(1)
+
+    // The created region has grown wider than the viewport: it overflows both
+    // sides (50px each). A rightward scroll step must still scroll right,
+    // by the right-side overflow
+    mockRect(initialized[0].element!, { left: -50, top: 0, width: 200, height: 100 })
+    wavesurfer.emit('scroll', 0, 0, 10, 110)
+
+    expect(scrollContainer.scrollLeft).toBe(50)
+
+    window.dispatchEvent(new MouseEvent('pointerup', { clientX: 20, clientY: 10 }))
+  })
+
+  test('disabling drag selection mid-gesture stops the scroll replay', () => {
+    const { wavesurfer, plugin, wrapper } = setup()
+    const initialized: Array<{ start: number; end: number }> = []
+    plugin.on('region-initialized', (region) => initialized.push(region))
+
+    const disable = plugin.enableDragSelection({})
+
+    wrapper.dispatchEvent(new MouseEvent('pointerdown', { clientX: 10, clientY: 10, bubbles: true }))
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 20, clientY: 10 }))
+    expect(initialized).toHaveLength(1)
+
+    disable()
+
+    // Scrolling after disabling must not keep mutating the abandoned region
+    const { start, end } = initialized[0]
+    wavesurfer.emit('scroll', 0, 0, 10, 110)
+    expect(initialized[0].start).toBeCloseTo(start)
+    expect(initialized[0].end).toBeCloseTo(end)
+  })
+
   test('container scroll during drag-creation keeps growing the region', () => {
     const { wavesurfer, plugin, wrapper } = setup()
     const created: Array<{ start: number; end: number }> = []

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -492,8 +492,8 @@ describe('Renderer', () => {
     // reactive/drag-stream.test.ts's pattern.
     const simulateDrag = (wrapper: HTMLElement) => {
       wrapper.dispatchEvent(new PointerEvent('pointerdown', { clientX: 0, clientY: 0, button: 0 }))
-      document.dispatchEvent(new PointerEvent('pointermove', { clientX: 20, clientY: 0 }))
-      document.dispatchEvent(new PointerEvent('pointerup', { clientX: 20, clientY: 0 }))
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 20, clientY: 0 }))
+      window.dispatchEvent(new PointerEvent('pointerup', { clientX: 20, clientY: 0 }))
     }
 
     test('enabling dragToSeek with the object form via setOptions makes drag work', () => {

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -1085,9 +1085,13 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
       // the container is kept scrolled to that edge.
       const scrollState: ScrollState = { scrollLeft: 0 }
       const onScroll = createScrollHandler(scrollState, (scrollDiff) => {
-        if (region) {
+        if (region && scrollDiff !== 0) {
           region._onUpdate(scrollDiff, scrollDiff > 0 ? 'end' : 'start', startTime)
-          adjustScroll(region, 'both')
+          // Keep scrolling toward the edge being grown. A concrete direction
+          // (not 'both') so the loop keeps going even once the drag-created
+          // region has grown wider than the viewport (adjustScroll ignores
+          // 'both' when both sides overflow).
+          adjustScroll(region, scrollDiff > 0 ? 'right' : 'left')
         }
       })
       let unsubscribeScroll: (() => void) | null = null
@@ -1178,6 +1182,11 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
       return ctx.scope.add(() => {
         unsubscribe()
         dragStream.cleanup()
+        // A creation gesture may be mid-flight when drag selection is
+        // disabled: drop its scroll listener too, or waveform scrolls would
+        // keep mutating the abandoned region until the plugin is destroyed.
+        unsubscribeScroll?.()
+        unsubscribeScroll = null
       })
     }
 

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -12,6 +12,7 @@ import { Scope } from '../scope.js'
 import { createDragStream } from '../reactive/drag-stream.js'
 import { effect } from '../reactive/store.js'
 import { fromEvent, cleanup as cleanupStream } from '../reactive/event-streams.js'
+import type WaveSurfer from '../wavesurfer.js'
 
 // The pre-port class took no options at all (`constructor(options?: undefined)`).
 // Kept as `undefined` here (the public alias) rather than widened, since
@@ -52,11 +53,14 @@ export type RegionsPluginEvents = BasePluginEvents & {
   'region-content-changed': [region: Region]
 }
 
+/** Which direction may be auto-scrolled when a region update overflows the scroll container */
+export type AutoScrollDirection = 'left' | 'right' | 'both' | 'none'
+
 export type RegionEvents = {
   /** Before the region is removed */
   remove: []
   /** When the region's parameters are being updated */
-  update: [side?: UpdateSide]
+  update: [side?: UpdateSide, autoScrollDirection?: AutoScrollDirection]
   /** When dragging or resizing is finished */
   'update-end': [side?: UpdateSide]
   /** When the region needs to be re-rendered */
@@ -104,6 +108,50 @@ export type RegionParams = {
   contentEditable?: boolean
 }
 
+/** How far each side of a region's element sticks out of the scroll container, in pixels */
+function getRegionSideOverflow(
+  element: HTMLElement | null,
+  scrollContainer: HTMLElement | null | undefined,
+): { overflowLeft: number; overflowRight: number } | undefined {
+  if (!element || !scrollContainer) return
+
+  const { clientWidth, scrollWidth } = scrollContainer
+  if (scrollWidth <= clientWidth) return
+
+  const scrollBbox = scrollContainer.getBoundingClientRect()
+  const bbox = element.getBoundingClientRect()
+  const left = bbox.left - scrollBbox.left
+  const right = bbox.right - scrollBbox.left
+
+  const boxOverflowsLeft = left < 0
+  const boxOverflowsRight = right > clientWidth
+
+  if (boxOverflowsLeft && boxOverflowsRight) {
+    return { overflowLeft: -left, overflowRight: right - clientWidth }
+  } else if (boxOverflowsRight) {
+    return { overflowLeft: 0, overflowRight: right - clientWidth }
+  } else if (boxOverflowsLeft) {
+    return { overflowLeft: -left, overflowRight: 0 }
+  }
+  return { overflowLeft: 0, overflowRight: 0 }
+}
+
+// Mutable holder shared between a gesture's pointer-move handler and its
+// 'scroll' handler, so each scroll delta is counted exactly once by whichever
+// of the two observes it first.
+type ScrollState = {
+  scrollLeft: number
+}
+
+/** Wrap a wavesurfer 'scroll' listener that reports the scroll delta since the last call */
+function createScrollHandler(scrollState: ScrollState, callback: (scrollDiff: number) => void) {
+  return (_start: number, _end: number, scrollLeft: number) => {
+    const scrollDiff = scrollLeft - scrollState.scrollLeft
+    scrollState.scrollLeft = scrollLeft
+    callback(scrollDiff)
+  }
+}
+
 class SingleRegion extends EventEmitter<RegionEvents> implements Region {
   public element: HTMLElement | null = null // Element is created on init
   public id: string
@@ -121,6 +169,9 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
   public contentEditable = false
   public updatingSide?: UpdateSide = undefined
   public isRemoved = false
+  /** True while the region body is being dragged; guards virtualization from detaching it mid-drag */
+  public isDragging = false
+  private autoScrollDirection: AutoScrollDirection = 'none'
   private resizeHandleCleanup: (() => void) | null = null
   private contentListenersCleanup: (() => void) | null = null
   /** True once initMouseEvents has run; controls whether setContent must (re)attach listeners itself */
@@ -137,6 +188,12 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
      */
     private scope: Scope,
     private numberOfChannels = 0,
+    /**
+     * The wavesurfer instance this region is rendered into, used to follow and
+     * drive the container's horizontal scroll while dragging or resizing.
+     * Null for inert regions created after the plugin was destroyed.
+     */
+    private wavesurfer: WaveSurfer | null = null,
   ) {
     super()
 
@@ -213,13 +270,30 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     const leftDragStream = createDragStream(leftHandle, { threshold: resizeThreshold })
     const rightDragStream = createDragStream(rightHandle, { threshold: resizeThreshold })
 
+    // While a handle is being dragged, container scroll (from adjustScroll's
+    // auto-scrolling, or any other source) keeps resizing the region: each
+    // scroll delta is replayed as a resize delta, which re-triggers the
+    // 'update' -> adjustScroll loop until the handle leaves the edge.
+    const scrollState: ScrollState = { scrollLeft: 0 }
+    const leftScrollHandler = createScrollHandler(scrollState, (scrollDiff) => this.onResize(scrollDiff, 'start'))
+    const rightScrollHandler = createScrollHandler(scrollState, (scrollDiff) => this.onResize(scrollDiff, 'end'))
+    let unsubscribeLeftScroll: (() => void) | null = null
+    let unsubscribeRightScroll: (() => void) | null = null
+
     const removeLeftEffect = this.scope.add(
       effect(() => {
         const drag = leftDragStream.signal.value
         if (!drag) return
-        if (drag.type === 'move' && drag.deltaX !== undefined) {
+        if (drag.type === 'start') {
+          scrollState.scrollLeft = this.wavesurfer?.getScroll() ?? 0
+          if (this.wavesurfer) {
+            unsubscribeLeftScroll = this.scope.add(this.wavesurfer.on('scroll', leftScrollHandler))
+          }
+        } else if (drag.type === 'move' && drag.deltaX !== undefined) {
           this.onResize(drag.deltaX, 'start')
         } else if (drag.type === 'end') {
+          unsubscribeLeftScroll?.()
+          unsubscribeLeftScroll = null
           this.onEndResizing('start')
         }
       }, [leftDragStream.signal]),
@@ -229,9 +303,16 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
       effect(() => {
         const drag = rightDragStream.signal.value
         if (!drag) return
-        if (drag.type === 'move' && drag.deltaX !== undefined) {
+        if (drag.type === 'start') {
+          scrollState.scrollLeft = this.wavesurfer?.getScroll() ?? 0
+          if (this.wavesurfer) {
+            unsubscribeRightScroll = this.scope.add(this.wavesurfer.on('scroll', rightScrollHandler))
+          }
+        } else if (drag.type === 'move' && drag.deltaX !== undefined) {
           this.onResize(drag.deltaX, 'end')
         } else if (drag.type === 'end') {
+          unsubscribeRightScroll?.()
+          unsubscribeRightScroll = null
           this.onEndResizing('end')
         }
       }, [rightDragStream.signal]),
@@ -249,6 +330,10 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
       removeLeftEffect()
       removeRightEffect()
       removeStreamCleanup()
+      unsubscribeLeftScroll?.()
+      unsubscribeLeftScroll = null
+      unsubscribeRightScroll?.()
+      unsubscribeRightScroll = null
     }
   }
 
@@ -380,6 +465,10 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     // Drag
     const dragStream = createDragStream(element)
 
+    const scrollState: ScrollState = { scrollLeft: 0 }
+    const onScroll = createScrollHandler(scrollState, (scrollDiff) => this.onMove(scrollDiff))
+    let unsubscribeScroll: (() => void) | null = null
+
     this.scope.add(
       effect(() => {
         const drag = dragStream.signal.value
@@ -387,10 +476,30 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
 
         if (drag.type === 'start') {
           this.toggleCursor(true)
+          this.isDragging = true
+          this.autoScrollDirection = this.getAutoScrollDirection()
+          scrollState.scrollLeft = this.wavesurfer?.getScroll() ?? 0
+          if (this.wavesurfer) {
+            // While dragging, container scroll keeps moving the region: each
+            // scroll delta is replayed as a move delta, which re-triggers the
+            // 'update' -> adjustScroll loop while the region hugs an edge.
+            unsubscribeScroll = this.scope.add(this.wavesurfer.on('scroll', onScroll))
+          }
         } else if (drag.type === 'move' && drag.deltaX !== undefined) {
-          this.onMove(drag.deltaX)
+          // deltaX is in client coordinates and doesn't account for the
+          // container auto-scrolling under the pointer -- add any scroll
+          // delta not yet seen by the scroll handler (shared scrollState
+          // guarantees each delta is only counted once).
+          const scrollLeft = this.wavesurfer?.getScroll() ?? scrollState.scrollLeft
+          const scrollDiff = scrollLeft - scrollState.scrollLeft
+          scrollState.scrollLeft = scrollLeft
+          this.onMove(drag.deltaX + scrollDiff)
         } else if (drag.type === 'end') {
           this.toggleCursor(false)
+          this.isDragging = false
+          this.autoScrollDirection = 'none'
+          unsubscribeScroll?.()
+          unsubscribeScroll = null
           if (this.drag) this.emit('update-end')
         }
       }, [dragStream.signal]),
@@ -401,7 +510,25 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     this.mouseEventsInitialized = true
   }
 
-  public _onUpdate(dx: number, side?: UpdateSide, startTime?: number) {
+  /**
+   * Which direction the container may auto-scroll for the drag that is
+   * starting: if a side of the region already overflows the container, only
+   * allow scrolling toward the opposite side (so a region parked against an
+   * edge doesn't immediately start scrolling further in that direction).
+   */
+  private getAutoScrollDirection(): AutoScrollDirection {
+    const scrollContainer = this.wavesurfer?.getWrapper()?.parentElement
+    const sideOverflow = getRegionSideOverflow(this.element, scrollContainer)
+    if (!sideOverflow) return 'none'
+
+    const { overflowLeft, overflowRight } = sideOverflow
+    if (overflowLeft > 0 && overflowRight > 0) return 'none'
+    if (overflowLeft > 0) return 'right'
+    if (overflowRight > 0) return 'left'
+    return 'both'
+  }
+
+  public _onUpdate(dx: number, side?: UpdateSide, startTime?: number, autoScrollDirection?: AutoScrollDirection) {
     if (!this.element?.parentElement) return
     const { width } = this.element.parentElement.getBoundingClientRect()
     const deltaSeconds = (dx / width) * this.totalDuration
@@ -443,20 +570,21 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
       this.end = newEnd
 
       this.renderPosition()
-      this.emit('update', side)
+      this.emit('update', side, autoScrollDirection)
     }
   }
 
   private onMove(dx: number) {
     if (!this.drag) return
-    this._onUpdate(dx)
+    this._onUpdate(dx, undefined, undefined, this.autoScrollDirection)
   }
 
   private onResize(dx: number, side: UpdateSide) {
     if (!this.resize) return
     if (!this.resizeStart && side === 'start') return
     if (!this.resizeEnd && side === 'end') return
-    this._onUpdate(dx, side)
+    // Resizing may only auto-scroll toward the handle being dragged
+    this._onUpdate(dx, side, undefined, side === 'start' ? 'left' : 'right')
   }
 
   private onEndResizing(side: UpdateSide) {
@@ -773,20 +901,30 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
       regions.forEach((region) => avoidOverlapping(region))
     }
 
-    function adjustScroll(region: Region) {
-      if (!region.element) return
+    function adjustScroll(region: Region, direction?: AutoScrollDirection) {
+      if (!direction || direction === 'none') return
       const scrollContainer = ctx.wavesurfer?.getWrapper()?.parentElement
-      if (!scrollContainer) return
-      const { clientWidth, scrollWidth } = scrollContainer
-      if (scrollWidth <= clientWidth) return
-      const scrollBbox = scrollContainer.getBoundingClientRect()
-      const bbox = region.element.getBoundingClientRect()
-      const left = bbox.left - scrollBbox.left
-      const right = bbox.right - scrollBbox.left
-      if (left < 0) {
-        scrollContainer.scrollLeft += left
-      } else if (right > clientWidth) {
-        scrollContainer.scrollLeft += right - clientWidth
+      const sideOverflow = getRegionSideOverflow(region.element, scrollContainer)
+      if (!scrollContainer || !sideOverflow) return
+
+      const { overflowLeft, overflowRight } = sideOverflow
+
+      // If both sides overflow (region wider than the viewport), only scroll
+      // in the single direction the gesture is headed
+      if (overflowLeft > 0 && overflowRight > 0) {
+        if (direction === 'left') {
+          scrollContainer.scrollLeft -= overflowLeft
+        } else if (direction === 'right') {
+          scrollContainer.scrollLeft += overflowRight
+        }
+        return
+      }
+
+      if (direction === 'left' || direction === 'both') {
+        scrollContainer.scrollLeft -= overflowLeft
+      }
+      if (direction === 'right' || direction === 'both') {
+        scrollContainer.scrollLeft += overflowRight
       }
     }
 
@@ -811,7 +949,9 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
 
         if (isVisible && !element.parentElement) {
           container.appendChild(element)
-        } else if (!isVisible && element.parentElement) {
+        } else if (!isVisible && element.parentElement && !region.isDragging) {
+          // Never detach a region mid-drag: auto-scrolling can briefly push it
+          // out of view, and removing it would end the gesture
           element.remove()
         }
       }
@@ -838,11 +978,8 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
       regions.push(region)
 
       regionScope.add(
-        region.on('update', (side) => {
-          // Undefined side indicates that we are dragging not resizing
-          if (!side) {
-            adjustScroll(region)
-          }
+        region.on('update', (side, autoScrollDirection) => {
+          adjustScroll(region, autoScrollDirection)
           ctx.emit('region-update', region, side)
         }),
       )
@@ -906,7 +1043,7 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
       const duration = ctx.wavesurfer.getDuration()
       const numberOfChannels = ctx.wavesurfer.getDecodedData()?.numberOfChannels
       const regionScope = ctx.scope.child()
-      const region = new SingleRegion(options, duration, regionScope, numberOfChannels)
+      const region = new SingleRegion(options, duration, regionScope, numberOfChannels, ctx.wavesurfer)
       ctx.emit('region-initialized', region)
 
       if (!duration) {
@@ -943,6 +1080,18 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
 
       const dragStream = createDragStream(wrapper, { threshold })
 
+      // While creating a region, container scroll keeps growing it: each
+      // scroll delta is replayed as an update to the edge being dragged, and
+      // the container is kept scrolled to that edge.
+      const scrollState: ScrollState = { scrollLeft: 0 }
+      const onScroll = createScrollHandler(scrollState, (scrollDiff) => {
+        if (region) {
+          region._onUpdate(scrollDiff, scrollDiff > 0 ? 'end' : 'start', startTime)
+          adjustScroll(region, 'both')
+        }
+      })
+      let unsubscribeScroll: (() => void) | null = null
+
       const unsubscribe = effect(() => {
         const drag = dragStream.signal.value
         if (!drag) return
@@ -955,9 +1104,13 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
           // Dispose it now rather than leaving it retained until the plugin
           // itself is destroyed.
           regionScope?.dispose()
+          unsubscribeScroll?.()
+          unsubscribeScroll = null
 
           startX = drag.x
           if (!ctx.wavesurfer) return
+          scrollState.scrollLeft = ctx.wavesurfer.getScroll()
+          unsubscribeScroll = ctx.scope.add(ctx.wavesurfer.on('scroll', onScroll))
           const duration = ctx.wavesurfer.getDuration()
           const numberOfChannels = ctx.wavesurfer?.getDecodedData()?.numberOfChannels
           const { width } = ctx.wavesurfer.getWrapper().getBoundingClientRect()
@@ -979,6 +1132,7 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
             duration,
             regionScope,
             numberOfChannels,
+            ctx.wavesurfer,
           )
 
           ctx.emit('region-initialized', region)
@@ -993,9 +1147,13 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
             // Update the end position of the region
             // If we're dragging to the left, we need to update the start instead
             region._onUpdate(drag.deltaX, drag.x > startX ? 'end' : 'start', startTime)
+            // Auto-scroll toward the edge being dragged
+            adjustScroll(region, drag.x > startX ? 'right' : 'left')
           }
         } else if (drag.type === 'end') {
           // On drag end
+          unsubscribeScroll?.()
+          unsubscribeScroll = null
           if (region && regionScope) {
             // Enforce minLength on the just-created region: mid-drag it
             // necessarily passes through sub-minLength sizes (see _onUpdate),

--- a/src/reactive/__tests__/drag-stream.test.ts
+++ b/src/reactive/__tests__/drag-stream.test.ts
@@ -82,7 +82,7 @@ describe('createDragStream', () => {
     element.dispatchEvent(pointerDown)
 
     const pointerMove = new PointerEvent('pointermove', { clientX: 20, clientY: 20 })
-    document.dispatchEvent(pointerMove)
+    window.dispatchEvent(pointerMove)
 
     expect(events.length).toBeGreaterThan(0)
     expect(events[0]?.type).toBe('start')
@@ -102,7 +102,7 @@ describe('createDragStream', () => {
     element.dispatchEvent(pointerDown)
 
     const pointerMove = new PointerEvent('pointermove', { clientX: 20, clientY: 30 })
-    document.dispatchEvent(pointerMove)
+    window.dispatchEvent(pointerMove)
 
     const moveEvent = events.find((e) => e.type === 'move')
     expect(moveEvent).toBeDefined()
@@ -124,10 +124,10 @@ describe('createDragStream', () => {
     element.dispatchEvent(pointerDown)
 
     const pointerMove = new PointerEvent('pointermove', { clientX: 20, clientY: 20 })
-    document.dispatchEvent(pointerMove)
+    window.dispatchEvent(pointerMove)
 
     const pointerUp = new PointerEvent('pointerup', { clientX: 20, clientY: 20 })
-    document.dispatchEvent(pointerUp)
+    window.dispatchEvent(pointerUp)
 
     expect(events.some((e) => e.type === 'end')).toBe(true)
 
@@ -146,14 +146,14 @@ describe('createDragStream', () => {
     element.dispatchEvent(pointerDown)
 
     const pointerMove = new PointerEvent('pointermove', { clientX: 15, clientY: 15 })
-    document.dispatchEvent(pointerMove)
+    window.dispatchEvent(pointerMove)
 
     // Should not emit events yet
     expect(events.length).toBe(0)
 
     // Simulate larger drag (above threshold)
     const pointerMove2 = new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
-    document.dispatchEvent(pointerMove2)
+    window.dispatchEvent(pointerMove2)
 
     // Should now emit events
     expect(events.length).toBeGreaterThan(0)
@@ -193,7 +193,7 @@ describe('createDragStream', () => {
     element.dispatchEvent(pointerDown)
 
     const pointerMove = new PointerEvent('pointermove', { clientX: 20, clientY: 20 })
-    document.dispatchEvent(pointerMove)
+    window.dispatchEvent(pointerMove)
 
     // Should not emit any events
     expect(events.length).toBe(0)
@@ -214,11 +214,11 @@ describe('createDragStream', () => {
 
     // Move - should prevent click
     const pointerMove = new PointerEvent('pointermove', { clientX: 20, clientY: 20 })
-    document.dispatchEvent(pointerMove)
+    window.dispatchEvent(pointerMove)
 
     // End drag
     const pointerUp = new PointerEvent('pointerup', { clientX: 20, clientY: 20 })
-    document.dispatchEvent(pointerUp)
+    window.dispatchEvent(pointerUp)
 
     // Simulate click after drag
     const clickHandler = jest.fn()
@@ -233,7 +233,7 @@ describe('createDragStream', () => {
     cleanup()
   })
 
-  it('should handle pointer leave events', () => {
+  it('does not end the drag when the pointer leaves the document (e.g. during auto-scroll)', () => {
     const { signal, cleanup } = createDragStream(element, { threshold: 0 })
 
     signal.subscribe((event: DragEvent | null) => {
@@ -246,9 +246,10 @@ describe('createDragStream', () => {
 
     // Move to start dragging
     const pointerMove = new PointerEvent('pointermove', { clientX: 20, clientY: 20, pointerId: 1 })
-    document.dispatchEvent(pointerMove)
+    window.dispatchEvent(pointerMove)
 
-    // Pointer leaves document
+    // Pointer leaves the document (also fired when the container scrolls
+    // under a stationary pointer) -- the drag must survive it
     const pointerOut = new PointerEvent('pointerout', {
       clientX: 20,
       clientY: 20,
@@ -257,7 +258,26 @@ describe('createDragStream', () => {
     })
     document.dispatchEvent(pointerOut)
 
-    // Should emit end event
+    expect(events.some((e) => e.type === 'end')).toBe(false)
+
+    // The drag still ends normally on pointerup
+    window.dispatchEvent(new PointerEvent('pointerup', { clientX: 20, clientY: 20, pointerId: 1 }))
+    expect(events.some((e) => e.type === 'end')).toBe(true)
+
+    cleanup()
+  })
+
+  it('ends the drag on pointercancel', () => {
+    const { signal, cleanup } = createDragStream(element, { threshold: 0 })
+
+    signal.subscribe((event: DragEvent | null) => {
+      if (event) events.push(event)
+    })
+
+    element.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, button: 0, pointerId: 1 }))
+    window.dispatchEvent(pointerEvent('pointermove', { clientX: 20, clientY: 20, pointerId: 1 }))
+    window.dispatchEvent(pointerEvent('pointercancel', { clientX: 20, clientY: 20, pointerId: 1 }))
+
     expect(events.some((e) => e.type === 'end')).toBe(true)
 
     cleanup()
@@ -273,13 +293,13 @@ describe('createDragStream', () => {
     // Two-finger tap: the second finger lifts before the first
     element.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, button: 0, pointerId: 1 }))
     element.dispatchEvent(pointerEvent('pointerdown', { clientX: 50, clientY: 10, button: 0, pointerId: 2 }))
-    document.dispatchEvent(pointerEvent('pointerup', { clientX: 50, clientY: 10, pointerId: 2 }))
-    document.dispatchEvent(pointerEvent('pointerup', { clientX: 10, clientY: 10, pointerId: 1 }))
+    window.dispatchEvent(pointerEvent('pointerup', { clientX: 50, clientY: 10, pointerId: 2 }))
+    window.dispatchEvent(pointerEvent('pointerup', { clientX: 10, clientY: 10, pointerId: 1 }))
 
     // A subsequent single-finger drag should work
     element.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, button: 0, pointerId: 3 }))
-    document.dispatchEvent(pointerEvent('pointermove', { clientX: 30, clientY: 10, pointerId: 3 }))
-    document.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 3 }))
+    window.dispatchEvent(pointerEvent('pointermove', { clientX: 30, clientY: 10, pointerId: 3 }))
+    window.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 3 }))
 
     expect(events.map((e) => e.type)).toEqual(['start', 'move', 'end'])
 
@@ -294,15 +314,15 @@ describe('createDragStream', () => {
     })
 
     element.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, button: 0, pointerId: 1 }))
-    document.dispatchEvent(pointerEvent('pointermove', { clientX: 20, clientY: 10, pointerId: 1 }))
+    window.dispatchEvent(pointerEvent('pointermove', { clientX: 20, clientY: 10, pointerId: 1 }))
 
     // A second finger touches and lifts mid-drag
     element.dispatchEvent(pointerEvent('pointerdown', { clientX: 50, clientY: 10, button: 0, pointerId: 2 }))
-    document.dispatchEvent(pointerEvent('pointerup', { clientX: 50, clientY: 10, pointerId: 2 }))
+    window.dispatchEvent(pointerEvent('pointerup', { clientX: 50, clientY: 10, pointerId: 2 }))
 
     // The first finger continues dragging and lifts
-    document.dispatchEvent(pointerEvent('pointermove', { clientX: 30, clientY: 10, pointerId: 1 }))
-    document.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 1 }))
+    window.dispatchEvent(pointerEvent('pointermove', { clientX: 30, clientY: 10, pointerId: 1 }))
+    window.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 1 }))
 
     expect(events.map((e) => e.type)).toEqual(['start', 'move', 'move', 'end'])
 
@@ -317,11 +337,11 @@ describe('createDragStream', () => {
     })
 
     element.dispatchEvent(pointerEvent('pointerdown', { clientX: 10, clientY: 10, button: 0, pointerId: 1 }))
-    document.dispatchEvent(pointerEvent('pointermove', { clientX: 20, clientY: 10, pointerId: 1 }))
+    window.dispatchEvent(pointerEvent('pointermove', { clientX: 20, clientY: 10, pointerId: 1 }))
 
     // Moves from an untracked pointer are ignored
-    document.dispatchEvent(pointerEvent('pointermove', { clientX: 90, clientY: 90, pointerId: 7 }))
-    document.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 1 }))
+    window.dispatchEvent(pointerEvent('pointermove', { clientX: 90, clientY: 90, pointerId: 7 }))
+    window.dispatchEvent(pointerEvent('pointerup', { clientX: 30, clientY: 10, pointerId: 1 }))
 
     expect(events.map((e) => e.type)).toEqual(['start', 'move', 'end'])
     expect(events[1]?.x).toBe(20)

--- a/src/reactive/drag-stream.ts
+++ b/src/reactive/drag-stream.ts
@@ -144,12 +144,6 @@ export function createDragStream(
       }
     }
 
-    const onPointerLeave = (e: PointerEvent) => {
-      if (!e.relatedTarget || e.relatedTarget === document.documentElement) {
-        onPointerUp(e)
-      }
-    }
-
     const onClick = (event: MouseEvent) => {
       if (isDragging) {
         event.stopPropagation()
@@ -166,18 +160,23 @@ export function createDragStream(
       }
     }
 
-    document.addEventListener('pointermove', onPointerMove)
-    document.addEventListener('pointerup', onPointerUp)
-    document.addEventListener('pointerout', onPointerLeave)
-    document.addEventListener('pointercancel', onPointerLeave)
+    // Listen on window (not document) so a drag survives the pointer leaving
+    // the document, and don't end the drag on 'pointerout': when the container
+    // auto-scrolls under a stationary pointer (e.g. dragging a region to the
+    // edge of a scrolling waveform), the element moves out from under the
+    // pointer and a spurious pointerout would otherwise kill the drag.
+    // 'pointercancel' is still honored -- the browser fires no pointerup after
+    // it, so ignoring it would leave the drag stuck until the next pointerup.
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+    window.addEventListener('pointercancel', onPointerUp)
     document.addEventListener('touchmove', onTouchMove, { passive: false })
     document.addEventListener('click', onClick, { capture: true })
 
     unsubscribeDocument = () => {
-      document.removeEventListener('pointermove', onPointerMove)
-      document.removeEventListener('pointerup', onPointerUp)
-      document.removeEventListener('pointerout', onPointerLeave)
-      document.removeEventListener('pointercancel', onPointerLeave)
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
+      window.removeEventListener('pointercancel', onPointerUp)
       document.removeEventListener('touchmove', onTouchMove)
       setTimeout(() => {
         document.removeEventListener('click', onClick, { capture: true })


### PR DESCRIPTION
## Short description
Resolves #4159

This is #4181 by @clinton-encord, reworked onto the v8 architecture. Their feature commits are cherry-picked (squashed into two logical commits that keep @clinton-encord as the author, with `cherry picked from` trailers referencing the original SHAs) and adapted to the rewritten v8 regions plugin.

## Implementation details
- **Directional auto-scroll**: `adjustScroll` now takes an `AutoScrollDirection` (`'left' | 'right' | 'both' | 'none'`) carried on the region `update` event. When a region gesture reaches the edge of the scroll container, the container scrolls to keep it in view — so holding it at the edge continuously scrolls the waveform.
  - Plain drags may scroll both ways, unless the region already overflowed a side when the drag started (then scrolling toward that side is disabled).
  - Resizes only scroll toward the dragged handle; drag-creation only toward the dragged edge. During resize/creation a region wider than the viewport keeps scrolling toward the gesture's active edge; body-dragging such a region disables auto-scroll (neither edge is near the viewport, so chasing one would jump the view by the full overflow).
- **Scroll-delta replay**: while a gesture is active, wavesurfer `scroll` deltas are fed back into the gesture (move/resize/create), closing the auto-scroll feedback loop and keeping the region under the pointer. A shared `ScrollState` guarantees each delta is counted exactly once between the pointer-move and scroll handlers.
- **Virtualization guard**: a region is never detached mid-drag (`region.isDragging`) — previously that aborted the gesture.
- **Drag survival** (v8 port of the original `draggable.ts` change, now in `reactive/drag-stream.ts`): `pointermove`/`pointerup` listen on `window` instead of `document`, and `pointerout` no longer ends a drag — the container scrolling under a stationary pointer fires a spurious `pointerout` that used to kill the drag. Deviation from the original: `pointercancel` is still honored (routed to the pointer-up handler on `window`), since the browser fires no `pointerup` after a cancel and the drag would otherwise hang.
- **Cleanup**: the disposer returned by `enableDragSelection` also removes an in-flight creation gesture's `scroll` listener.

v8 adaptations: scroll listeners are registered through the region's `Scope` (so removal mid-gesture cleans them up), gestures run over the reactive drag streams, and `SingleRegion` takes the wavesurfer instance as an optional trailing constructor parameter (`null` for inert post-destroy regions). The `update` event gains an optional trailing `autoScrollDirection` argument — no breaking API changes.

The e2e specs' synthetic drag pointer events are now dispatched on `window` (real pointer events bubble there; the specs' non-bubbling synthetic ones don't).

## How to test it
- Set up wavesurfer and zoom in far enough that the waveform scrolls horizontally.
- Drag a region to either edge of the container and hold it there: the waveform scrolls continuously.
- Same while resizing via a handle, and while drag-creating a region with `enableDragSelection`.
- A region parked against an edge before the drag starts does not immediately scroll further in that direction.

## Screenshots
Video available in the discussion on #4159 / #4181.

## Checklist
* [x] This PR is covered by e2e tests (full Cypress suite passes; the auto-scroll feedback loop itself is covered by 9 unit tests in `regions.test.ts` plus updated `drag-stream.test.ts`)
* [x] It introduces no breaking API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uW5iGkDtAvfYnx66L3E52