### PR TITLE
fix(7.x): emit play, pause, finish and other events once instead of twice

### DIFF
--- a/cypress/e2e/events.cy.js
+++ b/cypress/e2e/events.cy.js
@@ -1,0 +1,60 @@
+// Regression test for https://github.com/katspaugh/wavesurfer.js/issues/4360
+// (play/pause/finish fired twice in 7.12.x, where the reactive-state event
+// bridge re-emitted every event already emitted from the media listeners).
+// Exercised in a real browser with real playback -- the unit tests only
+// dispatch synthetic media events.
+describe('WaveSurfer playback events', () => {
+  let wavesurfer
+
+  afterEach(() => {
+    wavesurfer?.destroy()
+    wavesurfer = undefined
+  })
+
+  const waitForEvent = (name) => new Cypress.Promise((resolve) => wavesurfer.once(name, resolve))
+
+  it('emits play, pause and finish exactly once per playback transition', () => {
+    cy.visit('cypress/e2e/events.html')
+    cy.window().its('WaveSurfer').should('exist')
+
+    const counts = { play: 0, pause: 0, finish: 0 }
+
+    cy.window()
+      .then((win) => {
+        wavesurfer = win.WaveSurfer.create({
+          container: '#waveform',
+          url: '../../examples/audio/demo.wav',
+        })
+        for (const name of Object.keys(counts)) {
+          wavesurfer.on(name, () => counts[name]++)
+        }
+        return waitForEvent('ready')
+      })
+      .then(() => {
+        const played = waitForEvent('play')
+        wavesurfer.play()
+        return played
+      })
+      .then(() => {
+        const paused = waitForEvent('pause')
+        wavesurfer.pause()
+        return paused
+      })
+      .then(() => {
+        expect(counts).to.deep.equal({ play: 1, pause: 1, finish: 0 })
+
+        // Play the last fraction of a second so the media reaches 'ended'
+        const finished = waitForEvent('finish')
+        wavesurfer.setTime(wavesurfer.getDuration() - 0.3)
+        wavesurfer.play()
+        return finished
+      })
+      .then(() => {
+        // Let any duplicate emission queued behind 'ended' drain
+        cy.wait(200).then(() => {
+          // The media element fires 'pause' before 'ended', so pause is 2
+          expect(counts).to.deep.equal({ play: 2, pause: 2, finish: 1 })
+        })
+      })
+  })
+})

--- a/cypress/e2e/events.html
+++ b/cypress/e2e/events.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WaveSurfer Events Test</title>
+  </head>
+  <body>
+    <div id="waveform"></div>
+
+    <script type="module">
+      import WaveSurfer from '../../dist/wavesurfer.js'
+
+      window.WaveSurfer = WaveSurfer
+    </script>
+  </body>
+</html>

--- a/src/wavesurfer.ts
+++ b/src/wavesurfer.ts
@@ -7,7 +7,6 @@ import Renderer from './renderer.js'
 import Timer from './timer.js'
 import WebAudioPlayer from './webaudio.js'
 import { createWaveSurferState, type WaveSurferState, type WaveSurferActions } from './state/wavesurfer-state.js'
-import { setupStateEventEmission } from './reactive/state-event-emitter.js'
 
 export type WaveSurferOptions = {
   /** Required: an HTML element or selector where the waveform will be rendered */
@@ -171,7 +170,6 @@ class WaveSurfer extends Player<WaveSurferEvents> {
   // Reactive state
   private wavesurferState: WaveSurferState
   private wavesurferActions: WaveSurferActions
-  private reactiveCleanups: Array<() => void> = []
 
   public static readonly BasePlugin = BasePlugin
   public static readonly dom = dom
@@ -227,7 +225,6 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.initPlayerEvents()
     this.initRendererEvents()
     this.initTimerEvents()
-    this.initReactiveState()
     this.initPlugins()
 
     // Read the initial URL before load has been called
@@ -272,15 +269,6 @@ class WaveSurfer extends Player<WaveSurferEvents> {
             this.setTime(stopAt)
           }
         }
-      }),
-    )
-  }
-
-  private initReactiveState() {
-    // Bridge reactive state to EventEmitter for backwards compatibility
-    this.reactiveCleanups.push(
-      setupStateEventEmission(this.wavesurferState, {
-        emit: this.emit.bind(this),
       }),
     )
   }
@@ -756,8 +744,6 @@ class WaveSurfer extends Player<WaveSurferEvents> {
     this.plugins.forEach((plugin) => plugin.destroy())
     this.subscriptions.forEach((unsubscribe) => unsubscribe())
     this.unsubscribePlayerEvents()
-    this.reactiveCleanups.forEach((cleanup) => cleanup())
-    this.reactiveCleanups = []
     this.timer.destroy()
     this.renderer.destroy()
     super.destroy()


### PR DESCRIPTION
## Short description
Resolves #4360

Backport for the 7.12.x line. `play`, `pause`, `finish` (and also `timeupdate`, `seeking`, `ready`, `zoom`) were emitted twice per transition in 7.12.x. The `v7` base branch was cut from the `7.12.11` tag so this can ship as 7.12.12; main (8.0.0-beta) is not affected because the duplicated emitter was already removed there in 8.0.0-beta.1.

## Implementation details
`WaveSurfer` wired up two emitters for the same events:

- the media listeners in `initPlayerEvents()` emit `play`/`pause`/`finish`/`timeupdate`/`seeking` directly from the `HTMLMediaElement` events, and
- `setupStateEventEmission()` (the reactive-state → EventEmitter bridge) re-emitted each of them from the `isPlaying`/`currentTime`/`isSeeking` signals, plus `ready` and `zoom`.

This removes the bridge wiring from `src/wavesurfer.ts` (the import, `initReactiveState()`, and the `reactiveCleanups` teardown). The direct media listeners are the single source of these events, matching v8. The `reactive/state-event-emitter` module itself is left in place since it is part of the published `dist/`.

## How to test it
- `cypress/e2e/events.cy.js` (new) drives real playback: play → wait for `play`, pause → wait for `pause`, then seek near the end and play through to `ended`, counting the emitted events. It fails on the unmodified 7.12.11 build (`play` counted 2) and passes with this change.
- Manually: the snippet from #4360, or `examples/events.js` — each click of play/pause now logs `Play`/`Pause` once, and reaching the end logs `Pause` and `Finish` once each.
- Unit suite on this branch: 32 suites / 459 tests passing.

## Screenshots
n/a

## Checklist
* [x] This PR is covered by e2e tests
* [x] It introduces no breaking API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQA9aitijaiTzoEgAs8py4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQA9aitijaiTzoEgAs8py4)_