### PR TITLE
fix(regions, record): region event race, mobile double-tap, device-loss handling

### DIFF
--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -111,9 +111,31 @@ class MockAudioContext {
   }
 }
 
-function createFakeMicStream(): MediaStream {
+// Event-capable track mock: real MediaStreamTracks are EventTargets that fire
+// 'ended' when the capture device disappears (but NOT on our own stop() calls).
+class MockMediaStreamTrack {
+  stop = jest.fn()
+  addEventListener = jest.fn((type: string, listener: () => void) => {
+    if (type === 'ended') this.endedListeners.add(listener)
+  })
+  removeEventListener = jest.fn((type: string, listener: () => void) => {
+    if (type === 'ended') this.endedListeners.delete(listener)
+  })
+  private endedListeners = new Set<() => void>()
+
+  /** Simulate the device disappearing (dispatches 'ended' to listeners) */
+  end() {
+    this.endedListeners.forEach((listener) => listener())
+  }
+
+  get hasEndedListeners() {
+    return this.endedListeners.size > 0
+  }
+}
+
+function createFakeMicStream(tracks: MockMediaStreamTrack[] = [new MockMediaStreamTrack()]): MediaStream {
   return {
-    getTracks: () => [{ stop: jest.fn() }],
+    getTracks: () => tracks,
   } as unknown as MediaStream
 }
 
@@ -327,6 +349,146 @@ describe('RecordPlugin destroy-time record-end delivery (realistic async onstop)
       await flushMicrotasks()
       nowSpy.mockRestore()
     }
+  })
+})
+
+describe('RecordPlugin capture device loss (track "ended")', () => {
+  const originalAudioContext = global.AudioContext
+  const originalMediaRecorder = global.MediaRecorder
+  const originalMediaDevices = navigator.mediaDevices
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+
+  let track: MockMediaStreamTrack
+
+  beforeEach(() => {
+    global.AudioContext = MockAudioContext as unknown as typeof AudioContext
+    global.MediaRecorder = MockMediaRecorder as unknown as typeof MediaRecorder
+    track = new MockMediaStreamTrack()
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      writable: true,
+      value: { getUserMedia: jest.fn().mockResolvedValue(createFakeMicStream([track])) },
+    })
+    URL.createObjectURL = jest.fn(() => 'blob:mock-url')
+    URL.revokeObjectURL = jest.fn()
+  })
+
+  afterEach(() => {
+    global.AudioContext = originalAudioContext
+    global.MediaRecorder = originalMediaRecorder
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      writable: true,
+      value: originalMediaDevices,
+    })
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+  })
+
+  it('stops an active recording gracefully and emits record-ended-externally, then record-end with the blob', async () => {
+    const plugin = RecordPlugin.create()
+    const onEnd = jest.fn()
+    const onEndedExternally = jest.fn()
+    const callOrder: string[] = []
+    plugin.on('record-end', () => callOrder.push('record-end'))
+    plugin.on('record-ended-externally', () => callOrder.push('record-ended-externally'))
+    plugin.on('record-end', onEnd)
+    plugin.on('record-ended-externally', onEndedExternally)
+
+    await plugin.startRecording()
+    expect(plugin.isRecording()).toBe(true)
+    expect(track.hasEndedListeners).toBe(true)
+
+    // The device disappears (e.g. Bluetooth headset powers off)
+    track.end()
+
+    expect(onEndedExternally).toHaveBeenCalledTimes(1)
+    expect(plugin.isRecording()).toBe(false)
+    expect(plugin.isActive()).toBe(false)
+
+    // The recorder's queued onstop still delivers the final blob
+    await flushMicrotasks()
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd.mock.calls[0][0]).toBeInstanceOf(Blob)
+    expect(callOrder).toEqual(['record-ended-externally', 'record-end'])
+
+    // The mic session is fully torn down and listeners removed
+    expect(track.hasEndedListeners).toBe(false)
+    plugin.destroy()
+  })
+
+  it('handles device loss while the recording is paused', async () => {
+    const plugin = RecordPlugin.create()
+    const onEnd = jest.fn()
+    const onEndedExternally = jest.fn()
+    plugin.on('record-end', onEnd)
+    plugin.on('record-ended-externally', onEndedExternally)
+
+    await plugin.startRecording()
+    plugin.pauseRecording()
+    expect(plugin.isPaused()).toBe(true)
+
+    track.end()
+
+    expect(onEndedExternally).toHaveBeenCalledTimes(1)
+    expect(plugin.isActive()).toBe(false)
+    expect(plugin.isPaused()).toBe(false)
+
+    await flushMicrotasks()
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    plugin.destroy()
+  })
+
+  it('does not emit record-ended-externally on a user-initiated stop', async () => {
+    const plugin = RecordPlugin.create()
+    const onEndedExternally = jest.fn()
+    plugin.on('record-ended-externally', onEndedExternally)
+
+    await plugin.startRecording()
+    plugin.stopRecording()
+    await flushMicrotasks()
+
+    expect(onEndedExternally).not.toHaveBeenCalled()
+    // Normal stop removed the track listeners along with the mic teardown
+    expect(track.hasEndedListeners).toBe(false)
+    plugin.destroy()
+  })
+
+  it('tears down a preview-only mic session on device loss without emitting recording events', async () => {
+    const plugin = RecordPlugin.create()
+    const onEnd = jest.fn()
+    const onEndedExternally = jest.fn()
+    plugin.on('record-end', onEnd)
+    plugin.on('record-ended-externally', onEndedExternally)
+
+    await plugin.startMic()
+    expect(track.hasEndedListeners).toBe(true)
+
+    track.end()
+
+    // No recording was active: nothing to end, just clean up the monitoring
+    expect(onEnd).not.toHaveBeenCalled()
+    expect(onEndedExternally).not.toHaveBeenCalled()
+    expect(track.hasEndedListeners).toBe(false)
+    expect((plugin as unknown as { stream: MediaStream | null }).stream).toBeNull()
+    plugin.destroy()
+  })
+
+  it('removes track listeners on destroy, and a late "ended" does nothing', async () => {
+    const plugin = RecordPlugin.create()
+    const onEndedExternally = jest.fn()
+    plugin.on('record-ended-externally', onEndedExternally)
+
+    await plugin.startRecording()
+    expect(track.hasEndedListeners).toBe(true)
+
+    plugin.destroy()
+    await flushMicrotasks()
+
+    expect(track.hasEndedListeners).toBe(false)
+    expect(() => track.end()).not.toThrow()
+    expect(onEndedExternally).not.toHaveBeenCalled()
   })
 })
 

--- a/src/__tests__/regions.test.ts
+++ b/src/__tests__/regions.test.ts
@@ -336,6 +336,188 @@ describe('RegionsPlugin post-destroy API', () => {
   })
 })
 
+describe('Region in/out detection on timeupdate', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    installMatchMediaStub()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    document.body.innerHTML = ''
+    jest.clearAllMocks()
+  })
+
+  // #3631 / #3658 / #3781 / #3866: region.play() seeks to region.start, but
+  // media elements clamp/round currentTime, so the first 'timeupdate' can tick
+  // slightly BEFORE region.start (especially with many decimals). With an
+  // exact comparison the active region was considered "left" and a spurious
+  // 'region-out' fired within milliseconds of play().
+  test('does not fire region-out right after an in-tolerance seek to region.start', () => {
+    const wavesurfer = createWaveSurfer(20)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const start = 9.16454684654654
+    const region = plugin.addRegion({ start, end: 12 })
+
+    const regionIn = jest.fn()
+    const regionOut = jest.fn()
+    plugin.on('region-in', regionIn)
+    plugin.on('region-out', regionOut)
+
+    // Playback is inside the region, then the media element reports a tick
+    // that landed a hair before the high-precision start (clamped seek).
+    wavesurfer.emit('timeupdate', 10)
+    expect(regionIn).toHaveBeenCalledTimes(1)
+    expect(regionIn).toHaveBeenCalledWith(region)
+
+    wavesurfer.emit('timeupdate', 9.164546)
+
+    expect(regionOut).not.toHaveBeenCalled()
+    expect(regionIn).toHaveBeenCalledTimes(1) // still active, no re-entry either
+  })
+
+  test('fires region-in when currentTime is within tolerance before region.start', () => {
+    const wavesurfer = createWaveSurfer(20)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const region = plugin.addRegion({ start: 5, end: 7 })
+
+    const regionIn = jest.fn()
+    const regionOut = jest.fn()
+    plugin.on('region-in', regionIn)
+    plugin.on('region-out', regionOut)
+
+    // A seek to region.start that settled just before it counts as inside
+    wavesurfer.emit('timeupdate', 5 - 0.01)
+    expect(regionIn).toHaveBeenCalledTimes(1)
+    expect(regionIn).toHaveBeenCalledWith(region)
+
+    // Well before the tolerance window it must NOT count as inside
+    regionIn.mockClear()
+    wavesurfer.emit('timeupdate', 3)
+    expect(regionOut).toHaveBeenCalledTimes(1)
+    expect(regionOut).toHaveBeenCalledWith(region)
+    expect(regionIn).not.toHaveBeenCalled()
+  })
+
+  test('region-out still fires promptly past the region end', () => {
+    const wavesurfer = createWaveSurfer(20)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const region = plugin.addRegion({ start: 5, end: 7 })
+    const regionOut = jest.fn()
+    plugin.on('region-out', regionOut)
+
+    wavesurfer.emit('timeupdate', 6)
+    wavesurfer.emit('timeupdate', 7.001)
+
+    expect(regionOut).toHaveBeenCalledTimes(1)
+    expect(regionOut).toHaveBeenCalledWith(region)
+  })
+
+  test('keeps the 0.05s window for zero-length (marker) regions', () => {
+    const wavesurfer = createWaveSurfer(20)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const marker = plugin.addRegion({ start: 2 })
+
+    const regionIn = jest.fn()
+    const regionOut = jest.fn()
+    plugin.on('region-in', regionIn)
+    plugin.on('region-out', regionOut)
+
+    wavesurfer.emit('timeupdate', 2.03) // inside the marker's start + 0.05 window
+    expect(regionIn).toHaveBeenCalledTimes(1)
+    expect(regionIn).toHaveBeenCalledWith(marker)
+
+    wavesurfer.emit('timeupdate', 2.06) // past the window
+    expect(regionOut).toHaveBeenCalledTimes(1)
+    expect(regionOut).toHaveBeenCalledWith(marker)
+  })
+})
+
+describe('Region double-tap (touch) double-click', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    installMatchMediaStub()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    document.body.innerHTML = ''
+    jest.clearAllMocks()
+  })
+
+  // #3927: 'dblclick' never fires for touch input on many mobile browsers, so
+  // two taps within 300ms must emit 'region-double-clicked' themselves.
+  test('double-tap emits region-double-clicked once', () => {
+    const wavesurfer = createWaveSurfer(10)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const region = plugin.addRegion({ start: 1, end: 2 })
+    const doubleClicked = jest.fn()
+    plugin.on('region-double-clicked', doubleClicked)
+
+    const element = region.element!
+    element.dispatchEvent(new Event('touchend'))
+    jest.advanceTimersByTime(100)
+    element.dispatchEvent(new Event('touchend'))
+
+    expect(doubleClicked).toHaveBeenCalledTimes(1)
+    const [regionArg, eventArg] = doubleClicked.mock.calls[0]
+    expect(regionArg).toBe(region)
+    expect(eventArg).toBeInstanceOf(MouseEvent)
+    expect(eventArg.type).toBe('dblclick')
+
+    // A native dblclick the browser fires right after the double tap
+    // (desktop-emulation) must be deduped, not emitted a second time.
+    jest.advanceTimersByTime(50)
+    element.dispatchEvent(new MouseEvent('dblclick'))
+    expect(doubleClicked).toHaveBeenCalledTimes(1)
+  })
+
+  test('two taps outside the 300ms window do not emit region-double-clicked', () => {
+    const wavesurfer = createWaveSurfer(10)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const region = plugin.addRegion({ start: 1, end: 2 })
+    const doubleClicked = jest.fn()
+    plugin.on('region-double-clicked', doubleClicked)
+
+    const element = region.element!
+    element.dispatchEvent(new Event('touchend'))
+    jest.advanceTimersByTime(400)
+    element.dispatchEvent(new Event('touchend'))
+
+    expect(doubleClicked).not.toHaveBeenCalled()
+  })
+
+  test('a plain desktop dblclick still emits region-double-clicked', () => {
+    const wavesurfer = createWaveSurfer(10)
+    const plugin = RegionsPlugin.create()
+    plugin._init(wavesurfer as any)
+
+    const region = plugin.addRegion({ start: 1, end: 2 })
+    const doubleClicked = jest.fn()
+    plugin.on('region-double-clicked', doubleClicked)
+
+    const nativeEvent = new MouseEvent('dblclick')
+    region.element!.dispatchEvent(nativeEvent)
+
+    expect(doubleClicked).toHaveBeenCalledTimes(1)
+    expect(doubleClicked).toHaveBeenCalledWith(region, nativeEvent)
+  })
+})
+
 describe('Region drag against the waveform edges', () => {
   beforeEach(() => {
     jest.useFakeTimers()

--- a/src/plugins/record.ts
+++ b/src/plugins/record.ts
@@ -37,6 +37,13 @@ export type RecordPluginEvents = BasePluginEvents & {
   'record-resume': []
   /* When the recording stops, either by calling stopRecording or when the media recorder stops */
   'record-end': [blob: Blob]
+  /**
+   * Fires when an active recording (or paused recording) is stopped because the
+   * capture device ended on its own — e.g. a Bluetooth headset powered off or a
+   * dock was unplugged — rather than by a stopRecording()/destroy() call.
+   * A final 'record-end' with the recorded blob still follows.
+   */
+  'record-ended-externally': []
   /** Fires continuously while recording */
   'record-progress': [duration: number]
   /** On every new recorded chunk */
@@ -67,6 +74,11 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
   private duration = 0
   private micStream: MicStream | null = null
   private unsubscribeRecordEnd?: () => void
+  // Early-removal handles for the per-track 'ended' listeners registered in
+  // startMic(). Registered via this.scope.listen(), so a full destroy()
+  // (scope disposal) removes them even if stopMic() never ran; stopMic()
+  // calls these to remove them on a normal stop.
+  private unsubscribeTrackEnded: (() => void)[] = []
   private recordedBlobUrl: string | null = null
   // Snapshot of 'record-end' listeners taken at destroy() time when a recording is
   // still active. MediaRecorder.stop() fires 'onstop' via a queued task (async), so
@@ -306,7 +318,39 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     this.unsubscribeRecordEnd = this.once('record-end', micStream.onEnd)
     this.stream = stream
 
+    // Detect the capture device disappearing mid-session (e.g. a Bluetooth
+    // headset powering off, a dock being unplugged): the track then fires
+    // 'ended' on its own. Note that our own track.stop() calls (stopMic)
+    // do NOT fire 'ended', so this only catches external loss. Registered
+    // on the live scope so destroy() removes the listeners as a backstop;
+    // stopMic() removes them early on a normal stop.
+    this.unsubscribeTrackEnded = stream
+      .getTracks()
+      .map((track) => this.scope.listen(track, 'ended', () => this.handleTrackEnded()))
+
     return stream
+  }
+
+  /**
+   * A capture track ended on its own (device lost) rather than via our own
+   * track.stop() calls. Stop gracefully: the recorder's onstop still delivers
+   * the final blob through 'record-end', and 'record-ended-externally' lets
+   * the app tell this apart from a user-initiated stop.
+   */
+  private handleTrackEnded() {
+    if (this.isActive()) {
+      // Covers both recording and paused states. Emit before stopping so the
+      // app can update its UI knowing the 'record-end' that follows (async,
+      // from the recorder's queued onstop) was not user-initiated.
+      this.emit('record-ended-externally')
+      this.stopRecording()
+      // stopMic() (mic teardown, track-listener removal, option restore)
+      // runs via the once('record-end') subscription when onstop fires.
+    } else {
+      // Preview-only mic session (startMic without a recording): the device
+      // is gone, so tear down the monitoring instead of freezing silently.
+      this.stopMic()
+    }
   }
 
   /** Stop monitoring incoming audio */
@@ -315,6 +359,11 @@ class RecordPlugin extends BasePlugin<RecordPluginEvents, RecordPluginOptions> {
     this.unsubscribeRecordEnd?.()
     this.micStream = null
     this.unsubscribeRecordEnd = undefined
+    // Remove the per-track 'ended' listeners before stopping the tracks.
+    // track.stop() doesn't fire 'ended', so this is about not leaking
+    // listeners across mic sessions, not about suppressing a spurious event.
+    this.unsubscribeTrackEnded.forEach((unsubscribe) => unsubscribe())
+    this.unsubscribeTrackEnded = []
     // renderMicStream() hijacked the host's options (interact, and in
     // scrolling mode cursorWidth/normalize/maxPeak); restore them when the
     // mic session ends. The record-end render path also restores (whichever

--- a/src/plugins/regions.ts
+++ b/src/plugins/regions.ts
@@ -352,12 +352,51 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
     const dblclicks = fromEvent(element, 'dblclick')
     const pointerdowns = fromEvent(element, 'pointerdown')
     const pointerups = fromEvent(element, 'pointerup')
+    const touchends = fromEvent(element, 'touchend')
+
+    // Double-tap detection (#3927): many mobile browsers never fire 'dblclick'
+    // for touch input, so two touchend events on this region within
+    // DOUBLE_TAP_WINDOW synthesize the same 'dblclick' emission. Browsers that
+    // DO fire a native dblclick after a double tap would otherwise emit twice,
+    // so a native dblclick arriving shortly after a synthesized one is deduped.
+    let lastTapTime = 0
+    let lastSyntheticDblclickTime = 0
+
+    const emitDblclick = (e: MouseEvent) => this.emit('dblclick', e)
 
     // Subscribe to streams
     const unsubscribeClick = clicks.subscribe((e) => e && this.emit('click', e))
     const unsubscribeMouseenter = mouseenters.subscribe((e) => e && this.emit('over', e))
     const unsubscribeMouseleave = mouseleaves.subscribe((e) => e && this.emit('leave', e))
-    const unsubscribeDblclick = dblclicks.subscribe((e) => e && this.emit('dblclick', e))
+    const unsubscribeDblclick = dblclicks.subscribe((e) => {
+      if (!e) return
+      // Skip the native dblclick some browsers still fire right after a
+      // double tap we've already synthesized an event for.
+      if (Date.now() - lastSyntheticDblclickTime <= DOUBLE_TAP_WINDOW * 2) return
+      emitDblclick(e)
+    })
+    const unsubscribeTouchend = touchends.subscribe((e) => {
+      if (!e) return
+      const now = Date.now()
+      if (lastTapTime && now - lastTapTime <= DOUBLE_TAP_WINDOW) {
+        lastTapTime = 0
+        lastSyntheticDblclickTime = now
+        // Emit a synthesized MouseEvent so the public event signature
+        // ('region-double-clicked': [region, e: MouseEvent]) stays unchanged.
+        // It is passed to listeners directly, never dispatched to the DOM.
+        const touch = e.changedTouches?.[0]
+        emitDblclick(
+          new MouseEvent('dblclick', {
+            bubbles: true,
+            cancelable: true,
+            clientX: touch?.clientX ?? 0,
+            clientY: touch?.clientY ?? 0,
+          }),
+        )
+      } else {
+        lastTapTime = now
+      }
+    })
     const unsubscribePointerdown = pointerdowns.subscribe((e) => e && this.toggleCursor(true))
     const unsubscribePointerup = pointerups.subscribe((e) => e && this.toggleCursor(false))
 
@@ -367,12 +406,14 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
       unsubscribeMouseenter()
       unsubscribeMouseleave()
       unsubscribeDblclick()
+      unsubscribeTouchend()
       unsubscribePointerdown()
       unsubscribePointerup()
       cleanupStream(clicks)
       cleanupStream(mouseenters)
       cleanupStream(mouseleaves)
       cleanupStream(dblclicks)
+      cleanupStream(touchends)
       cleanupStream(pointerdowns)
       cleanupStream(pointerups)
     })
@@ -632,6 +673,35 @@ class SingleRegion extends EventEmitter<RegionEvents> implements Region {
   }
 }
 
+/**
+ * Tolerance (in seconds) applied at a region's START boundary when deciding
+ * whether the current time is inside the region.
+ *
+ * Seeking to `region.start` — which is exactly what `region.play()` does via
+ * `wavesurfer.play(region.start, end)` — is not guaranteed to land the next
+ * 'timeupdate' at or after `start`: media elements clamp/round `currentTime`
+ * (notably the MediaElement backend in Chrome, and any start with many
+ * decimals, e.g. 9.16454684654654), so the first tick can arrive a hair
+ * BEFORE `start`. With an exact `start <= currentTime` comparison the region
+ * then counts as "not entered", which fired a spurious 'region-out' for the
+ * previously active region and caused region-in/region-out ping-pong loops
+ * when jumping between regions (#3631, #3658, #3781, #3866).
+ *
+ * 0.05s matches the window already used for zero-length (marker) regions and
+ * is far below typical 'timeupdate' granularity (~100–250ms), so at worst
+ * 'region-in' fires one tick (~50ms of audio) early during linear playback.
+ * The END boundary stays exact so 'region-out' is not delayed.
+ */
+const REGION_BOUNDARY_TOLERANCE = 0.05
+
+/**
+ * Two taps on the same region within this window (ms) count as a double tap
+ * and emit 'region-double-clicked' (native 'dblclick' does not fire for touch
+ * input on many mobile browsers — #3927). 300ms is the conventional
+ * double-tap threshold used by mobile browsers themselves.
+ */
+const DOUBLE_TAP_WINDOW = 300
+
 // The public surface returned by setup() below: getRegions/addRegion/
 // enableDragSelection/clearRegions are RegionsPlugin's only public API
 // methods (destroy is chassis-owned by definePlugin, not part of Api).
@@ -689,10 +759,14 @@ const RegionsPlugin = definePlugin<RegionsPluginOptions | Record<string, never>,
 
     ctx.scope.add(
       ctx.wavesurfer.on('timeupdate', (currentTime) => {
-        // Detect when regions are being played
+        // Detect when regions are being played. The start boundary gets a
+        // small tolerance so a seek to region.start that settles slightly
+        // before it (media-element clamping/rounding) still counts as inside —
+        // see REGION_BOUNDARY_TOLERANCE. Zero-length regions keep their
+        // existing `start + 0.05` window at the end boundary.
         const playedRegions = regions.filter(
           (region) =>
-            region.start <= currentTime &&
+            region.start - REGION_BOUNDARY_TOLERANCE <= currentTime &&
             (region.end === region.start ? region.start + 0.05 : region.end) >= currentTime,
         )
 


### PR DESCRIPTION
## Short description
Resolves #3631, resolves #3658, resolves #3781, resolves #3866, resolves #3927, resolves #4285

Three fixes from the issue-tracker cleanup:
1. **Regions: region-in/region-out event race.** `region.play()` seeks to `region.start`, but media elements clamp/round `currentTime`, so the next `timeupdate` can tick slightly *before* the start. The exact `start <= currentTime` comparison then treated the region as "not entered", firing a spurious `region-out` (and causing in/out ping-pong loops when jumping between regions).
2. **Regions: `region-double-clicked` never fires on mobile**, since many mobile browsers don't fire `dblclick` for touch input.
3. **Record: silent freeze when the capture device disappears** mid-recording (Bluetooth headset powered off, dock unplugged) — the track's `ended` event was never handled, so the waveform froze and the app stayed in a recording state with no signal.

## Implementation details
- `src/plugins/regions.ts`
  - A `REGION_BOUNDARY_TOLERANCE = 0.05` is applied at the **start** boundary only in the `timeupdate` in/out detection, matching the window already used for zero-length markers and staying well below typical `timeupdate` granularity. The end boundary stays exact, so `region-out` timing is unchanged.
  - Double-tap detection on the region element: two `touchend`s within 300ms emit the same `dblclick` emission (a synthesized `MouseEvent` carrying the tap coordinates, passed to listeners only), deduped against browsers that also fire a native `dblclick` after a double tap. The public event signature is unchanged.
- `src/plugins/record.ts`
  - `startMic()` attaches scope-owned `ended` listeners to the stream's tracks (`track.stop()` never fires `ended` per spec, so user-initiated stops are unaffected; `stopMic()`/`destroy()` remove the listeners).
  - On external device loss during an active or paused recording, a new **`record-ended-externally`** event fires, then the existing graceful stop path runs — the final blob is still delivered via `record-end`. A preview-only mic session tears down monitoring instead of freezing. Purely additive event, no changes to existing event payloads.

## How to test it
- Unit: `npx jest --selectProjects default` — 693/693 pass, including 7 new regions tests (high-precision start seek, tolerance boundaries, marker window, double-tap emit/dedupe) and 5 new record tests (device loss while recording/paused, event ordering, preview teardown, destroy cleanup).
- Manual, regions: in the regions example, add a region with `start: 9.16454684654654`, wire `region-clicked` → `region.play()` and pause on `region-out` — before this change the audio stopped almost immediately; now the region plays through. On a phone, double-tap a region and observe `region-double-clicked`.
- Manual, record: start a recording with a Bluetooth headset, power it off — the recording now ends gracefully (`record-ended-externally` then `record-end` with the blob) instead of freezing.

## Screenshots
N/A — event-timing and lifecycle fixes.

## Checklist
* [ ] This PR is covered by e2e tests (covered by new unit tests; no e2e added)
* [x] It introduces no breaking API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Hjr99ifhHnxZovqTRCpqL

---
_Generated by [Claude Code](https://claude.ai/code/session_016Hjr99ifhHnxZovqTRCpqL)_