### PR TITLE
Add e2e test for playback event emission regression

### DIFF
--- a/cypress/e2e/events.cy.js
+++ b/cypress/e2e/events.cy.js
@@ -1,0 +1,60 @@
+// Regression test for https://github.com/katspaugh/wavesurfer.js/issues/4360
+// (play/pause/finish fired twice in 7.12.x, where the reactive-state event
+// bridge re-emitted every event already emitted from the media listeners).
+// Exercised in a real browser with real playback -- the unit tests only
+// dispatch synthetic media events.
+describe('WaveSurfer playback events', () => {
+  let wavesurfer
+
+  afterEach(() => {
+    wavesurfer?.destroy()
+    wavesurfer = undefined
+  })
+
+  const waitForEvent = (name) => new Cypress.Promise((resolve) => wavesurfer.once(name, resolve))
+
+  it('emits play, pause and finish exactly once per playback transition', () => {
+    cy.visit('cypress/e2e/player.html')
+    cy.window().its('WaveSurfer').should('exist')
+
+    const counts = { play: 0, pause: 0, finish: 0 }
+
+    cy.window()
+      .then((win) => {
+        wavesurfer = win.WaveSurfer.create({
+          container: '#waveform',
+          url: '../../examples/audio/demo.wav',
+        })
+        for (const name of Object.keys(counts)) {
+          wavesurfer.on(name, () => counts[name]++)
+        }
+        return waitForEvent('ready')
+      })
+      .then(() => {
+        const played = waitForEvent('play')
+        wavesurfer.play()
+        return played
+      })
+      .then(() => {
+        const paused = waitForEvent('pause')
+        wavesurfer.pause()
+        return paused
+      })
+      .then(() => {
+        expect(counts).to.deep.equal({ play: 1, pause: 1, finish: 0 })
+
+        // Play the last fraction of a second so the media reaches 'ended'
+        const finished = waitForEvent('finish')
+        wavesurfer.setTime(wavesurfer.getDuration() - 0.3)
+        wavesurfer.play()
+        return finished
+      })
+      .then(() => {
+        // Let any duplicate emission queued behind 'ended' drain
+        cy.wait(200).then(() => {
+          // The media element fires 'pause' before 'ended', so pause is 2
+          expect(counts).to.deep.equal({ play: 2, pause: 2, finish: 1 })
+        })
+      })
+  })
+})


### PR DESCRIPTION
## Short description
Resolves #4360

Adds a regression test to verify that play, pause, and finish events are emitted exactly once per playback transition in real browser playback scenarios.

## Implementation details

This test exercises the fix for issue #4360 where play/pause/finish events were being fired twice in version 7.12.x due to the reactive-state event bridge re-emitting events that were already emitted from media listeners.

The test:
- Creates a WaveSurfer instance with real audio playback
- Tracks event emission counts for 'play', 'pause', and 'finish' events
- Verifies that each event fires exactly once during normal playback transitions
- Tests the 'finish' event by seeking near the end of the audio and playing to completion
- Includes a small delay to catch any duplicate emissions that might be queued

Unlike unit tests that only dispatch synthetic media events, this e2e test validates the behavior in a real browser with actual playback.

## How to test it

Run the e2e test suite:
```bash
npm run test:e2e
```

Or run just this test:
```bash
npx cypress run --spec "cypress/e2e/events.cy.js"
```

## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes

https://claude.ai/code/session_01VQA9aitijaiTzoEgAs8py4